### PR TITLE
88 connecting solution component to problem does not create implied problem solution edge

### DIFF
--- a/web/src/common/components/ContextMenu/ContextMenu.tsx
+++ b/web/src/common/components/ContextMenu/ContextMenu.tsx
@@ -15,13 +15,11 @@ export const ContextMenu = () => {
   const isOpen = Boolean(anchorPosition);
 
   // create these based on what's set in the context
-  const menuItems = (
-    <>
-      {contextMenuContext.node && <ShowCriteriaMenuItem node={contextMenuContext.node} />}
-      {contextMenuContext.node && <DeleteNodeMenuItem node={contextMenuContext.node} />}
-      {contextMenuContext.edge && <DeleteEdgeMenuItem edge={contextMenuContext.edge} />}
-    </>
-  );
+  const menuItems = [
+    contextMenuContext.node && <ShowCriteriaMenuItem node={contextMenuContext.node} key={1} />,
+    contextMenuContext.node && <DeleteNodeMenuItem node={contextMenuContext.node} key={2} />,
+    contextMenuContext.edge && <DeleteEdgeMenuItem edge={contextMenuContext.edge} key={3} />,
+  ];
 
   return (
     <MuiMenu

--- a/web/src/modules/topic/components/CriteriaTable/CriteriaTable.tsx
+++ b/web/src/modules/topic/components/CriteriaTable/CriteriaTable.tsx
@@ -95,14 +95,14 @@ export const CriteriaTable = ({ problemNodeId }: Props) => {
           fromNodeId={problemNodeId}
           as="child"
           toNodeType="solution"
-          relation="solves"
+          relation={{ child: "solution", name: "solves", parent: "problem" }}
         />
 
         <AddNodeButton
           fromNodeId={problemNodeId}
           as="child"
           toNodeType="criterion"
-          relation="criterion for"
+          relation={{ child: "criterion", name: "criterion for", parent: "problem" }}
         />
 
         <Tooltip title="Transpose Table">

--- a/web/src/modules/topic/components/Node/AddNodeButton.tsx
+++ b/web/src/modules/topic/components/Node/AddNodeButton.tsx
@@ -2,7 +2,7 @@ import { Tooltip } from "@mui/material";
 
 import { addNode } from "../../store/actions";
 import { type RelationDirection } from "../../utils/diagram";
-import { RelationName } from "../../utils/edge";
+import { Relation } from "../../utils/edge";
 import { NodeType, nodeDecorations } from "../../utils/node";
 import { StyledButton } from "./AddNodeButton.styles";
 
@@ -10,7 +10,7 @@ interface Props {
   fromNodeId: string;
   as: RelationDirection;
   toNodeType: NodeType;
-  relation: RelationName;
+  relation: Relation;
   className?: string;
 }
 

--- a/web/src/modules/topic/store/actions.ts
+++ b/web/src/modules/topic/store/actions.ts
@@ -103,11 +103,11 @@ const connectCriteriaToSolutions = (state: TopicStoreState, newNode: Node, fromN
       );
     });
 
-  return newCriterionEdges;
+  /* eslint-disable functional/immutable-data, no-param-reassign */
+  problemDiagram.edges.push(...newCriterionEdges);
+  /* eslint-enable functional/immutable-data, no-param-reassign */
 };
 
