### PR TITLE
Feature: Adde tooltip for view criteria table and view claims buttons

### DIFF
--- a/web/src/modules/topic/components/Indicator/ClaimIndicator.tsx
+++ b/web/src/modules/topic/components/Indicator/ClaimIndicator.tsx
@@ -1,5 +1,4 @@
 import { Article, ArticleOutlined } from "@mui/icons-material";
-import Tooltip from "@mui/material/Tooltip";
 
 import { useExplicitClaimCount } from "../../store/arguableHooks";
 import { viewOrCreateClaimDiagram } from "../../store/viewActions";
@@ -17,17 +16,14 @@ export const ClaimIndicator = ({ arguableId, arguableType }: Props) => {
   const Icon = explicitClaimCount > 0 ? Article : ArticleOutlined;
 
   return (
-
-    <Tooltip title="View claims">
-
-    <Indicator  Icon={Icon} onClick={(event) => {
+    <Indicator
+      Icon={Icon}
+      title={"View claims"}
+      onClick={(event) => {
         // prevent setting the node as selected because we're about to navigate away from this diagram
         event.stopPropagation();
         viewOrCreateClaimDiagram(arguableId, arguableType);
-      }}  />
-        
-    </Tooltip>
-
-   
+      }}
+    />
   );
 };

--- a/web/src/modules/topic/components/Indicator/ClaimIndicator.tsx
+++ b/web/src/modules/topic/components/Indicator/ClaimIndicator.tsx
@@ -1,4 +1,5 @@
 import { Article, ArticleOutlined } from "@mui/icons-material";
+import Tooltip from "@mui/material/Tooltip";
 
 import { useExplicitClaimCount } from "../../store/arguableHooks";
 import { viewOrCreateClaimDiagram } from "../../store/viewActions";
@@ -16,13 +17,17 @@ export const ClaimIndicator = ({ arguableId, arguableType }: Props) => {
   const Icon = explicitClaimCount > 0 ? Article : ArticleOutlined;
 
   return (
-    <Indicator
-      Icon={Icon}
-      onClick={(event) => {
+
+    <Tooltip title="View claims">
+
+    <Indicator  Icon={Icon} onClick={(event) => {
         // prevent setting the node as selected because we're about to navigate away from this diagram
         event.stopPropagation();
         viewOrCreateClaimDiagram(arguableId, arguableType);
-      }}
-    />
+      }}  />
+        
+    </Tooltip>
+
+   
   );
 };

--- a/web/src/modules/topic/components/Indicator/CriteriaTableIndicator.tsx
+++ b/web/src/modules/topic/components/Indicator/CriteriaTableIndicator.tsx
@@ -1,5 +1,4 @@
 import { TableChart, TableChartOutlined } from "@mui/icons-material";
-import Tooltip from "@mui/material/Tooltip";
 import React from "react";
 
 import { useNode, useNodeChildren } from "../../store/nodeHooks";
@@ -20,16 +19,14 @@ export const CriteriaTableIndicator = ({ nodeId, diagramId }: Props) => {
   if (node === null || node.type !== "problem") {
     return <></>;
   }
-  
+
   const Icon = hasCriteria ? TableChart : TableChartOutlined;
-   
-     
+
   return (
-    <Tooltip title="View criteria table">
-
-    <Indicator  Icon={Icon} onClick={() => viewCriteriaTable(nodeId)}  />
-        
-    </Tooltip>
+    <Indicator
+      Icon={Icon}
+      title={"view criteria table"}
+      onClick={() => viewCriteriaTable(nodeId)}
+    />
   );
-
 };

--- a/web/src/modules/topic/components/Indicator/CriteriaTableIndicator.tsx
+++ b/web/src/modules/topic/components/Indicator/CriteriaTableIndicator.tsx
@@ -1,4 +1,6 @@
 import { TableChart, TableChartOutlined } from "@mui/icons-material";
+import Tooltip from "@mui/material/Tooltip";
+import React from "react";
 
 import { useNode, useNodeChildren } from "../../store/nodeHooks";
 import { viewCriteriaTable } from "../../store/viewActions";
@@ -18,8 +20,16 @@ export const CriteriaTableIndicator = ({ nodeId, diagramId }: Props) => {
   if (node === null || node.type !== "problem") {
     return <></>;
   }
-
+  
   const Icon = hasCriteria ? TableChart : TableChartOutlined;
+   
+     
+  return (
+    <Tooltip title="View criteria table">
 
-  return <Indicator Icon={Icon} onClick={() => viewCriteriaTable(nodeId)} />;
+    <Indicator  Icon={Icon} onClick={() => viewCriteriaTable(nodeId)}  />
+        
+    </Tooltip>
+  );
+
 };

