### PR TITLE
Resizing editable node

### DIFF
--- a/web/src/modules/topic/components/CriteriaTable/CriteriaTable.styles.tsx
+++ b/web/src/modules/topic/components/CriteriaTable/CriteriaTable.styles.tsx
@@ -8,6 +8,10 @@ export const tableStyles = css`
     height: calc(100% - ${tableToolbarHeightPx});
     .MuiTableContainer-root {
       max-height: 100%;
+      /* MUI-Paper is not sized dynamically with the total table. 
+        Because of this; directly applying the box shadow from MUI-paper onto table */
+      box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14),
+        0px 1px 5px 0px rgba(0, 0, 0, 0.12);
     }
 
     table {

--- a/web/src/modules/topic/components/Node/EditableNode.styles.tsx
+++ b/web/src/modules/topic/components/Node/EditableNode.styles.tsx
@@ -1,8 +1,8 @@
 import styled from "@emotion/styled";
 import { TextareaAutosize } from "@mui/material";
 
-export const nodeWidth = 300;
-export const nodeHeight = 84;
+export const nodeWidth = 176;
+export const nodeHeight = 66;
 
 export const YEdgeDiv = styled.div`
   display: flex;
@@ -17,8 +17,8 @@ export const NodeTypeDiv = styled.div`
 `;
 
 export const NodeTypeSpan = styled.span`
-  font-size: 16px;
-  line-height: 16px;
+  font-size: 14px;
+  line-height: 1;
   padding-left: 4px;
 `;
 
@@ -34,6 +34,7 @@ export const XEdgeDiv = styled.div`
 export const MiddleDiv = styled.div`
   display: flex;
   flex-grow: 1; // fill out remaining space with this div because it contains the textarea
+  padding: 4px 4px 8px;
 `;
 
 interface StyledTextareaProps {
@@ -48,7 +49,8 @@ export const StyledTextareaAutosize = styled(TextareaAutosize)<StyledTextareaPro
   align-self: center;
   background-color: ${({ color }) => color};
   width: 100%;
-  font-size: 20px;
+  font-size: 16px;
+  line-height: 1;
   font-family: inherit;
 `;
 

--- a/web/src/modules/topic/components/Node/EditableNode.tsx
+++ b/web/src/modules/topic/components/Node/EditableNode.tsx
@@ -13,7 +13,6 @@ import {
   NodeTypeDiv,
   NodeTypeSpan,
   StyledTextareaAutosize,
-  XEdgeDiv,
   YEdgeDiv,
 } from "./EditableNode.styles";
 
@@ -44,13 +43,12 @@ export const EditableNode = ({ node, className = "" }: { node: Node; className?:
     >
       <YEdgeDiv>
         <NodeTypeDiv>
-          <NodeIcon sx={{ width: "16px", height: "16px" }} />
+          <NodeIcon sx={{ width: "14px", height: "14px" }} />
           <NodeTypeSpan>{nodeDecoration.title}</NodeTypeSpan>
         </NodeTypeDiv>
         <NodeIndicatorGroup node={node} />
       </YEdgeDiv>
       <MiddleDiv>
-        <XEdgeDiv />
         <StyledTextareaAutosize
           ref={textAreaRef}
           color={color}
@@ -64,9 +62,7 @@ export const EditableNode = ({ node, className = "" }: { node: Node; className?:
           onChange={(event) => setNodeLabel(node.id, event.target.value)}
           className="nopan" // allow regular text input drag functionality without using reactflow's pan behavior
         />
-        <XEdgeDiv />
       </MiddleDiv>
-      <YEdgeDiv />
     </NodeDiv>
   );
 };

--- a/web/src/modules/topic/components/Surface/TopicPane.styles.tsx
+++ b/web/src/modules/topic/components/Surface/TopicPane.styles.tsx
@@ -14,6 +14,7 @@ export const NestedListItemButton = styled(StyledListItemButton)`
 export const PositionedDiv = styled.div`
   display: flex;
   position: absolute;
+  height: 100%;
 `;
 
 export const TogglePaneButton = styled(IconButton)`
@@ -40,14 +41,16 @@ const options = {
 export const StyledDrawer = styled(Drawer, options)<DrawerProps>`
   // paper uses 'transform' for transition by default, but I wasn't sure how to match that in the parent Drawer div,
   // so we're using 'width' for both instead, as done in https://mui.com/material-ui/react-drawer/#mini-variant-drawer
-  width: ${({ open }) => (open ? width : "0px")};
+  width: ${({ open }) => (open ? width : "0")};
   transition: ${({ theme }) => theme.transitions.create(["width"])};
   white-space: nowrap; // prevent wrapping during drawer transition
 
   & .MuiDrawer-paper {
     z-index: ${({ theme }) => theme.zIndex.appBar - 1};
-    width: ${({ open }) => (open ? width : "0px")};
+    width: ${({ open }) => (open ? width : "0")};
     transition: ${({ theme }) => theme.transitions.create(["width"])};
     overflow-x: hidden; // prevent scrollbar during drawer transition
+    // allows the drawer to start at parent position, as opposed to MUI's default fixed positioning starting from top of page
+    position: relative;
   }
 `;

--- a/web/src/modules/topic/components/Surface/TopicPane.tsx
+++ b/web/src/modules/topic/components/Surface/TopicPane.tsx
@@ -9,7 +9,7 @@ import {
   TableChart,
   TableView,
 } from "@mui/icons-material";
-import { Collapse, List, ListItem, ListItemIcon, ListItemText, Toolbar } from "@mui/material";
+import { Collapse, List, ListItem, ListItemIcon, ListItemText } from "@mui/material";
 import { useState } from "react";
 
 import { useNodes } from "../../store/nodeHooks";
@@ -56,9 +56,6 @@ export const TopicPane = () => {
         </TogglePaneButton>
         {/* `permanent` because `persistent` adds transitions that conflict with our styles */}
         <StyledDrawer variant="permanent" open={isTopicDrawerOpen}>
-          {/* Drawer's Paper height is full height of screen, so this toolbar exists to push the list below the two toolbars on the page */}
-          <Toolbar variant="dense" />
-          <Toolbar variant="dense" />
           <List>
             <ListItem key="1" disablePadding>
               <StyledListItemButton


### PR DESCRIPTION
Partially Closes issue #74

### Description of changes
-  Topic Pane Drawer correctly sits inside the workspace height space. It no longer over flows the top.
-  Editable node has been tidied up, extra space around text area has been removed, thus increasing the text area's available space
-  Criteria Table gained a box shadow effect on the bottom; this gives WOW factor.

### Additional context
- This should be merged into master before the REM unit changes.
