### PR TITLE
34 showhide criteria

### DIFF
--- a/web/src/common/theme.ts
+++ b/web/src/common/theme.ts
@@ -24,11 +24,13 @@ declare module "@mui/material/styles" {
   interface Palette extends NodeTypePalettes {
     primaryVariantDark: Palette["primary"];
     primaryVariantLight: Palette["primary"];
+    neutral: Palette["primary"];
   }
 
   interface PaletteOptions extends NodeTypePaletteOptions {
     primaryVariantDark: PaletteOptions["primary"];
     primaryVariantLight: PaletteOptions["primary"];
+    neutral: PaletteOptions["primary"];
   }
 }
 
@@ -38,11 +40,13 @@ declare module "@mui/material" {
   interface ButtonPropsColorOverrides extends NodeTypeColors {
     primaryVariantDark: true;
     primaryVariantLight: true;
+    neutral: true;
   }
 
   interface AppBarPropsColorOverrides extends NodeTypeColors {
     primaryVariantDark: true;
     primaryVariantLight: true;
+    neutral: true;
   }
 }
 /* eslint-disable @typescript-eslint/no-empty-interface */
@@ -79,6 +83,7 @@ const sharedPalette = {
   primaryVariantLight: { main: "#82CE84" }, // 200 lower than primary on material design color tool
   // use black contrast text for consistency with other node colors; accessibility tool indicates black is still accessible
   secondary: { main: secondary, contrastText: "rgba(0, 0, 0, 0.87)" },
+  neutral: augmentColor({ color: { main: "#BDBDBD" } }), // gray is very neutral, somewhat arbitrarily chosen, no particular relation to the other colors
   problem: augmentColor({ color: { main: secondary, contrastText: "rgba(0, 0, 0, 0.87)" } }),
   solution: augmentColor({ color: { main: primary } }),
   criterion: augmentColor({ color: { main: "#4AB885" } }), // mint: analogous to solution; between solution & support because criteria are kind of like supports for solutions

--- a/web/src/common/theme.ts
+++ b/web/src/common/theme.ts
@@ -48,6 +48,12 @@ declare module "@mui/material" {
     primaryVariantLight: true;
     neutral: true;
   }
+
+  interface SvgIconPropsColorOverrides extends NodeTypeColors {
+    primaryVariantDark: true;
+    primaryVariantLight: true;
+    neutral: true;
+  }
 }
 /* eslint-disable @typescript-eslint/no-empty-interface */
 

--- a/web/src/modules/topic/components/CriteriaIndicator/CriteriaIndicator.tsx
+++ b/web/src/modules/topic/components/CriteriaIndicator/CriteriaIndicator.tsx
@@ -1,0 +1,27 @@
+import { Ballot, BallotOutlined } from "@mui/icons-material";
+
+import { toggleShowCriteria } from "../../store/actions";
+import { useNode, useNodeChildren } from "../../store/nodeHooks";
+import { ProblemNode } from "../../utils/diagram";
+import { Indicator } from "../Indicator/Indicator";
+
+interface Props {
+  nodeId: string;
+}
+
+export const CriteriaIndicator = ({ nodeId }: Props) => {
+  const node = useNode(nodeId);
+  const nodeChildren = useNodeChildren(nodeId);
+
+  const hasCriteria = nodeChildren.some((child) => child.type === "criterion");
+
+  if (node.type !== "problem" || !hasCriteria) {
+    return <></>;
+  }
+
+  const problemNode = node as ProblemNode;
+
+  const Icon = problemNode.data.showCriteria ? Ballot : BallotOutlined;
+
+  return <Indicator Icon={Icon} onClick={() => toggleShowCriteria(nodeId)} />;
+};

--- a/web/src/modules/topic/components/Diagram/Diagram.tsx
+++ b/web/src/modules/topic/components/Diagram/Diagram.tsx
@@ -10,7 +10,7 @@ import {
 } from "reactflow";
 
 import { connectNodes, deselectNodes, setActiveDiagram } from "../../store/actions";
-import { rootId, useActiveDiagram, useActiveDiagramId } from "../../store/store";
+import { rootId, useActiveDiagramId, useFilteredActiveDiagram } from "../../store/store";
 import { type Edge, type Node } from "../../utils/diagram";
 import { type NodeType } from "../../utils/nodes";
 import { EditableNode } from "../EditableNode/EditableNode";
