### PR TITLE
docs: add contributors to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,22 @@ See the [Contributor's Guide](https://github.com/amelioro/ameliorate/blob/main/C
 - [Working with the code](https://github.com/amelioro/ameliorate/blob/main/CONTRIBUTING.md#working-with-the-code)
 - [PR process](https://github.com/amelioro/ameliorate/blob/main/CONTRIBUTING.md#pr-process)
 
+## Contributors ✨
+
+Thanks go to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://allcontributors.org) specification.
+Contributions of any kind are welcome!
+
 ## License
 
 [MIT](https://github.com/amelioro/ameliorate/blob/main/LICENSE)


### PR DESCRIPTION
### Description of changes
- Add Contributions to the README.md 

### Additional context
- Example command: `@all-contributors please add @<username> for <contributions>`
- @all-contributors please add @alextilot for documentation


