### PR TITLE
fix: pie chart correctly closes

### DIFF
--- a/web/src/modules/topic/components/Score/Score.styles.tsx
+++ b/web/src/modules/topic/components/Score/Score.styles.tsx
@@ -1,32 +1,76 @@
 import styled from "@emotion/styled";
-import { Box, Button, Popper, css } from "@mui/material";
+import { Button, Popper, css } from "@mui/material";
 
 interface StyledButtonProps {
   buttonLength: number;
+  fontScaler?: number;
 }
 
 // seems like MUI automatically forwards invalid props to underlying HTML components?
 // this seems wrong, or at least that it shouldn't be the default
-const options = {
-  shouldForwardProp: (prop: string) => !["buttonLength"].includes(prop),
+const buttonOptions = {
+  shouldForwardProp: (prop: string) => !["buttonLength", "fontScaler"].includes(prop),
 };
-export const StyledButton = styled(Button, options)<StyledButtonProps>`
+export const StyledButton = styled(Button, buttonOptions)<StyledButtonProps>`
   height: ${({ buttonLength }) => `${buttonLength}px`};
   width: ${({ buttonLength }) => `${buttonLength}px`};
   min-width: ${({ buttonLength }) => `${buttonLength}px`};
-  line-height: 16px;
-  font-size: 16px;
+  line-height: ${({ fontScaler = 1 }) => `${16 * fontScaler}px`};
+  font-size: ${({ fontScaler = 1 }) => `${16 * fontScaler}px`};
   padding: 0px;
   border-radius: 50%;
 `;
 
-export const StyledPopper = styled(Popper)`
+export const ScorePopper = styled(Popper)`
+  display: flex;
+  position: absolute;
   border-radius: 50%;
-  ${({ theme }) => css`
-    z-index: ${theme.zIndex.tooltip}; // even in front of toolbars
-  `}
+  ${({ theme }) =>
+    css`
+      z-index: ${theme.zIndex.tooltip};
+    `}
 `;
 
-export const StyledBox = styled(Box)`
+interface BackdropProps {
+  isPieSelected: boolean;
+}
+
+const backdropOptions = {
+  shouldForwardProp: (props: string) => !["isPieSelected"].includes(props),
+};
+
+export const BackdropPopper = styled(Popper, backdropOptions)<BackdropProps>`
+  inset: 0;
+  ${({ theme }) => css`
+    z-index: ${theme.zIndex.tooltip};
+  `}
+  ${({ isPieSelected }) => {
+    if (isPieSelected)
+      return css`
+        background: black;
+        opacity: 0.5;
+      `;
+  }}
+`;
+
+interface CircleProps {
+  circleDiameter: number;
+}
+
+const circleOptions = {
+  shouldForwardProp: (prop: string) => !["circleDiameter"].includes(prop),
+};
+
+export const CircleDiv = styled("div", circleOptions)<CircleProps>`
+  /* Center content based on parent center*/
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
+  border-radius: 50%;
   pointer-events: none;
+
+  height: ${({ circleDiameter }) => `${circleDiameter}px`};
+  width: ${({ circleDiameter }) => `${circleDiameter}px`};
 `;

--- a/web/src/modules/topic/components/Score/ScorePie.tsx
+++ b/web/src/modules/topic/components/Score/ScorePie.tsx
@@ -7,15 +7,15 @@ import { Data } from "react-minimal-pie-chart/types/commonTypes";
 import { setScore } from "../../store/actions";
 import { ArguableType, Score, possibleScores } from "../../utils/diagram";
 import { scoreColors } from "./Score";
-import { StyledBox } from "./Score.styles";
+import { CircleDiv } from "./Score.styles";
 
 interface Props {
-  pieDiameter: number;
+  circleDiameter: number;
   arguableId: string;
   arguableType: ArguableType;
 }
 
-export const ScorePie = ({ pieDiameter, arguableId, arguableType }: Props) => {
+export const ScorePie = ({ circleDiameter, arguableId, arguableType }: Props) => {
   const theme = useTheme();
   const [hovered, setHovered] = useState<number | undefined>(undefined);
 
@@ -31,7 +31,7 @@ export const ScorePie = ({ pieDiameter, arguableId, arguableType }: Props) => {
   });
 
   return (
-    <StyledBox display="flex" width={pieDiameter} height={pieDiameter}>
+    <CircleDiv circleDiameter={circleDiameter}>
       <PieChart
         data={data}
         radius={45} // is relative to viewbox size [100, 100]
@@ -57,6 +57,6 @@ export const ScorePie = ({ pieDiameter, arguableId, arguableType }: Props) => {
         onClick={(_, dataIndex) => setScore(arguableId, arguableType, data[dataIndex].key as Score)}
         background="white"
       />
-    </StyledBox>
+    </CircleDiv>
   );
 };


### PR DESCRIPTION
Revamped score component implementation 

### Description of changes
-  Pie chart close event does not trigger for onMouseLeave & click away listener component.
- Backdrop component waits for mouse wheel / click / hover to remove pir chart.
