### PR TITLE
fix: claim buttons were showing horizontally

### DIFF
--- a/web/src/modules/topic/components/FlowNode/FlowNode.styles.tsx
+++ b/web/src/modules/topic/components/FlowNode/FlowNode.styles.tsx
@@ -26,7 +26,7 @@ const StyledAddNodeButtonGroup = styled(AddNodeButtonGroup)`
 
   .react-flow__node:hover > &,
   .react-flow__node.selected > & {
-    display: inherit;
+    display: flex;
   }
 `;
 


### PR DESCRIPTION
### Description of changes

- button group was using display: inherit, but the parent changed from EditableNode to FlowNode, and FlowNode just uses the default display: block. looked at Material UI's [example](https://mui.com/material-ui/react-button-group/#vertical-group) to see that flex is the intent

### Additional context

- 