-// trying to keep state changes directly within this method,
-// but wasn't sure how to cleanly handle next node/edge id's without letting invoked methods use & mutate state for them
 export const addNode = ({ fromNodeId, as, toNodeType, relation }: AddNodeProps) => {
   useTopicStore.setState(
     (state) => {
@@ -124,11 +124,7 @@ export const addNode = ({ fromNodeId, as, toNodeType, relation }: AddNodeProps) 
 
       // connect criteria
       if (["criterion", "solution"].includes(newNode.type) && fromNode.type === "problem") {
-        const newCriterionEdges = connectCriteriaToSolutions(state, newNode, fromNode);
-
-        /* eslint-disable functional/immutable-data, no-param-reassign */
-        activeDiagram.edges.push(...newCriterionEdges);
-        /* eslint-enable functional/immutable-data, no-param-reassign */
+        connectCriteriaToSolutions(state, newNode, fromNode);
       }
 
       // re-layout

--- a/web/src/modules/topic/store/actions.ts
+++ b/web/src/modules/topic/store/actions.ts
@@ -142,6 +142,9 @@ const createShortcutEdges = (state: TopicStoreState, parent: Node, child: Node) 
   const diagram = state.diagrams[parent.data.diagramId];
 
   // assumes relation.name is unique per parent & child combination
+  // note: this logic doesn't necessarily need to run when adding nodes, since criteria are the only
+  // detours, and all edges there are created automatically, but we do need it to run when connecting
+  // nodes, because criteria edges can be deleted and re-added
   shortcutRelations.forEach((shortcutRelation) => {
     // create parent implied edges
     if (

--- a/web/src/modules/topic/store/actions.ts
+++ b/web/src/modules/topic/store/actions.ts
@@ -1,5 +1,3 @@
-import _ from "lodash";
-
 import { emitter } from "../../../common/event";
 import { getClaimDiagramId, getImplicitLabel, parseClaimDiagramId } from "../utils/claim";
 import {
@@ -195,13 +193,13 @@ const createEdgesImpliedByComposition = (
 
   const nodesComposedByParent = getNodesComposedBy(parent, diagram);
   nodesComposedByParent.forEach((nodeComposedByParent) => {
-    const relationForComposed = _.assign(relation, { parent: nodeComposedByParent.type });
+    const relationForComposed = { ...relation, parent: nodeComposedByParent.type } as Relation;
     createEdgeAndImpliedEdges(state, nodeComposedByParent, child, relationForComposed);
   });
 
   const nodesComposedByChild = getNodesComposedBy(child, diagram);
   nodesComposedByChild.forEach((nodeComposedByChild) => {
-    const relationForComposed = _.assign(relation, { child: nodeComposedByChild.type });
+    const relationForComposed = { ...relation, child: nodeComposedByChild.type } as Relation;
     createEdgeAndImpliedEdges(state, parent, nodeComposedByChild, relationForComposed);
   });
 };

--- a/web/src/modules/topic/utils/diagram.ts
+++ b/web/src/modules/topic/utils/diagram.ts
@@ -1,6 +1,6 @@
 import { MarkerType } from "reactflow";
 
-import { RelationName, childNode, parentNode, shortcutRelations } from "./edge";
+import { RelationName, childNode, composedRelations, parentNode, shortcutRelations } from "./edge";
 import { Orientation, layout } from "./layout";
 import { NodeType, children, parents } from "./node";
 
@@ -70,8 +70,8 @@ export interface Edge {
   };
   label: RelationName;
   markerStart: { type: MarkerType; width: number; height: number };
-  source: string;
-  target: string;
+  source: string; // source === parent if arrows point from bottom to top
+  target: string; // target === child if arrows point from bottom to top
   type: "ScoreEdge";
 }
 
@@ -117,6 +117,20 @@ export const findEdge = (diagram: Diagram, edgeId: string) => {
 
 export const findArguable = (diagram: Diagram, arguableId: string, arguableType: ArguableType) => {
   return arguableType === "node" ? findNode(diagram, arguableId) : findEdge(diagram, arguableId);
+};
+
+export const getNodesComposedBy = (node: Node, diagram: Diagram) => {
+  return composedRelations.flatMap((composedRelation) => {
+    const composingEdges = diagram.edges.filter((edge) => {
+      return edge.source === node.id && edge.label === composedRelation.name;
+    });
+
+    const potentialComposedNodes = composingEdges.map((edge) => findNode(diagram, edge.target));
+
+    return potentialComposedNodes
+      .filter((node) => node.type === composedRelation.child)
+      .map((node) => node);
+  });
 };
 
 // see algorithm pseudocode & example at https://github.com/amelioro/ameliorate/issues/66#issuecomment-1465078133

--- a/web/src/modules/topic/utils/diagram.ts
+++ b/web/src/modules/topic/utils/diagram.ts
@@ -1,6 +1,6 @@
 import { MarkerType } from "reactflow";
 
-import { RelationName, childNode, impliedRelations, parentNode } from "./edge";
+import { RelationName, childNode, parentNode, shortcutRelations } from "./edge";
 import { Orientation, layout } from "./layout";
 import { NodeType, children, parents } from "./node";
 
@@ -120,31 +120,31 @@ export const findArguable = (diagram: Diagram, arguableId: string, arguableType:
 };
 
 // see algorithm pseudocode & example at https://github.com/amelioro/ameliorate/issues/66#issuecomment-1465078133
-const isEdgeImplied = (edge: Edge, diagram: Diagram) => {
+const isEdgeAShortcut = (edge: Edge, diagram: Diagram) => {
   const edgeParent = parentNode(edge, diagram);
   const edgeChild = childNode(edge, diagram);
 
-  return impliedRelations.some((impliedRelation) => {
-    const edgeCouldBeImplied =
-      edgeParent.type === impliedRelation.relation.parent &&
-      edgeChild.type === impliedRelation.relation.child;
+  return shortcutRelations.some((shortcutRelation) => {
+    const edgeCouldBeAShortcut =
+      edgeParent.type === shortcutRelation.relation.parent &&
+      edgeChild.type === shortcutRelation.relation.child;
 
-    if (!edgeCouldBeImplied) return false;
+    if (!edgeCouldBeAShortcut) return false;
 
     const childrenOfParent = children(edgeParent, diagram);
     const parentsOfChild = parents(edgeChild, diagram);
 
-    const throughNodeAsChild = childrenOfParent.find(
-      (child) => child.type === impliedRelation.throughNodeType
+    const detourNodeAsChild = childrenOfParent.find(
+      (child) => child.type === shortcutRelation.detourNodeType
     );
-    const throughNodeAsParent = parentsOfChild.find(
-      (parent) => parent.type === impliedRelation.throughNodeType
+    const detourNodeAsParent = parentsOfChild.find(
+      (parent) => parent.type === shortcutRelation.detourNodeType
     );
 
-    const throughNodeConnectsParentAndChild =
-      throughNodeAsChild && throughNodeAsParent && throughNodeAsChild.data.showing;
+    const detourNodeConnectsParentAndChild =
+      detourNodeAsChild && detourNodeAsParent && detourNodeAsChild.data.showing;
 
-    return throughNodeConnectsParentAndChild;
+    return detourNodeConnectsParentAndChild;
   });
 };
 
@@ -155,7 +155,7 @@ export const filterHiddenComponents = (diagram: Diagram): Diagram => {
   const shownEdges = diagram.edges.filter((edge) => {
     if (!shownNodeIds.includes(edge.source) || !shownNodeIds.includes(edge.target)) return false;
 
-    if (isEdgeImplied(edge, diagram)) return false;
+    if (isEdgeAShortcut(edge, diagram)) return false;
 
     return true;
   });

--- a/web/src/modules/topic/utils/edge.ts
+++ b/web/src/modules/topic/utils/edge.ts
@@ -144,7 +144,7 @@ export const addableRelationsFrom = (nodeType: NodeType, addingAs: RelationDirec
 
   const formattedRelations = addableRelations.map((relation) => ({
     toNodeType: relation[addingAs],
-    relation: relation.name,
+    relation,
   }));
 
   return formattedRelations;

--- a/web/src/modules/topic/utils/edge.ts
+++ b/web/src/modules/topic/utils/edge.ts
@@ -59,7 +59,7 @@ const componentTypes: Partial<Record<NodeType, NodeType>> = {
 // and any connection to/from the component node implies a connection to/from the composed node
 // e.g. if a solution component connects to a problem, it's implied that the solution also connects
 // to the problem.
-const impliedComponentRelations: ImpliedRelation[] = Object.entries(componentTypes).flatMap(
+const shortcutComponentRelations: ShortcutRelation[] = Object.entries(componentTypes).flatMap(
   ([nodeType, componentType]) => {
     return relations
       .filter(
@@ -67,55 +67,55 @@ const impliedComponentRelations: ImpliedRelation[] = Object.entries(componentTyp
           [child, parent].includes(nodeType as NodeType) && ![child, parent].includes(componentType)
       )
       .map((relation) => ({
-        throughNodeType: componentType,
+        detourNodeType: componentType,
         relation: relation,
       }));
   }
 );
 
-interface ImpliedRelation {
-  throughNodeType: NodeType;
+interface ShortcutRelation {
+  detourNodeType: NodeType;
   relation: Relation;
 }
 
-export const impliedRelations: ImpliedRelation[] = [
+export const shortcutRelations: ShortcutRelation[] = [
   {
-    throughNodeType: "criterion",
+    detourNodeType: "criterion",
     relation: { child: "solution", name: "solves", parent: "problem" },
   },
   {
-    throughNodeType: "criterion",
+    detourNodeType: "criterion",
     relation: { child: "solutionComponent", name: "solves", parent: "problem" },
   },
   {
-    throughNodeType: "criterion",
+    detourNodeType: "criterion",
     relation: { child: "effect", name: "solves", parent: "problem" },
   },
   {
-    throughNodeType: "effect",
+    detourNodeType: "effect",
     relation: { child: "solution", name: "solves", parent: "problem" },
   },
   {
-    throughNodeType: "effect",
+    detourNodeType: "effect",
     relation: { child: "solutionComponent", name: "solves", parent: "problem" },
   },
   {
-    throughNodeType: "effect",
+    detourNodeType: "effect",
     relation: { child: "solution", name: "embodies", parent: "criterion" },
   },
   {
-    throughNodeType: "effect",
+    detourNodeType: "effect",
     relation: { child: "solutionComponent", name: "embodies", parent: "criterion" },
   },
   {
-    throughNodeType: "effect",
+    detourNodeType: "effect",
     relation: { child: "problem", name: "created by", parent: "solution" },
   },
   {
-    throughNodeType: "effect",
+    detourNodeType: "effect",
     relation: { child: "problem", name: "created by", parent: "solutionComponent" },
   },
-  ...impliedComponentRelations,
+  ...shortcutComponentRelations,
 ];
 
 type AddableNodes = {

--- a/web/src/modules/topic/utils/edge.ts
+++ b/web/src/modules/topic/utils/edge.ts
@@ -79,30 +79,6 @@ export const shortcutRelations: ShortcutRelation[] = [
     detourNodeType: "criterion",
     relation: { child: "effect", name: "solves", parent: "problem" },
   },
-  {
-    detourNodeType: "effect",
-    relation: { child: "solution", name: "solves", parent: "problem" },
-  },
-  {
-    detourNodeType: "effect",
-    relation: { child: "solutionComponent", name: "solves", parent: "problem" },
-  },
-  {
-    detourNodeType: "effect",
-    relation: { child: "solution", name: "embodies", parent: "criterion" },
-  },
-  {
-    detourNodeType: "effect",
-    relation: { child: "solutionComponent", name: "embodies", parent: "criterion" },
-  },
-  {
-    detourNodeType: "effect",
-    relation: { child: "problem", name: "created by", parent: "solution" },
-  },
-  {
-    detourNodeType: "effect",
-    relation: { child: "problem", name: "created by", parent: "solutionComponent" },
-  },
 ];
 
 type AddableNodes = {

--- a/web/src/modules/topic/utils/edge.ts
+++ b/web/src/modules/topic/utils/edge.ts
@@ -175,16 +175,6 @@ export const canCreateEdge = (diagram: Diagram, parent: Node, child: Node) => {
     return false;
   }
 
-  if (
-    (parent.type === "criterion" || child.type === "criterion") &&
-    [parent.type, child.type].some((type) => type === "problem" || type === "solution")
-  ) {
-    console.log(
-      "cannot connect nodes: criteria is always already connected to as many problems & solutions as it can"
-    );
-    return false;
-  }
-
   if (!relation) {
     console.log("cannot connect nodes: nodes don't form a valid relation");
     return false;

--- a/web/src/modules/topic/utils/edge.ts
+++ b/web/src/modules/topic/utils/edge.ts
@@ -51,33 +51,21 @@ export const getRelation = (parent: NodeType, child: NodeType): Relation | undef
   return relations.find((relation) => relation.parent === parent && relation.child === child);
 };
 
-const componentTypes: Partial<Record<NodeType, NodeType>> = {
-  solution: "solutionComponent",
-};
-
-// component nodes can connect to any node type that the composed node type can connect to,
-// and any connection to/from the component node implies a connection to/from the composed node
-// e.g. if a solution component connects to a problem, it's implied that the solution also connects
-// to the problem.
-const shortcutComponentRelations: ShortcutRelation[] = Object.entries(componentTypes).flatMap(
-  ([nodeType, componentType]) => {
-    return relations
-      .filter(
-        ({ child, parent }) =>
-          [child, parent].includes(nodeType as NodeType) && ![child, parent].includes(componentType)
-      )
-      .map((relation) => ({
-        detourNodeType: componentType,
-        relation: relation,
-      }));
-  }
-);
+export const composedRelations: Relation[] = [
+  { child: "solution", name: "has", parent: "solutionComponent" },
+];
 
 interface ShortcutRelation {
   detourNodeType: NodeType;
   relation: Relation;
 }
 
+/**
+ * Shortcut relations are implied through detour nodes.
+ *
+ * e.g. a criterion is a detour for a solution-solves-problem relation because if a solution embodies
+ * the criterion and the criterion is for a problem, then the solution solves the problem
+ */
 export const shortcutRelations: ShortcutRelation[] = [
   {
     detourNodeType: "criterion",
@@ -115,7 +103,6 @@ export const shortcutRelations: ShortcutRelation[] = [
     detourNodeType: "effect",
     relation: { child: "problem", name: "created by", parent: "solutionComponent" },
   },
-  ...shortcutComponentRelations,
 ];
 
 type AddableNodes = {


### PR DESCRIPTION
Closes #88 

### Description of changes

- edges implied by detour nodes need to behave a little differently from edges implied by detour nodes - the latter do not care about relation direction
- implied edges were only being created on connect, not on add
- other commits are small fixes/touchups, see commit messages for details

### Additional context

- 
