### PR TITLE
chore: disable renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -9,6 +9,7 @@
   ],
   ignorePaths: ["mock-auth/**"],
   labels: ["dependencies"],
-  schedule: "before 4am on Saturday",
+  // schedule: "before 4am on Saturday",
+  schedule: "never", // enable once all initial upgrades are done
   timezone: "America/Chicago",
 }


### PR DESCRIPTION
get through all the upgrades in the renovate dashboard, make sure there good, before having a ton of PRs autocreated