### PR TITLE
fix: Score Dial appropriately closes

### DIFF
--- a/web/src/modules/topic/components/Score/Score.styles.tsx
+++ b/web/src/modules/topic/components/Score/Score.styles.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { Button, Popper, css } from "@mui/material";
+import { Box, Button, Popper, css } from "@mui/material";
 
 interface StyledButtonProps {
   buttonLength: number;
@@ -21,7 +21,12 @@ export const StyledButton = styled(Button, options)<StyledButtonProps>`
 `;
 
 export const StyledPopper = styled(Popper)`
+  border-radius: 50%;
   ${({ theme }) => css`
     z-index: ${theme.zIndex.tooltip}; // even in front of toolbars
   `}
+`;
+
+export const StyledBox = styled(Box)`
+  pointer-events: none;
 `;

--- a/web/src/modules/topic/components/Score/ScorePie.tsx
+++ b/web/src/modules/topic/components/Score/ScorePie.tsx
@@ -1,5 +1,5 @@
 import { useTheme } from "@emotion/react";
-import { Box, type PaletteColor } from "@mui/material";
+import { type PaletteColor } from "@mui/material";
 import { useState } from "react";
 import { PieChart } from "react-minimal-pie-chart";
 import { Data } from "react-minimal-pie-chart/types/commonTypes";
@@ -7,6 +7,7 @@ import { Data } from "react-minimal-pie-chart/types/commonTypes";
 import { setScore } from "../../store/actions";
 import { ArguableType, Score, possibleScores } from "../../utils/diagram";
 import { scoreColors } from "./Score";
+import { StyledBox } from "./Score.styles";
 
 interface Props {
   pieDiameter: number;
@@ -18,40 +19,42 @@ export const ScorePie = ({ pieDiameter, arguableId, arguableType }: Props) => {
   const theme = useTheme();
   const [hovered, setHovered] = useState<number | undefined>(undefined);
 
-  const data: Data = possibleScores.map((score, index) => {
+  const data: Data = possibleScores.map((score, dataIndex) => {
     const scoreColor = scoreColors[score];
     const paletteColor = theme.palette[scoreColor] as PaletteColor; // not sure how to guarantee this type, since palette has non-PaletteColor keys
 
     return {
       value: 1,
-      color: hovered === index ? paletteColor.dark : paletteColor.main,
+      color: hovered === dataIndex ? paletteColor.dark : paletteColor.main,
       key: score,
     };
   });
 
   return (
-    <Box display="flex" width={pieDiameter} height={pieDiameter}>
+    <StyledBox display="flex" width={pieDiameter} height={pieDiameter}>
       <PieChart
         data={data}
-        radius={50} // is relative to viewbox size [100, 100]
+        radius={45} // is relative to viewbox size [100, 100]
         label={({ dataEntry }) => dataEntry.key}
         labelStyle={() => ({
           fontSize: "14", // is relative to viewbox size [100, 100]
           pointerEvents: "none",
+          userSelect: "none",
         })}
-        segmentsStyle={{
+        segmentsStyle={(dataIndex) => ({
           transition: theme.transitions.create("all", {
             duration: theme.transitions.duration.shortest,
           }),
+          pointerEvents: "auto",
           cursor: "pointer",
-        }}
+        })}
         labelPosition={70} // percent of radius
         startAngle={-90 - 360 / possibleScores.length / 2} // shift first slice to top center
-        onMouseOver={(_, index) => setHovered(index)}
-        onMouseOut={() => setHovered(undefined)}
+        onMouseOver={(_, dataIndex) => setHovered(dataIndex)}
+        onMouseOut={(_) => setHovered(undefined)}
         onClick={(_, dataIndex) => setScore(arguableId, arguableType, data[dataIndex].key as Score)}
         background="white"
       />
-    </Box>
+    </StyledBox>
   );
 };

--- a/web/src/modules/topic/components/Score/ScorePie.tsx
+++ b/web/src/modules/topic/components/Score/ScorePie.tsx
@@ -42,6 +42,8 @@ export const ScorePie = ({ pieDiameter, arguableId, arguableType }: Props) => {
           userSelect: "none",
         })}
         segmentsStyle={(dataIndex) => ({
+          transform: hovered === dataIndex ? "scale(1.1)" : "",
+          transformOrigin: "center",
           transition: theme.transitions.create("all", {
             duration: theme.transitions.duration.shortest,
           }),


### PR DESCRIPTION
Closes #81

### Description of changes

- Added functionality to segment mouse events,handles mouseleave and mouse hover events.
- Applies CSS to currently hovered segment.
- Selection wheel closes as soon as mouse leaves the pie chart.