### PR TITLE
chore(renovate): separate nextjs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,12 +4,18 @@
     ":enableVulnerabilityAlertsWithLabel(security)",
     ":pinAllExceptPeerDependencies", // recommended by config:js-app; idk seems nice to see update diffs in package.json instead of lockfile
     "config:best-practices",
-    "group:allNonMajor",
-    "npm:unpublishSafe",
+    "group:allNonMajor", // majors separate because they might come with breaking changes that need addressing
+    "npm:unpublishSafe", // wait three days before upgrading; could consider using 30 days to reduce risk of upgrading to something with issues
   ],
-  ignorePaths: ["mock-auth/**"],
+  ignorePaths: ["mock-auth/**"], // don't care about keeping our local auth server up-to-date
   labels: ["dependencies"],
   // schedule: "before 4am on Saturday",
-  schedule: "never", // enable once all initial upgrades are done
+  schedule: "* 0 31 12 ?", // disable until all initial upgrades are done
   timezone: "America/Chicago",
+  packageRules: [
+    {
+      groupName: "next", // separate group because nextjs 13.5 doesn't work with netlify, and they recommend (https://answers.netlify.com/t/runtime-importmoduleerror-error-cannot-find-module-styled-jsx-style/102375/10) staying on 13.4 until they can fix it
+      matchPackagePatterns: ["next"],
+    },
+  ],
 }


### PR DESCRIPTION
separate group because nextjs 13.5 doesn't work with netlify, and they recommend (https://answers.netlify.com/t/runtime-importmoduleerror-error-cannot-find-module-styled-jsx-style/102375/10) staying on 13.4 until they can fix it