### PR TITLE
Minor setup script improvements - add shebang and -e

### DIFF
--- a/scripts/setupLocal.sh
+++ b/scripts/setupLocal.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
 npm install # install dependencies
 npx husky install # activate commit hooks
 cp .env.example .env # set up env variables


### PR DESCRIPTION
The first time I ran the setup script, it errored on `npm run db:start`, but it continued to run all the commands after that as well, which made it hard at the end to see what failed. `-e` makes it so that it stops execution if the script encounters an error. the shebang is optional but nice to have (and `shellcheck` reports not having it as an error), but not technically required as you call the script with `bash ...`

### Description of changes

- minor improvements to setup script

### Additional context

-
