### PR TITLE
docs: add economic system example

### DIFF
--- a/web/public/examples/economic_system.json
+++ b/web/public/examples/economic_system.json
@@ -1,0 +1,945 @@
+{
+  "diagrams": {
+    "root": {
+      "id": "root",
+      "nodes": [
+        {
+          "id": "0",
+          "data": {
+            "label": "Economic system",
+            "score": "-",
+            "diagramId": "root",
+            "showCriteria": true
+          },
+          "position": { "x": 1195, "y": 0 },
+          "selected": false,
+          "type": "problem"
+        },
+        {
+          "id": "1",
+          "data": { "label": "\"True\" Capitalism", "score": "-", "diagramId": "root" },
+          "position": { "x": 430, "y": 488 },
+          "selected": false,
+          "type": "solution"
+        },
+        {
+          "id": "2",
+          "data": { "label": "Socialism", "score": "-", "diagramId": "root" },
+          "position": { "x": 1960, "y": 488 },
+          "selected": false,
+          "type": "solution"
+        },
+        {
+          "id": "7",
+          "data": {
+            "label": "Discourages unsustainable lifestyles",
+            "score": "-",
+            "diagramId": "root"
+          },
+          "position": { "x": 320, "y": 244 },
+          "selected": false,
+          "type": "criterion"
+        },
+        {
+          "id": "19",
+          "data": {
+            "label": "Encourages quality of production",
+            "score": "-",
+            "diagramId": "root"
+          },
+          "position": { "x": 670, "y": 244 },
+          "selected": false,
+          "type": "criterion"
+        },
+        {
+          "id": "23",
+          "data": { "label": "Power in the right hands", "score": "-", "diagramId": "root" },
+          "position": { "x": 1020, "y": 244 },
+          "selected": false,
+          "type": "criterion"
+        },
+        {
+          "id": "33",
+          "data": {
+            "label": "Supports those who cannot support themselves",
+            "score": "1",
+            "diagramId": "root"
+          },
+          "position": { "x": 1370, "y": 244 },
+          "selected": false,
+          "type": "criterion"
+        },
+        {
+          "id": "34",
+          "data": {
+            "label": "Does not discriminate based on birth",
+            "score": "-",
+            "diagramId": "root"
+          },
+          "position": { "x": 1720, "y": 244 },
+          "selected": false,
+          "type": "criterion"
+        },
+        {
+          "id": "70",
+          "data": { "label": "text70", "score": "-", "diagramId": "root" },
+          "position": { "x": 2070, "y": 244 },
+          "selected": false,
+          "type": "criterion"
+        }
+      ],
+      "edges": [
+        {
+          "id": "0",
+          "data": { "score": "-" },
+          "label": "solves",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "0",
+          "target": "1",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "1",
+          "data": { "score": "-" },
+          "label": "solves",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "0",
+          "target": "2",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "7",
+          "data": { "score": "10" },
+          "label": "embodies",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "7",
+          "target": "1",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "8",
+          "data": { "score": "1" },
+          "label": "embodies",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "7",
+          "target": "2",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "6",
+          "data": { "score": "-" },
+          "label": "criterion for",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "0",
+          "target": "7",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "16",
+          "data": { "score": "-" },
+          "label": "embodies",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "19",
+          "target": "1",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "17",
+          "data": { "score": "-" },
+          "label": "embodies",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "19",
+          "target": "2",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "15",
+          "data": { "score": "-" },
+          "label": "criterion for",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "0",
+          "target": "19",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "21",
+          "data": { "score": "-" },
+          "label": "embodies",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "23",
+          "target": "1",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "22",
+          "data": { "score": "3" },
+          "label": "embodies",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "23",
+          "target": "2",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "20",
+          "data": { "score": "-" },
+          "label": "criterion for",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "0",
+          "target": "23",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "30",
+          "data": { "score": "-" },
+          "label": "embodies",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "33",
+          "target": "1",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "31",
+          "data": { "score": "-" },
+          "label": "embodies",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "33",
+          "target": "2",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "29",
+          "data": { "score": "-" },
+          "label": "criterion for",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "0",
+          "target": "33",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "33",
+          "data": { "score": "-" },
+          "label": "embodies",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "34",
+          "target": "1",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "34",
+          "data": { "score": "-" },
+          "label": "embodies",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "34",
+          "target": "2",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "32",
+          "data": { "score": "-" },
+          "label": "criterion for",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "0",
+          "target": "34",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "85",
+          "data": { "score": "-" },
+          "label": "embodies",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "70",
+          "target": "1",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "86",
+          "data": { "score": "-" },
+          "label": "embodies",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "70",
+          "target": "2",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "84",
+          "data": { "score": "-" },
+          "label": "criterion for",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "0",
+          "target": "70",
+          "type": "ScoreEdge"
+        }
+      ],
+      "type": "problem"
+    },
+    "node-7": {
+      "id": "node-7",
+      "nodes": [
+        {
+          "id": "8",
+          "data": {
+            "label": "\"Encourages unsustainable lifestyles\" is important",
+            "score": "-",
+            "diagramId": "node-7"
+          },
+          "position": { "x": 0, "y": 0 },
+          "selected": false,
+          "type": "rootClaim"
+        }
+      ],
+      "edges": [],
+      "type": "claim"
+    },
+    "edge-6": {
+      "id": "edge-6",
+      "nodes": [
+        {
+          "id": "9",
+          "data": {
+            "label": "\"Discourages un...\" criterion for \"Economic system\"",
+            "score": "-",
+            "diagramId": "edge-6"
+          },
+          "position": { "x": 0, "y": 0 },
+          "selected": false,
+          "type": "rootClaim"
+        }
+      ],
+      "edges": [],
+      "type": "claim"
+    },
+    "edge-7": {
+      "id": "edge-7",
+      "nodes": [
+        {
+          "id": "11",
+          "data": {
+            "label": "\"\"True\" Capitalism\" embodies \"Discourages un...\"",
+            "score": "10",
+            "diagramId": "edge-7"
+          },
+          "position": { "x": 0, "y": 70 },
+          "selected": false,
+          "type": "rootClaim"
+        },
+        {
+          "id": "12",
+          "data": {
+            "label": "No social support = people die",
+            "score": "-",
+            "diagramId": "edge-7"
+          },
+          "position": { "x": 560, "y": 0 },
+          "selected": false,
+          "type": "support"
+        },
+        {
+          "id": "44",
+          "data": {
+            "label": "Gain from things not tied to work",
+            "score": "-",
+            "diagramId": "edge-7"
+          },
+          "position": { "x": 560, "y": 140 },
+          "selected": false,
+          "type": "critique"
+        },
+        {
+          "id": "45",
+          "data": { "label": "Inheritance", "score": "-", "diagramId": "edge-7" },
+          "position": { "x": 1120, "y": 70 },
+          "selected": false,
+          "type": "support"
+        },
+        {
+          "id": "46",
+          "data": { "label": "Stock", "score": "-", "diagramId": "edge-7" },
+          "position": { "x": 1120, "y": 210 },
+          "selected": false,
+          "type": "support"
+        }
+      ],
+      "edges": [
+        {
+          "id": "10",
+          "data": { "score": "-" },
+          "label": "supports",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "11",
+          "target": "12",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "41",
+          "data": { "score": "-" },
+          "label": "critiques",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "11",
+          "target": "44",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "42",
+          "data": { "score": "-" },
+          "label": "supports",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "44",
+          "target": "45",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "43",
+          "data": { "score": "-" },
+          "label": "supports",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "44",
+          "target": "46",
+          "type": "ScoreEdge"
+        }
+      ],
+      "type": "claim"
+    },
+    "edge-8": {
+      "id": "edge-8",
+      "nodes": [
+        {
+          "id": "13",
+          "data": {
+            "label": "\"Socialism\" embodies \"Discourages un...\"",
+            "score": "1",
+            "diagramId": "edge-8"
+          },
+          "position": { "x": 0, "y": 70 },
+          "selected": false,
+          "type": "rootClaim"
+        },
+        {
+          "id": "14",
+          "data": { "label": "Social welfare", "score": "-", "diagramId": "edge-8" },
+          "position": { "x": 560, "y": 0 },
+          "selected": false,
+          "type": "critique"
+        },
+        {
+          "id": "17",
+          "data": {
+            "label": "Public schools teach counter-productive things",
+            "score": "-",
+            "diagramId": "edge-8"
+          },
+          "position": { "x": 560, "y": 140 },
+          "selected": false,
+          "type": "critique"
+        },
+        {
+          "id": "18",
+          "data": { "label": "Anti-reproduction sentiments", "score": "-", "diagramId": "edge-8" },
+          "position": { "x": 1120, "y": 140 },
+          "selected": false,
+          "type": "support"
+        }
+      ],
+      "edges": [
+        {
+          "id": "11",
+          "data": { "score": "-" },
+          "label": "critiques",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "13",
+          "target": "14",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "13",
+          "data": { "score": "-" },
+          "label": "critiques",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "13",
+          "target": "17",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "14",
+          "data": { "score": "-" },
+          "label": "supports",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "17",
+          "target": "18",
+          "type": "ScoreEdge"
+        }
+      ],
+      "type": "claim"
+    },
+    "node-1": {
+      "id": "node-1",
+      "nodes": [
+        {
+          "id": "15",
+          "data": {
+            "label": "\"\"True\" Capitalism\" is important",
+            "score": "-",
+            "diagramId": "node-1"
+          },
+          "position": { "x": 0, "y": 0 },
+          "selected": false,
+          "type": "rootClaim"
+        }
+      ],
+      "edges": [],
+      "type": "claim"
+    },
+    "edge-16": {
+      "id": "edge-16",
+      "nodes": [
+        {
+          "id": "20",
+          "data": {
+            "label": "\"\"True\" Capitalism\" embodies \"Encourages qua...\"",
+            "score": "-",
+            "diagramId": "edge-16"
+          },
+          "position": { "x": 0, "y": 70 },
+          "selected": false,
+          "type": "rootClaim"
+        },
+        {
+          "id": "21",
+          "data": { "label": "Companies must compete", "score": "-", "diagramId": "edge-16" },
+          "position": { "x": 560, "y": 0 },
+          "selected": false,
+          "type": "support"
+        },
+        {
+          "id": "30",
+          "data": { "label": "Innovation is rewarded", "score": "-", "diagramId": "edge-16" },
+          "position": { "x": 560, "y": 140 },
+          "selected": false,
+          "type": "support"
+        }
+      ],
+      "edges": [
+        {
+          "id": "18",
+          "data": { "score": "-" },
+          "label": "supports",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "20",
+          "target": "21",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "27",
+          "data": { "score": "-" },
+          "label": "supports",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "20",
+          "target": "30",
+          "type": "ScoreEdge"
+        }
+      ],
+      "type": "claim"
+    },
+    "edge-22": {
+      "id": "edge-22",
+      "nodes": [
+        {
+          "id": "24",
+          "data": {
+            "label": "\"Socialism\" embodies \"Power in the r...\"",
+            "score": "3",
+            "diagramId": "edge-22"
+          },
+          "position": { "x": 0, "y": 70 },
+          "selected": false,
+          "type": "rootClaim"
+        },
+        {
+          "id": "25",
+          "data": {
+            "label": "Decides for others without self consequence",
+            "score": "-",
+            "diagramId": "edge-22"
+          },
+          "position": { "x": 560, "y": 0 },
+          "selected": false,
+          "type": "critique"
+        },
+        {
+          "id": "29",
+          "data": {
+            "label": "No system to exclude bad deciders",
+            "score": "-",
+            "diagramId": "edge-22"
+          },
+          "position": { "x": 560, "y": 140 },
+          "selected": false,
+          "type": "critique"
+        }
+      ],
+      "edges": [
+        {
+          "id": "23",
+          "data": { "score": "-" },
+          "label": "critiques",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "24",
+          "target": "25",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "26",
+          "data": { "score": "-" },
+          "label": "critiques",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "24",
+          "target": "29",
+          "type": "ScoreEdge"
+        }
+      ],
+      "type": "claim"
+    },
+    "edge-21": {
+      "id": "edge-21",
+      "nodes": [
+        {
+          "id": "26",
+          "data": {
+            "label": "\"\"True\" Capitalism\" embodies \"Power in the r...\"",
+            "score": "-",
+            "diagramId": "edge-21"
+          },
+          "position": { "x": 0, "y": 0 },
+          "selected": false,
+          "type": "rootClaim"
+        },
+        {
+          "id": "27",
+          "data": {
+            "label": "Wealthy people are the best decision makers",
+            "score": "-",
+            "diagramId": "edge-21"
+          },
+          "position": { "x": 560, "y": 0 },
+          "selected": false,
+          "type": "support"
+        },
+        {
+          "id": "28",
+          "data": {
+            "label": "Capitalist wealth implies they knew what people wanted",
+            "score": "-",
+            "diagramId": "edge-21"
+          },
+          "position": { "x": 1120, "y": 0 },
+          "selected": false,
+          "type": "support"
+        }
+      ],
+      "edges": [
+        {
+          "id": "24",
+          "data": { "score": "-" },
+          "label": "supports",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "26",
+          "target": "27",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "25",
+          "data": { "score": "-" },
+          "label": "supports",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "27",
+          "target": "28",
+          "type": "ScoreEdge"
+        }
+      ],
+      "type": "claim"
+    },
+    "edge-30": {
+      "id": "edge-30",
+      "nodes": [
+        {
+          "id": "35",
+          "data": {
+            "label": "\"\"True\" Capitalism\" embodies \"Supports those...\"",
+            "score": "-",
+            "diagramId": "edge-30"
+          },
+          "position": { "x": 0, "y": 0 },
+          "selected": false,
+          "type": "rootClaim"
+        }
+      ],
+      "edges": [],
+      "type": "claim"
+    },
+    "edge-33": {
+      "id": "edge-33",
+      "nodes": [
+        {
+          "id": "36",
+          "data": {
+            "label": "\"\"True\" Capitalism\" embodies \"Does not discr...\"",
+            "score": "-",
+            "diagramId": "edge-33"
+          },
+          "position": { "x": 0, "y": 0 },
+          "selected": false,
+          "type": "rootClaim"
+        },
+        {
+          "id": "37",
+          "data": {
+            "label": "Born into wealth gives people a better chance",
+            "score": "-",
+            "diagramId": "edge-33"
+          },
+          "position": { "x": 560, "y": 0 },
+          "selected": false,
+          "type": "critique"
+        }
+      ],
+      "edges": [
+        {
+          "id": "35",
+          "data": { "score": "-" },
+          "label": "critiques",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "36",
+          "target": "37",
+          "type": "ScoreEdge"
+        }
+      ],
+      "type": "claim"
+    },
+    "node-34": {
+      "id": "node-34",
+      "nodes": [
+        {
+          "id": "38",
+          "data": {
+            "label": "\"Does not discriminate based on birth\" is important",
+            "score": "-",
+            "diagramId": "node-34"
+          },
+          "position": { "x": 0, "y": 140 },
+          "selected": false,
+          "type": "rootClaim"
+        },
+        {
+          "id": "39",
+          "data": {
+            "label": "Everyone should have a chance in society",
+            "score": "-",
+            "diagramId": "node-34"
+          },
+          "position": { "x": 560, "y": 0 },
+          "selected": false,
+          "type": "support"
+        },
+        {
+          "id": "40",
+          "data": { "label": "Incentives can be useful", "score": "-", "diagramId": "node-34" },
+          "position": { "x": 560, "y": 140 },
+          "selected": false,
+          "type": "critique"
+        },
+        {
+          "id": "41",
+          "data": {
+            "label": "Equality must be balanced against other values",
+            "score": "-",
+            "diagramId": "node-34"
+          },
+          "position": { "x": 560, "y": 280 },
+          "selected": false,
+          "type": "critique"
+        },
+        {
+          "id": "63",
+          "data": {
+            "label": "Bad genes lead to unhappier people",
+            "score": "10",
+            "diagramId": "node-34"
+          },
+          "position": { "x": 1120, "y": 0 },
+          "selected": false,
+          "type": "critique"
+        }
+      ],
+      "edges": [
+        {
+          "id": "36",
+          "data": { "score": "-" },
+          "label": "supports",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "38",
+          "target": "39",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "37",
+          "data": { "score": "-" },
+          "label": "critiques",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "38",
+          "target": "40",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "38",
+          "data": { "score": "-" },
+          "label": "critiques",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "38",
+          "target": "41",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "69",
+          "data": { "score": "-" },
+          "label": "critiques",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "39",
+          "target": "63",
+          "type": "ScoreEdge"
+        }
+      ],
+      "type": "claim"
+    },
+    "node-33": {
+      "id": "node-33",
+      "nodes": [
+        {
+          "id": "47",
+          "data": {
+            "label": "\"Supports those who cannot support...\" is important",
+            "score": "1",
+            "diagramId": "node-33"
+          },
+          "position": { "x": 0, "y": 70 },
+          "selected": false,
+          "type": "rootClaim"
+        },
+        {
+          "id": "48",
+          "data": {
+            "label": "Genetics correlate to success",
+            "score": "10",
+            "diagramId": "node-33"
+          },
+          "position": { "x": 560, "y": 0 },
+          "selected": false,
+          "type": "critique"
+        },
+        {
+          "id": "62",
+          "data": {
+            "label": "Dependents will breed more dependents",
+            "score": "-",
+            "diagramId": "node-33"
+          },
+          "position": { "x": 560, "y": 140 },
+          "selected": false,
+          "type": "critique"
+        }
+      ],
+      "edges": [
+        {
+          "id": "44",
+          "data": { "score": "-" },
+          "label": "critiques",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "47",
+          "target": "48",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "68",
+          "data": { "score": "-" },
+          "label": "critiques",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "47",
+          "target": "62",
+          "type": "ScoreEdge"
+        }
+      ],
+      "type": "claim"
+    },
+    "edge-17": {
+      "id": "edge-17",
+      "nodes": [
+        {
+          "id": "64",
+          "data": {
+            "label": "\"Socialism\" embodies \"Encourages qua...\"",
+            "score": "-",
+            "diagramId": "edge-17"
+          },
+          "position": { "x": 0, "y": 0 },
+          "selected": false,
+          "type": "rootClaim"
+        },
+        {
+          "id": "65",
+          "data": { "label": "Can offer capped incentives", "score": "-", "diagramId": "edge-17" },
+          "position": { "x": 560, "y": 0 },
+          "selected": false,
+          "type": "support"
+        },
+        {
+          "id": "66",
+          "data": { "label": "Capping prevents meritocracy", "score": "-", "diagramId": "edge-17" },
+          "position": { "x": 1120, "y": 0 },
+          "selected": false,
+          "type": "critique"
+        }
+      ],
+      "edges": [
+        {
+          "id": "70",
+          "data": { "score": "-" },
+          "label": "supports",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "64",
+          "target": "65",
+          "type": "ScoreEdge"
+        },
+        {
+          "id": "71",
+          "data": { "score": "-" },
+          "label": "critiques",
+          "markerStart": { "type": "arrowclosed", "width": 30, "height": 30 },
+          "source": "65",
+          "target": "66",
+          "type": "ScoreEdge"
+        }
+      ],
+      "type": "claim"
+    },
+    "edge-31": {
+      "id": "edge-31",
+      "nodes": [
+        {
+          "id": "71",
+          "data": {
+            "label": "\"Socialism\" embodies \"Supports those...\"",
+            "score": "-",
+            "diagramId": "edge-31"
+          },
+          "position": { "x": 0, "y": 0 },
+          "selected": false,
+          "type": "rootClaim"
+        }
+      ],
+      "edges": [],
+      "type": "claim"
+    }
+  },
+  "activeTableProblemId": null,
+  "activeClaimDiagramId": null,
+  "nextNodeId": 72,
+  "nextEdgeId": 87
+}

