### PR TITLE
touchup: allow disabling layout partitioning

### DIFF
--- a/src/web/topic/components/Surface/MoreActionsDrawer.tsx
+++ b/src/web/topic/components/Surface/MoreActionsDrawer.tsx
@@ -4,6 +4,7 @@ import {
   Close,
   Download,
   Engineering,
+  Layers,
   Route,
   Upload,
 } from "@mui/icons-material";
@@ -22,8 +23,10 @@ import { StorageValue } from "zustand/middleware";
 
 import { errorWithData } from "../../../../common/errorHandling";
 import {
+  toggleForceNodesIntoLayers,
   toggleShowImpliedEdges,
   toggleUnrestrictedEditing,
+  useForceNodesIntoLayers,
   useShowImpliedEdges,
   useUnrestrictedEditing,
 } from "../../../view/actionConfigStore";
@@ -89,6 +92,7 @@ export const MoreActionsDrawer = ({
   const isTableActive = activeView === "criteriaTable";
   const showImpliedEdges = useShowImpliedEdges();
   const unrestrictedEditing = useUnrestrictedEditing();
+  const forceNodesIntoLayers = useForceNodesIntoLayers();
 
   return (
     <Drawer
@@ -170,6 +174,18 @@ export const MoreActionsDrawer = ({
                 sx={{ borderRadius: "50%", border: "0" }}
               >
                 <Route />
+              </ToggleButton>
+              <ToggleButton
+                value={forceNodesIntoLayers}
+                title="Force nodes into layers"
+                aria-label="Force nodes into layers"
+                color="secondary"
+                size="small"
+                selected={forceNodesIntoLayers}
+                onClick={() => toggleForceNodesIntoLayers(!forceNodesIntoLayers)}
+                sx={{ borderRadius: "50%", border: "0" }}
+              >
+                <Layers />
               </ToggleButton>
             </>
           )}

--- a/src/web/topic/hooks/diagramHooks.ts
+++ b/src/web/topic/hooks/diagramHooks.ts
@@ -1,13 +1,19 @@
 import { useState } from "react";
 
+import { useForceNodesIntoLayers } from "../../view/actionConfigStore";
 import { useSelectedGraphPart } from "../../view/navigateStore";
 import { Diagram, PositionedDiagram, PositionedNode } from "../utils/diagram";
 import { NodePosition, layout } from "../utils/layout";
 
 // re-renders when diagram changes, but only re-layouts if graph parts are added or removed
 export const useLayoutedDiagram = (diagram: Diagram) => {
-  const diagramHash = [...diagram.nodes, ...diagram.edges].map((graphPart) => graphPart.id).join();
+  const forceNodesIntoLayers = useForceNodesIntoLayers();
+  const diagramHash = [...diagram.nodes, ...diagram.edges]
+    .map((graphPart) => graphPart.id)
+    .concat(String(forceNodesIntoLayers)) // re-layout if this changes
+    .join();
   const [prevDiagramHash, setPrevDiagramHash] = useState<string | null>(null);
+
   const [layoutedNodes, setLayoutedNodes] = useState<NodePosition[] | null>(null);
   const [hasNewLayout, setHasNewLayout] = useState<boolean>(false);
 
@@ -17,7 +23,12 @@ export const useLayoutedDiagram = (diagram: Diagram) => {
     setPrevDiagramHash(diagramHash);
 
     const layoutDiagram = async () => {
-      const newLayoutedNodes = await layout(diagram.nodes, diagram.edges, diagram.orientation);
+      const newLayoutedNodes = await layout(
+        diagram.nodes,
+        diagram.edges,
+        diagram.orientation,
+        forceNodesIntoLayers
+      );
       setLayoutedNodes(newLayoutedNodes);
       setHasNewLayout(true);
     };

--- a/src/web/topic/utils/layout.ts
+++ b/src/web/topic/utils/layout.ts
@@ -82,7 +82,8 @@ export interface NodePosition {
 export const layout = async (
   nodes: Node[],
   edges: Edge[],
-  orientation: Orientation
+  orientation: Orientation,
+  partition: boolean
 ): Promise<NodePosition[]> => {
   // see support layout options at https://www.eclipse.org/elk/reference/algorithms/org-eclipse-elk-layered.html
   const layoutOptions: LayoutOptions = {
@@ -100,7 +101,7 @@ export const layout = async (
     "elk.layered.spacing.nodeNodeBetweenLayers": orientation === "DOWN" ? "130" : "220",
     "elk.spacing.nodeNode": orientation === "DOWN" ? "20" : "50",
     // allow nodes to be partitioned into layers by type
-    "elk.partitioning.activate": "true",
+    "elk.partitioning.activate": partition ? "true" : "false",
     // ensure node islands don't overlap (needed for when node has 3 rows of text)
     "elk.spacing.componentComponent": "30", // default is 20
   };

--- a/src/web/view/actionConfigStore.ts
+++ b/src/web/view/actionConfigStore.ts
@@ -4,11 +4,13 @@ import { persist } from "zustand/middleware";
 interface ActionConfigStoreState {
   showImpliedEdges: boolean;
   unrestrictedEditing: boolean;
+  forceNodesIntoLayers: boolean;
 }
 
 const initialState: ActionConfigStoreState = {
   showImpliedEdges: true,
   unrestrictedEditing: false,
+  forceNodesIntoLayers: true,
 };
 
 const useActionConfigStore = create<ActionConfigStoreState>()(
@@ -26,6 +28,10 @@ export const useUnrestrictedEditing = () => {
   return useActionConfigStore((state) => state.unrestrictedEditing);
 };
 
+export const useForceNodesIntoLayers = () => {
+  return useActionConfigStore((state) => state.forceNodesIntoLayers);
+};
+
 // actions
 export const toggleShowImpliedEdges = (show: boolean) => {
   useActionConfigStore.setState({ showImpliedEdges: show });
@@ -33,6 +39,10 @@ export const toggleShowImpliedEdges = (show: boolean) => {
 
 export const toggleUnrestrictedEditing = (unrestricted: boolean) => {
   useActionConfigStore.setState({ unrestrictedEditing: unrestricted });
+};
+
+export const toggleForceNodesIntoLayers = (force: boolean) => {
+  useActionConfigStore.setState({ forceNodesIntoLayers: force });
 };
 
 // utils


### PR DESCRIPTION
### Description of changes

- some layouts are really complex and error or are visually bad to layout with partitioning on

### Additional context

-
