### PR TITLE
touchup: increase DOWN spacing between layers

### DIFF
--- a/web/src/modules/topic/utils/layout.ts
+++ b/web/src/modules/topic/utils/layout.ts
@@ -17,7 +17,7 @@ export const layout = async (nodes: Node[], edges: Edge[], orientation: Orientat
     // preserve order if layout is already good enough
     "elk.layered.considerModelOrder.strategy": "NODES_AND_EDGES",
     // these spacings are just what roughly seem to look good
-    "elk.layered.spacing.nodeNodeBetweenLayers": orientation === "DOWN" ? "90" : "135",
+    "elk.layered.spacing.nodeNodeBetweenLayers": orientation === "DOWN" ? "120" : "135",
     "elk.spacing.nodeNode": orientation === "DOWN" ? "20" : "50",
   };
 


### PR DESCRIPTION
nodes with three lines were too close to the next layer; the edge label was overlapping the edge arrow. this is a short-term solution until we estimate the node height based on node text https://github.com/amelioro/ameliorate/issues/62
before:
![image](https://user-images.githubusercontent.com/13872370/233667113-56a1a740-244c-44e0-ac17-2af06dd4a117.png)
after: 
![image](https://user-images.githubusercontent.com/13872370/233667284-5dafec7f-8182-4031-a420-ae5e6501b50c.png)

### Description of changes

- 

### Additional context

- 