--- a/web/src/modules/topic/components/TopicToolbar/TopicToolbar.tsx
+++ b/web/src/modules/topic/components/TopicToolbar/TopicToolbar.tsx
@@ -52,6 +52,7 @@ export const TopicToolbar = () => {
           <ExpandMore />
         </Button>
         <Menu anchorEl={anchorEl} isOpen={menuIsOpen} closeMenu={closeMenu}>
+          <MenuItem onClick={() => loadExample("economic_system.json")}>Economic System</MenuItem>
           <MenuItem onClick={() => loadExample("living_location.json")}>Living Location</MenuItem>
           <MenuItem onClick={() => loadExample("unwanted_pregnancy.json")}>
             Unwanted Pregnancy


### PR DESCRIPTION
### Description of changes

- watched [Capitalism vs Socialism debate video](https://www.youtube.com/watch?v=CVjgbFfaOJk) and tried to map out the problem, solutions, & arguments with ameliorate in order to identify improvements for the tool. Created a bunch of issues as a result (which are linked below)

### Additional context

Notes from this exercise:
- Score hover is really annoying
- Adding criteria from problem view is useful, so I don't have to leave the context to get to the table
- Problem node indicators are a little busy #60
- Allow more text in nodes, just use scroll?
  - "…" seems to imply there's something there, but we're actually trimming it in data
  - Adding too much text is still discouraged because it won't be easily visible
  - Don't trim text when adding implicit claims #61
- Overlay could be a little more transparent… but also my monitor could be darker
-  Space between claims should be reduced
  - Extra space for multi-line nodes should be calculable #62
- Even with overlay, supports/critiques still feel a LIIIITTLE disconnected #63
- Socialist guy is pretty condescending ("obviously" "your eccentric view")
  - Devolving into semantics - keeps correcting verbiage when the intention seems implied, and the corrections don't actually seem correct :( ("appeal to authority requires the authority to not be credible")
- The diagram should highlight the most-disagreed-upon values/claims #64
  - Bad genes lead to unhappier people
- Dark mode #68

Wants
- Elevate nodes/edges based on selected node #32
  - Can't score edges that overlap right now (though criteria can be scored in table view)
  - Actually, this in addition to on-hover sounds good
- Scratch notes per node to convey things that the system doesn't allow #65
- Effect nodes #67
  - Capitalism -> creates effect -> Unsustainable lifestyles disappear
- Component nodes #66
  - Capitalism -> composed of -> no social aid
  - Capitalism -> composed of -> private property
- Justify criteria via solution effects and/or components
  - Particularly because effects/components would be used across different criteria
  - Convert claim to effect/solution component #70
- Text annotation #69
  - "true" capitalism: no social support for each other - people who cannot sustain themselves will die
- Curator to score arguables from different perspectives #71

Maybe
- Convert effect to criterion?
  - "Unsustainable lifestyles disappear" -> "discourages unsustainable lifestyles"
  - Also replaced "Encourages unsustainable lifestyles" problem that was created by socialism
  - Eh effect & criteria might both be important separately, since effect can contribute to multiple criteria
- User-expandable panes?
  - Desired mainly because of the long/unreadable root claim text
  - Meh
- Criterion worded in verb form, Solution in noun form, for root claim like "capitalism encourages quality of production"

Bugs
- Panning suddenly doesn't work? Mouse shows click icon instead of pan icon #72
  - Workaround: remove focus from flow
  - This happens if you press shift when a node textbox is focused, and this is related to the react flow selection functional (if you click and drag, you can select multiple nodes). Solution is probably to turn off selection