### PR TITLE
fix: can't interact with diagram after switching

### DIFF
--- a/src/web/common/event.ts
+++ b/src/web/common/event.ts
@@ -1,6 +1,7 @@
 import { createNanoEvents } from "nanoevents";
 
 import { Node } from "../topic/utils/graph";
+import { resetNavigation } from "../view/navigateStore";
 
 interface Events {
   addNode: (node: Node) => void;
@@ -9,3 +10,8 @@ interface Events {
 }
 
 export const emitter = createNanoEvents<Events>();
+
+// could go elsewhere but don't want to put into Diagram components because they usually aren't rendered before loading
+emitter.on("loadedTopicData", () => {
+  resetNavigation();
+});

--- a/src/web/view/navigateStore.ts
+++ b/src/web/view/navigateStore.ts
@@ -145,3 +145,8 @@ export const goBack = () => {
 export const goForward = () => {
   useNavigateStore.temporal.getState().redo();
 };
+
+export const resetNavigation = () => {
+  useNavigateStore.setState(initialState);
+  useNavigateStore.temporal.getState().clear();
+};


### PR DESCRIPTION
previously, if viewing a claim tree or criteria table, then switching to another topic (or resetting playground), the navigation store would still assume the topic diagram is in the background, so it wouldn't be interactive until refreshing page.

solution is just to reset navigation store on topic load (whose initial state has topic diagram in front).