@@ -50,7 +50,7 @@ export interface EdgeProps extends DefaultEdgeProps {
 
 export const Diagram = () => {
   const activeDiagramId = useActiveDiagramId();
-  const activeDiagram = useActiveDiagram();
+  const activeDiagram = useFilteredActiveDiagram();
 
   const nodes = activeDiagram.nodes;
   const edges = activeDiagram.edges;

--- a/web/src/modules/topic/components/EditableNode/EditableNode.styles.tsx
+++ b/web/src/modules/topic/components/EditableNode/EditableNode.styles.tsx
@@ -89,6 +89,10 @@ export const NodeTypeSpan = styled.span`
   padding-left: 4px;
 `;
 
+export const IndicatorDiv = styled.div`
+  display: flex;
+`;
+
 export const XEdgeDiv = styled.div`
   width: 24px;
 `;

--- a/web/src/modules/topic/components/EditableNode/EditableNode.tsx
+++ b/web/src/modules/topic/components/EditableNode/EditableNode.tsx
@@ -7,12 +7,14 @@ import { setNodeLabel } from "../../store/actions";
 import { useDiagramType } from "../../store/store";
 import { orientations } from "../../utils/diagram";
 import { NodeType, nodeDecorations } from "../../utils/nodes";
+import { CriteriaIndicator } from "../CriteriaIndicator/CriteriaIndicator";
 import { NodeProps } from "../Diagram/Diagram";
 import { ScoreDial } from "../ScoreDial/ScoreDial";
 import {
   AddNodeButtonGroupChild,
   AddNodeButtonGroupParent,
   HoverBridgeDiv,
+  IndicatorDiv,
   MiddleDiv,
   NodeTypeDiv,
   NodeTypeSpan,
@@ -51,7 +53,10 @@ export const EditableNode = ({ id, data, type }: NodeProps) => {
           <NodeIcon sx={{ width: "16px", height: "16px" }} />
           <NodeTypeSpan>{_.startCase(nodeType)}</NodeTypeSpan>
         </NodeTypeDiv>
-        <ScoreDial scorableId={id} scorableType="node" score={data.score} />
+        <IndicatorDiv>
+          <CriteriaIndicator nodeId={id} />
+          <ScoreDial scorableId={id} scorableType="node" score={data.score} />
+        </IndicatorDiv>
       </YEdgeDiv>
       <MiddleDiv>
         <XEdgeDiv />

--- a/web/src/modules/topic/components/Indicator/Indicator.styles.tsx
+++ b/web/src/modules/topic/components/Indicator/Indicator.styles.tsx
@@ -1,0 +1,12 @@
+import styled from "@emotion/styled";
+import { Button } from "@mui/material";
+
+import { indicatorLength } from "../../utils/nodes";
+
+export const StyledButton = styled(Button)`
+  width: ${indicatorLength}px;
+  min-width: ${indicatorLength}px;
+  height: ${indicatorLength}px;
+  margin-top: 2px;
+  padding: 0px;
+`;

--- a/web/src/modules/topic/components/Indicator/Indicator.tsx
+++ b/web/src/modules/topic/components/Indicator/Indicator.tsx
@@ -1,0 +1,18 @@
+import { MuiIcon } from "../../utils/nodes";
+import { StyledButton } from "./Indicator.styles";
+
+interface IndicatorProps {
+  Icon: MuiIcon;
+  onClick?: () => void;
+}
+
+export const Indicator = ({ Icon, onClick }: IndicatorProps) => {
+  return (
+    // hard to tell which variant & color combo works best
+    // want to use neutral generally, but not stand out too much (contained with neutral color stands out because of heavy black to fill in icon)
+    // and have a clearly visible hover
+    <StyledButton variant="contained" color="secondary" onClick={onClick} disabled={!onClick}>
+      <Icon color="neutral" />
+    </StyledButton>
+  );
+};

--- a/web/src/modules/topic/components/ScoreDial/ScoreDial.tsx
+++ b/web/src/modules/topic/components/ScoreDial/ScoreDial.tsx
@@ -55,7 +55,7 @@ export const ScoreDial = ({ scorableId, scorableType, score }: ScoreDialProps) =
         position={buttonPositions[index]}
         key={possibleScore}
         variant="contained"
-        color="inherit" // idk how this becomes gray but that's the color that looks good here
+        color="neutral"
         onClick={() => setScore(scorableId, scorableType, possibleScore)}
       >
         {possibleScore}
@@ -74,7 +74,7 @@ export const ScoreDial = ({ scorableId, scorableType, score }: ScoreDialProps) =
           onClick={() => setOrCreateActiveDiagram(scorableId, scorableType)}
           buttonLength={buttonLength}
           variant="contained"
-          color="inherit" // idk how this becomes gray but that's the color that looks good here
+          color="neutral"
           sx={doesDiagramExist ? { border: 1 } : {}}
         >
           {score}

--- a/web/src/modules/topic/components/ScoreDial/ScoreDial.tsx
+++ b/web/src/modules/topic/components/ScoreDial/ScoreDial.tsx
@@ -4,6 +4,7 @@ import { setOrCreateActiveDiagram, setScore } from "../../store/actions";
 import { useDoesDiagramExist } from "../../store/store";
 import { getClaimDiagramId } from "../../utils/claim";
 import { type ScorableType, type Score, possibleScores } from "../../utils/diagram";
+import { indicatorLength } from "../../utils/nodes";
 import { FloatingButton, FloatingDiv, MainButton, StyledDiv } from "./ScoreDial.style";
 
 const getButtonPositions = (expansionRadius: number, numberOfButtons: number) => {
@@ -42,7 +43,7 @@ export const ScoreDial = ({ scorableId, scorableType, score }: ScoreDialProps) =
   const childDiagramId = getClaimDiagramId(scorableId, scorableType);
   const doesDiagramExist = useDoesDiagramExist(childDiagramId);
 
-  const buttonLength = 20; //px
+  const buttonLength = indicatorLength; //px
   const expansionRadius = 2 * buttonLength; // no collisions for fitting 11 elements
 
   // little awkward to use parallel arrays, but wanted to isolate position logic

--- a/web/src/modules/topic/components/TopicToolbar/TopicToolbar.tsx
+++ b/web/src/modules/topic/components/TopicToolbar/TopicToolbar.tsx
@@ -4,7 +4,7 @@ import fileDownload from "js-file-download";
 import { useState } from "react";
 
 import { getState, setState } from "../../store/actions";
-import { AllDiagramState } from "../../store/store";
+import { DiagramStoreState } from "../../store/store";
 
 // TODO: might be useful to have downloaded state be more human editable;
 // for this, probably should prettify the JSON, and remove position values (we can re-layout on import)
@@ -19,7 +19,7 @@ const uploadTopic = (event: React.ChangeEvent<HTMLInputElement>) => {
   event.target.files[0]
     .text()
     // TODO: validate that file JSON matches interface
-    .then((text) => setState(JSON.parse(text) as AllDiagramState))
+    .then((text) => setState(JSON.parse(text) as DiagramStoreState))
     .catch((error) => {
       console.log("error reading file: ", error);
       throw new Error("Failed to read file");
@@ -30,7 +30,7 @@ const loadExample = (exampleFileName: string) => {
   fetch(`/examples/${exampleFileName}`)
     .then((response) => response.json())
     // TODO: validate that file JSON matches interface
-    .then((exampleState) => setState(exampleState as AllDiagramState))
+    .then((exampleState) => setState(exampleState as DiagramStoreState))
     .catch((error) => {
       console.log("error loading example: ", error);
       throw new Error("Failed to load example");

--- a/web/src/modules/topic/store/actions.ts
+++ b/web/src/modules/topic/store/actions.ts
@@ -14,13 +14,13 @@ import {
 } from "../utils/diagram";
 import { RelationName, canCreateEdge, getRelation } from "../utils/edge";
 import { NodeType } from "../utils/nodes";
-import { AllDiagramState, rootId, useDiagramStore } from "./store";
+import { DiagramStoreState, rootId, useDiagramStore } from "./store";
 
 export const getState = () => {
   return useDiagramStore.getState();
 };
 
-export const setState = (state: AllDiagramState) => {
+export const setState = (state: DiagramStoreState) => {
   useDiagramStore.setState(() => state);
 };
 
@@ -32,7 +32,7 @@ interface AddNodeProps {
 }
 
 const createAndConnectNode = (
-  state: AllDiagramState,
+  state: DiagramStoreState,
   { fromNodeId, as, toNodeType, relation }: AddNodeProps
 ) => {
   /* eslint-disable functional/immutable-data, no-param-reassign */
@@ -51,7 +51,7 @@ const createAndConnectNode = (
 
 // if adding a criterion, connect to solutions
 // if adding a solution, connect to criteria
-const connectCriteriaToSolutions = (state: AllDiagramState, newNode: Node, fromNode: Node) => {
+const connectCriteriaToSolutions = (state: DiagramStoreState, newNode: Node, fromNode: Node) => {
   const activeDiagram = state.diagrams[state.activeDiagramId];
 
   const targetRelation: RelationName = newNode.type === "criterion" ? "solves" : "criterion for";

--- a/web/src/modules/topic/store/actions.ts
+++ b/web/src/modules/topic/store/actions.ts
@@ -125,7 +125,7 @@ export const connectNodes = (parentId: string | null, childId: string | null) =>
       const newEdgeId = `${state.nextEdgeId++}`;
       /* eslint-enable functional/immutable-data, no-param-reassign */
 
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- isValidEdge ensures relation is valid
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- canCreateEdge ensures relation is valid
       const relation = getRelation(parent.type, child.type)!;
       const newEdge = buildEdge(newEdgeId, parent.id, child.id, relation.name);
       const newEdges = activeDiagram.edges.concat(newEdge);

--- a/web/src/modules/topic/store/actions.ts
+++ b/web/src/modules/topic/store/actions.ts
@@ -7,6 +7,7 @@ import {
   Score,
   buildEdge,
   buildNode,
+  findNode,
   findScorable,
   layoutVisibleComponents,
 } from "../utils/diagram";
@@ -49,8 +50,7 @@ const connectCriteriaToSolutions = (state: AllDiagramState, newNode: Node, fromN
   const newCriterionEdges = activeDiagram.edges
     .filter((edge) => edge.source === fromNode.id && edge.label === targetRelation)
     .map((edge) => {
-      const targetNode = activeDiagram.nodes.find((node) => node.id === edge.target);
-      if (!targetNode) throw new Error("targetNode not found");
+      const targetNode = findNode(activeDiagram, edge.target);
 
       /* eslint-disable functional/immutable-data, no-param-reassign */
       const newCriterionEdgeId = `${state.nextEdgeId++}`;
@@ -71,9 +71,7 @@ export const addNode = ({ fromNodeId, as, toNodeType, relation }: AddNodeProps) 
   useDiagramStore.setState(
     (state) => {
       const activeDiagram = state.diagrams[state.activeDiagramId];
-
-      const fromNode = activeDiagram.nodes.find((node) => node.id === fromNodeId);
-      if (!fromNode) throw new Error("fromNode not found");
+      const fromNode = findNode(activeDiagram, fromNodeId);
 
       // create and connect node
       const [newNode, newEdge] = createAndConnectNode(state, {
@@ -269,9 +267,7 @@ export const setNodeLabel = (nodeId: string, value: string) => {
   useDiagramStore.setState(
     (state) => {
       const activeDiagram = state.diagrams[state.activeDiagramId];
-
-      const node = activeDiagram.nodes.find((node) => node.id === nodeId);
-      if (!node) throw new Error("node not found");
+      const node = findNode(activeDiagram, nodeId);
 
       /* eslint-disable functional/immutable-data, no-param-reassign */
       node.data.label = value;

--- a/web/src/modules/topic/store/actions.ts
+++ b/web/src/modules/topic/store/actions.ts
@@ -2,6 +2,7 @@ import { getClaimDiagramId, getImplicitLabel, parseClaimDiagramId } from "../uti
 import {
   Edge,
   Node,
+  ProblemNode,
   RelationDirection,
   ScorableType,
   Score,
@@ -14,6 +15,14 @@ import {
 import { RelationName, canCreateEdge, getRelation } from "../utils/edge";
 import { NodeType } from "../utils/nodes";
 import { AllDiagramState, rootId, useDiagramStore } from "./store";
+
+export const getState = () => {
+  return useDiagramStore.getState();
+};
+
+export const setState = (state: AllDiagramState) => {
+  useDiagramStore.setState(() => state);
+};
 
 interface AddNodeProps {
   fromNodeId: string;
@@ -278,10 +287,27 @@ export const setNodeLabel = (nodeId: string, value: string) => {
   );
 };
 
-export const getState = () => {
-  return useDiagramStore.getState();
-};
+export const toggleShowCriteria = (nodeId: string) => {
+  useDiagramStore.setState(
+    (state) => {
+      const activeDiagram = state.diagrams[state.activeDiagramId];
 
-export const setState = (state: AllDiagramState) => {
-  useDiagramStore.setState(() => state);
+      const node = findNode(activeDiagram, nodeId);
+      if (node.type !== "problem") throw new Error("node is not a problem");
+      const problemNode = node as ProblemNode;
+
+      /* eslint-disable functional/immutable-data, no-param-reassign */
+      problemNode.data.showCriteria = !problemNode.data.showCriteria;
+      /* eslint-enable functional/immutable-data, no-param-reassign */
+
+      const layoutedDiagram = layoutVisibleComponents(activeDiagram); // depends on showCriteria having been updated
+
+      /* eslint-disable functional/immutable-data, no-param-reassign */
+      activeDiagram.nodes = layoutedDiagram.nodes;
+      activeDiagram.edges = layoutedDiagram.edges;
+      /* eslint-enable functional/immutable-data, no-param-reassign */
+    },
+    false,
+    "toggleShowCriteria"
+  );
 };

--- a/web/src/modules/topic/store/actions.ts
+++ b/web/src/modules/topic/store/actions.ts
@@ -8,10 +8,9 @@ import {
   buildEdge,
   buildNode,
   findScorable,
-  orientations,
+  layoutVisibleComponents,
 } from "../utils/diagram";
 import { RelationName, canCreateEdge, getRelation } from "../utils/edge";
-import { layout } from "../utils/layout";
 import { NodeType } from "../utils/nodes";
 import { AllDiagramState, rootId, useDiagramStore } from "./store";
 
@@ -94,15 +93,15 @@ export const addNode = ({ fromNodeId, as, toNodeType, relation }: AddNodeProps) 
       }
 
       // re-layout
-      const { layoutedNodes, layoutedEdges } = layout(
-        activeDiagram.nodes.concat(newNode),
-        activeDiagram.edges.concat(newEdge),
-        orientations[activeDiagram.type]
-      );
+      const layoutedDiagram = layoutVisibleComponents({
+        ...activeDiagram,
+        nodes: activeDiagram.nodes.concat(newNode),
+        edges: activeDiagram.edges.concat(newEdge),
+      });
 
       /* eslint-disable functional/immutable-data, no-param-reassign */
-      activeDiagram.nodes = layoutedNodes;
-      activeDiagram.edges = layoutedEdges;
+      activeDiagram.nodes = layoutedDiagram.nodes;
+      activeDiagram.edges = layoutedDiagram.edges;
       /* eslint-enable functional/immutable-data, no-param-reassign */
     },
     false,
@@ -130,15 +129,11 @@ export const connectNodes = (parentId: string | null, childId: string | null) =>
       const newEdge = buildEdge(newEdgeId, parent.id, child.id, relation.name);
       const newEdges = activeDiagram.edges.concat(newEdge);
 
-      const { layoutedNodes, layoutedEdges } = layout(
-        activeDiagram.nodes,
-        newEdges,
-        orientations[activeDiagram.type]
-      );
+      const layoutedDiagram = layoutVisibleComponents({ ...activeDiagram, edges: newEdges });
 
       /* eslint-disable functional/immutable-data, no-param-reassign */
-      activeDiagram.nodes = layoutedNodes;
-      activeDiagram.edges = layoutedEdges;
+      activeDiagram.nodes = layoutedDiagram.nodes;
+      activeDiagram.edges = layoutedDiagram.edges;
       /* eslint-enable functional/immutable-data, no-param-reassign */
     },
     false,

--- a/web/src/modules/topic/store/migrate.ts
+++ b/web/src/modules/topic/store/migrate.ts
@@ -3,7 +3,7 @@ import _ from "lodash";
 import { range } from "lodash";
 
 export const migrate = (persistedState: any, version: number) => {
-  const migrations = [migrate_0_to_1, migrate_1_to_2];
+  const migrations = [migrate_0_to_1, migrate_1_to_2, migrate_2_to_3];
 
   let state = persistedState;
 
@@ -60,6 +60,19 @@ const migrate_1_to_2 = (state: any) => {
     diagram.nodes.forEach((node: any) => {
       // change type to lowercase
       node.type = _.camelCase(node.type);
+    });
+  });
+
+  return state;
+};
+
+const migrate_2_to_3 = (state: any) => {
+  Object.values(state.diagrams).forEach((diagram: any) => {
+    diagram.nodes.forEach((node: any) => {
+      // add showCriteria: true to each problem
+      if (node.type === "problem") {
+        node.data.showCriteria = true;
+      }
     });
   });
 

--- a/web/src/modules/topic/store/nodeHooks.ts
+++ b/web/src/modules/topic/store/nodeHooks.ts
@@ -1,0 +1,19 @@
+import { findNode } from "../utils/diagram";
+import { children } from "../utils/nodes";
+import { useDiagramStoreAfterHydration } from "./store";
+
+export const useNode = (nodeId: string) => {
+  return useDiagramStoreAfterHydration((state) => {
+    const activeDiagram = state.diagrams[state.activeDiagramId];
+    return findNode(activeDiagram, nodeId);
+  });
+};
+
+export const useNodeChildren = (nodeId: string) => {
+  return useDiagramStoreAfterHydration((state) => {
+    const activeDiagram = state.diagrams[state.activeDiagramId];
+    const node = findNode(activeDiagram, nodeId);
+
+    return children(node, activeDiagram);
+  });
+};

--- a/web/src/modules/topic/store/store.ts
+++ b/web/src/modules/topic/store/store.ts
@@ -36,7 +36,7 @@ const initialState = {
 export const useDiagramStore = create<AllDiagramState>()(
   persist(immer(devtools(() => initialState)), {
     name: "diagram-storage",
-    version: 2,
+    version: 3,
     migrate: migrate,
   })
 );

--- a/web/src/modules/topic/store/store.ts
+++ b/web/src/modules/topic/store/store.ts
@@ -4,7 +4,7 @@ import { devtools, persist } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 
 import { HydrationContext } from "../../../pages/index";
-import { DiagramState, buildNode } from "../utils/diagram";
+import { DiagramState, buildNode, filterHiddenComponents } from "../utils/diagram";
 import { migrate } from "./migrate";
 
 export const rootId = "root";
@@ -63,8 +63,10 @@ export const useActiveDiagramId = () => {
   return useDiagramStoreAfterHydration((state) => state.activeDiagramId);
 };
 
-export const useActiveDiagram = () => {
-  return useDiagramStoreAfterHydration((state) => state.diagrams[state.activeDiagramId]);
+export const useFilteredActiveDiagram = () => {
+  return useDiagramStoreAfterHydration((state) =>
+    filterHiddenComponents(state.diagrams[state.activeDiagramId])
+  );
 };
 
 export const useDiagramType = (diagramId: string) => {

--- a/web/src/modules/topic/store/store.ts
+++ b/web/src/modules/topic/store/store.ts
@@ -4,12 +4,12 @@ import { devtools, persist } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 
 import { HydrationContext } from "../../../pages/index";
-import { DiagramState, buildNode, filterHiddenComponents } from "../utils/diagram";
+import { Diagram, buildNode, filterHiddenComponents } from "../utils/diagram";
 import { migrate } from "./migrate";
 
 export const rootId = "root";
 
-const initialDiagrams: Record<string, DiagramState> = {
+const initialDiagrams: Record<string, Diagram> = {
   [rootId]: {
     nodes: [buildNode({ id: "0", type: "problem", diagramId: rootId })],
     edges: [],
@@ -18,7 +18,7 @@ const initialDiagrams: Record<string, DiagramState> = {
 };
 
 export interface AllDiagramState {
-  diagrams: Record<string, DiagramState>;
+  diagrams: Record<string, Diagram>;
   activeDiagramId: string;
   nextNodeId: number;
   nextEdgeId: number;

--- a/web/src/modules/topic/store/store.ts
+++ b/web/src/modules/topic/store/store.ts
@@ -41,7 +41,9 @@ export const useDiagramStore = create<AllDiagramState>()(
   })
 );
 
-const useDiagramStoreAfterHydration = ((selector, compare) => {
+// create atomic selectors for usage outside of store/ dir
+// this is only exported to allow hooks to be extracted to a separate file
+export const useDiagramStoreAfterHydration = ((selector, compare) => {
   /*
   This a fix to ensure zustand never hydrates the store before React hydrates the page.
   Without this, there is a mismatch between SSR/SSG and client side on first draw which produces

--- a/web/src/modules/topic/store/store.ts
+++ b/web/src/modules/topic/store/store.ts
@@ -17,7 +17,7 @@ const initialDiagrams: Record<string, Diagram> = {
   },
 };
 
-export interface AllDiagramState {
+export interface DiagramStoreState {
   diagrams: Record<string, Diagram>;
   activeDiagramId: string;
   nextNodeId: number;
@@ -33,7 +33,7 @@ const initialState = {
 
 // create atomic selectors for usage outside of store/ dir
 // this is only exported to allow actions to be extracted to a separate file
-export const useDiagramStore = create<AllDiagramState>()(
+export const useDiagramStore = create<DiagramStoreState>()(
   persist(immer(devtools(() => initialState)), {
     name: "diagram-storage",
     version: 3,

--- a/web/src/modules/topic/utils/claim.ts
+++ b/web/src/modules/topic/utils/claim.ts
@@ -1,6 +1,6 @@
 import _ from "lodash";
 
-import { DiagramState, ScorableType } from "./diagram";
+import { Diagram, ScorableType } from "./diagram";
 import { maxCharsPerLine } from "./nodes";
 
 export const parseClaimDiagramId = (diagramId: string) => {
@@ -15,7 +15,7 @@ export const getClaimDiagramId = (parentScorableId: string, parentScorableType: 
 export const getImplicitLabel = (
   parentScorableId: string,
   parentScorableType: ScorableType,
-  parentScorableDiagram: DiagramState
+  parentScorableDiagram: Diagram
 ): string => {
   if (parentScorableType === "node") {
     const parentNode = parentScorableDiagram.nodes.find((node) => node.id === parentScorableId);

--- a/web/src/modules/topic/utils/diagram.ts
+++ b/web/src/modules/topic/utils/diagram.ts
@@ -18,6 +18,21 @@ export interface DiagramState {
   type: DiagramType;
 }
 
+export interface Node {
+  id: string;
+  data: {
+    label: string;
+    score: Score;
+    width: number;
+    diagramId: string;
+  };
+  position: {
+    x: number;
+    y: number;
+  };
+  selected: boolean;
+  type: NodeType;
+}
 interface BuildProps {
   id: string;
   label?: string;
@@ -39,7 +54,6 @@ export const buildNode = ({ id, label, score, type, diagramId }: BuildProps) => 
     type: type,
   };
 };
-export type Node = ReturnType<typeof buildNode>;
 
 export const buildEdge = (
   newEdgeId: string,

--- a/web/src/modules/topic/utils/diagram.ts
+++ b/web/src/modules/topic/utils/diagram.ts
@@ -89,18 +89,26 @@ export type ScorableType = "node" | "edge";
 export const possibleScores = ["-", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] as const;
 export type Score = typeof possibleScores[number];
 
+export const findNode = (diagram: DiagramState, nodeId: string) => {
+  const node = diagram.nodes.find((node) => node.id === nodeId);
+  if (!node) throw new Error("node not found");
+
+  return node;
+};
+
+export const findEdge = (diagram: DiagramState, edgeId: string) => {
+  const edge = diagram.edges.find((edge) => edge.id === edgeId);
+  if (!edge) throw new Error("edge not found");
+
+  return edge;
+};
+
 export const findScorable = (
   diagram: DiagramState,
   scorableId: string,
   scorableType: ScorableType
 ) => {
-  const scorableKey = scorableType === "node" ? "nodes" : "edges";
-  // RIP typescript can't infer this https://github.com/microsoft/TypeScript/issues/33591#issuecomment-786443978
-  const scorables: (Node | Edge)[] = diagram[scorableKey];
-  const scorable = scorables.find((scorable) => scorable.id === scorableId);
-  if (!scorable) throw new Error("scorable not found");
-
-  return scorable;
+  return scorableType === "node" ? findNode(diagram, scorableId) : findEdge(diagram, scorableId);
 };
 
 export const filterHiddenComponents = (diagram: DiagramState) => {

--- a/web/src/modules/topic/utils/diagram.ts
+++ b/web/src/modules/topic/utils/diagram.ts
@@ -12,7 +12,7 @@ export const orientations: Record<DiagramType, Orientation> = {
   Claim: "LR",
 };
 
-export interface DiagramState {
+export interface Diagram {
   nodes: Node[];
   edges: Edge[];
   type: DiagramType;
@@ -89,29 +89,25 @@ export type ScorableType = "node" | "edge";
 export const possibleScores = ["-", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] as const;
 export type Score = typeof possibleScores[number];
 
-export const findNode = (diagram: DiagramState, nodeId: string) => {
+export const findNode = (diagram: Diagram, nodeId: string) => {
   const node = diagram.nodes.find((node) => node.id === nodeId);
   if (!node) throw new Error("node not found");
 
   return node;
 };
 
-export const findEdge = (diagram: DiagramState, edgeId: string) => {
+export const findEdge = (diagram: Diagram, edgeId: string) => {
   const edge = diagram.edges.find((edge) => edge.id === edgeId);
   if (!edge) throw new Error("edge not found");
 
   return edge;
 };
 
-export const findScorable = (
-  diagram: DiagramState,
-  scorableId: string,
-  scorableType: ScorableType
-) => {
+export const findScorable = (diagram: Diagram, scorableId: string, scorableType: ScorableType) => {
   return scorableType === "node" ? findNode(diagram, scorableId) : findEdge(diagram, scorableId);
 };
 
-export const filterHiddenComponents = (diagram: DiagramState) => {
+export const filterHiddenComponents = (diagram: Diagram) => {
   const shownNodes = diagram.nodes.filter((node) => {
     if (node.type !== "criterion") {
       return true;
@@ -145,7 +141,7 @@ export const filterHiddenComponents = (diagram: DiagramState) => {
   return { ...diagram, nodes: shownNodes, edges: shownEdges };
 };
 
-export const layoutVisibleComponents = (diagram: DiagramState) => {
+export const layoutVisibleComponents = (diagram: Diagram) => {
   // filter
   const displayDiagram = filterHiddenComponents(diagram);
 

--- a/web/src/modules/topic/utils/edge.ts
+++ b/web/src/modules/topic/utils/edge.ts
@@ -1,4 +1,4 @@
-import { DiagramState, Edge, Node, RelationDirection, findScorable } from "./diagram";
+import { Diagram, Edge, Node, RelationDirection, findScorable } from "./diagram";
 import { NodeType } from "./nodes";
 
 export type RelationName =
@@ -81,7 +81,7 @@ export const addableRelationsFrom = (nodeType: NodeType, addingAs: RelationDirec
   return formattedRelations;
 };
 
-export const canCreateEdge = (diagram: DiagramState, parent: Node, child: Node) => {
+export const canCreateEdge = (diagram: Diagram, parent: Node, child: Node) => {
   const relation = getRelation(parent.type, child.type);
 
   const existingEdge = diagram.edges.find((edge) => {
@@ -121,10 +121,10 @@ export const canCreateEdge = (diagram: DiagramState, parent: Node, child: Node) 
   return true;
 };
 
-export const parentNode = (edge: Edge, diagram: DiagramState) => {
+export const parentNode = (edge: Edge, diagram: Diagram) => {
   return findScorable(diagram, edge.source, "node");
 };
 
-export const childNode = (edge: Edge, diagram: DiagramState) => {
+export const childNode = (edge: Edge, diagram: Diagram) => {
   return findScorable(diagram, edge.target, "node");
 };

--- a/web/src/modules/topic/utils/edge.ts
+++ b/web/src/modules/topic/utils/edge.ts
@@ -1,4 +1,4 @@
-import { DiagramState, Node, RelationDirection } from "./diagram";
+import { DiagramState, Edge, Node, RelationDirection, findScorable } from "./diagram";
 import { NodeType } from "./nodes";
 
 export type RelationName =
@@ -119,4 +119,12 @@ export const canCreateEdge = (diagram: DiagramState, parent: Node, child: Node) 
   }
 
   return true;
+};
+
+export const parentNode = (edge: Edge, diagram: DiagramState) => {
+  return findScorable(diagram, edge.source, "node");
+};
+
+export const childNode = (edge: Edge, diagram: DiagramState) => {
+  return findScorable(diagram, edge.target, "node");
 };

--- a/web/src/modules/topic/utils/nodes.ts
+++ b/web/src/modules/topic/utils/nodes.ts
@@ -1,5 +1,7 @@
 import { Article, Ballot, Check, Extension, ThumbDown, ThumbUp } from "@mui/icons-material";
 
+import { DiagramState, Node } from "./diagram";
+
 export const maxCharsPerLine = 19; // measured by typing "a"'s in a node textbox
 
 export interface NodeDecoration {
@@ -27,4 +29,37 @@ export const nodeDecorations: Record<NodeType, NodeDecoration> = {
   critique: {
     NodeIcon: ThumbDown,
   },
+};
+
+// TODO: memoize? this could traverse a lot of nodes & edges, seems not performant
+export const parents = (node: Node, diagram: DiagramState) => {
+  const parentEdges = diagram.edges.filter((edge) => edge.target === node.id);
+
+  return parentEdges.map((edge) => {
+    const node = diagram.nodes.find((node) => edge.source === node.id);
+    if (!node) throw new Error(`node ${edge.source} not found`);
+
+    return node;
+  });
+};
+
+export const children = (node: Node, diagram: DiagramState) => {
+  const childEdges = diagram.edges.filter((edge) => edge.source === node.id);
+  return childEdges.map((edge) => {
+    const node = diagram.nodes.find((node) => edge.target === node.id);
+    if (!node) throw new Error(`node ${edge.target} not found`);
+
+    return node;
+  });
+};
+
+// errors if node does not have only one parent
+export const onlyParent = (node: Node, diagram: DiagramState) => {
+  const allParents = parents(node, diagram);
+
+  if (allParents.length !== 1) {
+    throw new Error(`has ${allParents.length} parents, expected one`);
+  }
+
+  return allParents[0];
 };

--- a/web/src/modules/topic/utils/nodes.ts
+++ b/web/src/modules/topic/utils/nodes.ts
@@ -1,6 +1,6 @@
 import { Article, Ballot, Check, Extension, ThumbDown, ThumbUp } from "@mui/icons-material";
 
-import { DiagramState, Node } from "./diagram";
+import { Diagram, Node } from "./diagram";
 
 export const maxCharsPerLine = 19; // measured by typing "a"'s in a node textbox
 export const indicatorLength = 20; // px
@@ -35,7 +35,7 @@ export const nodeDecorations: Record<NodeType, NodeDecoration> = {
 };
 
 // TODO: memoize? this could traverse a lot of nodes & edges, seems not performant
-export const parents = (node: Node, diagram: DiagramState) => {
+export const parents = (node: Node, diagram: Diagram) => {
   const parentEdges = diagram.edges.filter((edge) => edge.target === node.id);
 
   return parentEdges.map((edge) => {
@@ -46,7 +46,7 @@ export const parents = (node: Node, diagram: DiagramState) => {
   });
 };
 
-export const children = (node: Node, diagram: DiagramState) => {
+export const children = (node: Node, diagram: Diagram) => {
   const childEdges = diagram.edges.filter((edge) => edge.source === node.id);
   return childEdges.map((edge) => {
     const node = diagram.nodes.find((node) => edge.target === node.id);
@@ -57,7 +57,7 @@ export const children = (node: Node, diagram: DiagramState) => {
 };
 
 // errors if node does not have only one parent
-export const onlyParent = (node: Node, diagram: DiagramState) => {
+export const onlyParent = (node: Node, diagram: Diagram) => {
   const allParents = parents(node, diagram);
 
   if (allParents.length !== 1) {

--- a/web/src/modules/topic/utils/nodes.ts
+++ b/web/src/modules/topic/utils/nodes.ts
@@ -3,9 +3,12 @@ import { Article, Ballot, Check, Extension, ThumbDown, ThumbUp } from "@mui/icon
 import { DiagramState, Node } from "./diagram";
 
 export const maxCharsPerLine = 19; // measured by typing "a"'s in a node textbox
+export const indicatorLength = 20; // px
+
+export type MuiIcon = typeof Extension;
 
 export interface NodeDecoration {
-  NodeIcon: typeof Extension;
+  NodeIcon: MuiIcon;
 }
 
 export type NodeType = "problem" | "solution" | "criterion" | "rootClaim" | "support" | "critique";


### PR DESCRIPTION
Closes #34 

### Description of changes

- see commit messages

### Additional context

- working with this, I think showing criteria in the problem view is too much. there are too many connections and it's very easy to be visually overwhelming. I think at this point it's worth merging still, but it seems likely that the criteria table view (as suggested in the issue's figma design) will completely replace any value that there is in this show/hiding of criteria in the problem view. in any case, this adds some value until that can be done, and a lot of the code needed to implement this will still be needed for future features.