--- a/web/src/modules/topic/components/Indicator/CriteriaTableIndicator.tsx
+++ b/web/src/modules/topic/components/Indicator/CriteriaTableIndicator.tsx
@@ -25,7 +25,7 @@ export const CriteriaTableIndicator = ({ nodeId, diagramId }: Props) => {
   return (
     <Indicator
       Icon={Icon}
-      title={"view criteria table"}
+      title={"View criteria table"}
       onClick={() => viewCriteriaTable(nodeId)}
     />
   );

--- a/web/src/modules/topic/components/Indicator/CriteriaTableIndicator.tsx
+++ b/web/src/modules/topic/components/Indicator/CriteriaTableIndicator.tsx
@@ -1,5 +1,4 @@
 import { TableChart, TableChartOutlined } from "@mui/icons-material";
-import React from "react";
 
 import { useNode, useNodeChildren } from "../../store/nodeHooks";
 import { viewCriteriaTable } from "../../store/viewActions";

--- a/web/src/modules/topic/components/Indicator/Indicator.tsx
+++ b/web/src/modules/topic/components/Indicator/Indicator.tsx
@@ -1,55 +1,56 @@
-import { MouseEventHandler, forwardRef } from "react";
+import Tooltip from "@mui/material/Tooltip";
+import { MouseEventHandler } from "react";
 
 import { MuiIcon } from "../../utils/node";
 import { StyledButton } from "./Indicator.styles";
 
 interface IndicatorProps {
   Icon: MuiIcon;
+  title: string;
   onClick?: MouseEventHandler<HTMLButtonElement>;
 }
 
-export const Indicator = forwardRef<HTMLButtonElement, IndicatorProps>(
-  function Indicator(props, ref){
-    const { Icon, onClick } = props;
-  
-    return(
-      // black outline looks a bit weird on the table icon, not sure how to easily fix though
-      // also hover color diff for black is impossible to see, so a custom hover is added to darken the gray instead
-      <StyledButton {...props} variant="contained" color="neutralContrast" onClick={onClick} disabled={!onClick} ref={ref}>
-         <Icon color="neutral" />
+export const Indicator = ({ Icon, title, onClick }: IndicatorProps) => {
+  return (
+    // black outline looks a bit weird on the table icon, not sure how to easily fix though
+    // also hover color diff for black is impossible to see, so a custom hover is added to darken the gray instead
+    <Tooltip title={title}>
+      <StyledButton
+        variant="contained"
+        color="neutralContrast"
+        onClick={onClick}
+        disabled={!onClick}
+      >
+        <Icon color="neutral" />
       </StyledButton>
+    </Tooltip>
 
-      // hard to tell which variant & color combo works best
-      // want to use neutral generally, but not stand out too much (contained with neutral color stands out because of heavy black to fill in icon)
-      // and have a clearly visible hover
-      // below are the variants that have been considered:
+    // hard to tell which variant & color combo works best
+    // want to use neutral generally, but not stand out too much (contained with neutral color stands out because of heavy black to fill in icon)
+    // and have a clearly visible hover
+    // below are the variants that have been considered:
 
-      // passing nodeType color doesn't work for edges
-      // <StyledButton variant="contained" color={nodeType} onClick={onClick} disabled={!onClick}>
-      //   <Icon color="neutral" />
-      // </StyledButton>
+    // passing nodeType color doesn't work for edges
+    // <StyledButton variant="contained" color={nodeType} onClick={onClick} disabled={!onClick}>
+    //   <Icon color="neutral" />
+    // </StyledButton>
 
-      // text variant hover doesn't do anything?
-      // <StyledButton variant="text" color={nodeType} onClick={onClick} disabled={!onClick}>
-      //   <Icon color="neutral" />
-      // </StyledButton>
+    // text variant hover doesn't do anything?
+    // <StyledButton variant="text" color={nodeType} onClick={onClick} disabled={!onClick}>
+    //   <Icon color="neutral" />
+    // </StyledButton>
 
-      // outlined variant adds border that feels awkward (halfway to being a shadow) and hover only increases border, so it's hard to see
-      // <StyledButton variant="outlined" color="neutral" onClick={onClick} disabled={!onClick}>
-      //   <Icon color="neutral" />
-      // </StyledButton>
+    // outlined variant adds border that feels awkward (halfway to being a shadow) and hover only increases border, so it's hard to see
+    // <StyledButton variant="outlined" color="neutral" onClick={onClick} disabled={!onClick}>
+    //   <Icon color="neutral" />
+    // </StyledButton>
 
-      // this follows the MUI example, but I can't actually see the hover at all
-      // <StyledIconButton onClick={onClick} disabled={!onClick}>
-      //   <Icon color="neutralContrast" />
-      // </StyledIconButton>
+    // this follows the MUI example, but I can't actually see the hover at all
+    // <StyledIconButton onClick={onClick} disabled={!onClick}>
+    //   <Icon color="neutralContrast" />
+    // </StyledIconButton>
 
-      // no hover effect (this isn't even a button)
-      // <Icon />
-      
-    )
-
-  }
-
-);
-  
+    // no hover effect (this isn't even a button)
+    // <Icon />
+  );
+};

--- a/web/src/modules/topic/components/Indicator/Indicator.tsx
+++ b/web/src/modules/topic/components/Indicator/Indicator.tsx
@@ -1,4 +1,4 @@
-import { MouseEventHandler } from "react";
+import { MouseEventHandler, forwardRef } from "react";
 
 import { MuiIcon } from "../../utils/node";
 import { StyledButton } from "./Indicator.styles";
@@ -8,40 +8,48 @@ interface IndicatorProps {
   onClick?: MouseEventHandler<HTMLButtonElement>;
 }
 
-export const Indicator = ({ Icon, onClick }: IndicatorProps) => {
-  return (
-    // black outline looks a bit weird on the table icon, not sure how to easily fix though
-    // also hover color diff for black is impossible to see, so a custom hover is added to darken the gray instead
-    <StyledButton variant="contained" color="neutralContrast" onClick={onClick} disabled={!onClick}>
-      <Icon color="neutral" />
-    </StyledButton>
+export const Indicator = forwardRef<HTMLButtonElement, IndicatorProps>(
+  function Indicator(props, ref){
+    const { Icon, onClick } = props;
+  
+    return(
+      // black outline looks a bit weird on the table icon, not sure how to easily fix though
+      // also hover color diff for black is impossible to see, so a custom hover is added to darken the gray instead
+      <StyledButton {...props} variant="contained" color="neutralContrast" onClick={onClick} disabled={!onClick} ref={ref}>
+         <Icon color="neutral" />
+      </StyledButton>
 
-    // hard to tell which variant & color combo works best
-    // want to use neutral generally, but not stand out too much (contained with neutral color stands out because of heavy black to fill in icon)
-    // and have a clearly visible hover
-    // below are the variants that have been considered:
+      // hard to tell which variant & color combo works best
+      // want to use neutral generally, but not stand out too much (contained with neutral color stands out because of heavy black to fill in icon)
+      // and have a clearly visible hover
+      // below are the variants that have been considered:
 
-    // passing nodeType color doesn't work for edges
-    // <StyledButton variant="contained" color={nodeType} onClick={onClick} disabled={!onClick}>
-    //   <Icon color="neutral" />
-    // </StyledButton>
+      // passing nodeType color doesn't work for edges
+      // <StyledButton variant="contained" color={nodeType} onClick={onClick} disabled={!onClick}>
+      //   <Icon color="neutral" />
+      // </StyledButton>
 
-    // text variant hover doesn't do anything?
-    // <StyledButton variant="text" color={nodeType} onClick={onClick} disabled={!onClick}>
-    //   <Icon color="neutral" />
-    // </StyledButton>
+      // text variant hover doesn't do anything?
+      // <StyledButton variant="text" color={nodeType} onClick={onClick} disabled={!onClick}>
+      //   <Icon color="neutral" />
+      // </StyledButton>
 
-    // outlined variant adds border that feels awkward (halfway to being a shadow) and hover only increases border, so it's hard to see
-    // <StyledButton variant="outlined" color="neutral" onClick={onClick} disabled={!onClick}>
-    //   <Icon color="neutral" />
-    // </StyledButton>
+      // outlined variant adds border that feels awkward (halfway to being a shadow) and hover only increases border, so it's hard to see
+      // <StyledButton variant="outlined" color="neutral" onClick={onClick} disabled={!onClick}>
+      //   <Icon color="neutral" />
+      // </StyledButton>
 
-    // this follows the MUI example, but I can't actually see the hover at all
-    // <StyledIconButton onClick={onClick} disabled={!onClick}>
-    //   <Icon color="neutralContrast" />
-    // </StyledIconButton>
+      // this follows the MUI example, but I can't actually see the hover at all
+      // <StyledIconButton onClick={onClick} disabled={!onClick}>
+      //   <Icon color="neutralContrast" />
+      // </StyledIconButton>
 
-    // no hover effect (this isn't even a button)
-    // <Icon />
-  );
-};
+      // no hover effect (this isn't even a button)
+      // <Icon />
+      
+    )
+
+  }
+
+);
+  


### PR DESCRIPTION
Closes #147 

### Description of changes
The toolbar buttons and add node buttons already have tooltips, but the node indicator buttons do not yet. We should add these.
- 

### Additional context
![image](https://github.com/amelioro/ameliorate/assets/55488549/c1959474-ef62-4f90-8e9d-740c8a8ee264)
![image](https://github.com/amelioro/ameliorate/assets/55488549/82ccdf42-32ae-4263-8c21-5240113128ac)


- 
