### PR TITLE
fix: criteria diagram correctly overlays table

### DIFF
--- a/web/src/pages/index.page.tsx
+++ b/web/src/pages/index.page.tsx
@@ -47,7 +47,8 @@ const Page = () => {
         </Box>
 
         {claimDiagramId && (
-          <Box width="100%" height="100%" position="absolute">
+          // Criteria Table has header (z-index:2); expectation: overlay the component
+          <Box width="100%" height="100%" position="absolute" zIndex="2">
             <Diagram diagramId={claimDiagramId} />
           </Box>
         )}


### PR DESCRIPTION
### Description of changes
- criteria diagram wasn't correctly overlaying the criteria table, zIndex was changed.