### PR TITLE
feat: add node types filter

### DIFF
--- a/src/common/node.ts
+++ b/src/common/node.ts
@@ -35,7 +35,7 @@ export const nodeTypes = [
   "custom",
 ] as const;
 
-const zNodeTypes = z.enum(nodeTypes);
+export const zNodeTypes = z.enum(nodeTypes);
 
 export type NodeType = z.infer<typeof zNodeTypes>;
 

--- a/src/web/topic/store/utils.ts
+++ b/src/web/topic/store/utils.ts
@@ -1,7 +1,7 @@
-import { claimRelationNames, exploreRelationNames, topicRelationNames } from "../../../common/edge";
+import { claimRelationNames, topicRelationNames } from "../../../common/edge";
 import { claimNodeTypes, exploreNodeTypes, topicNodeTypes } from "../../../common/node";
 import { Diagram, getDiagramTitle } from "../utils/diagram";
-import { Graph } from "../utils/graph";
+import { Graph, getRelevantEdges } from "../utils/graph";
 import { PlaygroundTopic, StoreTopic, TopicStoreState } from "./store";
 
 export const getTopicTitle = (state: TopicStoreState) => {
@@ -19,13 +19,8 @@ export const getTopicDiagram = (topicGraph: Graph): Diagram => {
 };
 
 export const getExploreDiagram = (topicGraph: Graph): Diagram => {
-  const edges = topicGraph.edges.filter((edge) => exploreRelationNames.includes(edge.label));
-  const nodes = topicGraph.nodes.filter(
-    (node) =>
-      exploreNodeTypes.includes(node.type) ||
-      // show contextual nodes (e.g. problem node that a question points at)
-      edges.some((edge) => edge.source === node.id || edge.target === node.id)
-  );
+  const nodes = topicGraph.nodes.filter((node) => exploreNodeTypes.includes(node.type));
+  const edges = getRelevantEdges(nodes, topicGraph);
 
   return {
     nodes,

--- a/src/web/topic/utils/graph.ts
+++ b/src/web/topic/utils/graph.ts
@@ -223,3 +223,17 @@ export const getRelevantEdges = (nodes: Node[], graph: Graph) => {
     (edge) => nodeIds.includes(edge.target) && nodeIds.includes(edge.source)
   );
 };
+
+export const getContextualNodes = (nodes: Node[], graph: Graph) => {
+  const nodeIds = nodes.map((node) => node.id);
+
+  return graph.nodes.filter(
+    (node) =>
+      !nodeIds.includes(node.id) &&
+      graph.edges.some(
+        (edge) =>
+          (edge.source === node.id && nodeIds.includes(edge.target)) ||
+          (edge.target === node.id && nodeIds.includes(edge.source))
+      )
+  );
+};

--- a/src/web/view/components/FilterOptions/FilterOptions.tsx
+++ b/src/web/view/components/FilterOptions/FilterOptions.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { z } from "zod";
 
+import { NodeType, exploreNodeTypes, topicNodeTypes } from "../../../../common/node";
 import {
   useCriteria,
   useProblems,
@@ -23,6 +24,7 @@ type ValidatedFormData = z.infer<typeof filterOptionsSchema>;
 
 // how to build this based on schemas? .merge doesn't work because `type` is overridden by the last schema's literal
 interface FormData {
+  nodeTypes: NodeType[];
   type: FilterTypes;
   centralProblemId?: string;
   detail: "all" | "connectedToCriteria" | "none";
@@ -67,6 +69,7 @@ export const FilterOptions = ({ activeView }: Props) => {
   } = useForm<FormData>({
     resolver: zodResolver(filterOptionsSchema),
     defaultValues: {
+      nodeTypes: filterOptions.nodeTypes,
       type: filterOptions.type,
       centralProblemId: getProp<string | undefined>(
         filterOptions,
@@ -89,6 +92,7 @@ export const FilterOptions = ({ activeView }: Props) => {
     },
   });
 
+  const filterNodeTypes = activeView === "topicDiagram" ? topicNodeTypes : exploreNodeTypes;
   const filterTypes = activeView === "topicDiagram" ? topicFilterTypes : exploreFilterTypes;
 
   const type = watch("type");
@@ -147,6 +151,33 @@ export const FilterOptions = ({ activeView }: Props) => {
   return (
     <form style={{ padding: "8px" }}>
       <Stack spacing={1.5}>
+        <Controller
+          control={control}
+          name="nodeTypes"
+          render={({ field }) => (
+            <Autocomplete
+              {...field}
+              multiple
+              limitTags={2} // one line's worth
+              disableCloseOnSelect
+              options={filterNodeTypes}
+              onChange={(_event, values) => {
+                field.onChange([...values]);
+                submit();
+              }}
+              disableClearable
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  label="Node Types"
+                  error={!!errors.nodeTypes}
+                  helperText={errors.nodeTypes?.message}
+                />
+              )}
+              size="small"
+            />
+          )}
+        />
         {/* GitHub code search found this example implementing Mui Autocomplete with react-hook-form https://github.com/GeoWerkstatt/ews-boda/blob/79cb1484db53170aace5a4b01ed1f9c56269f7c4/src/ClientApp/src/components/SchichtForm.js#L126-L153 */}
         <Controller
           control={control}
@@ -160,7 +191,7 @@ export const FilterOptions = ({ activeView }: Props) => {
                 submit(); // how otherwise to ensure submit happens on change of any form input?
               }}
               disableClearable
-              renderInput={(params) => <TextField {...params} label="Filter" />}
+              renderInput={(params) => <TextField {...params} label="Standard Filter" />}
               size="small"
             />
           )}

--- a/src/web/view/navigateStore.ts
+++ b/src/web/view/navigateStore.ts
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { createWithEqualityFn } from "zustand/traditional";
 
 import { throwError } from "../../common/errorHandling";
+import { exploreNodeTypes, topicNodeTypes } from "../../common/node";
 import { emitter } from "../common/event";
 import { useGraphPart } from "../topic/store/graphPartHooks";
 import { useNode } from "../topic/store/nodeHooks";
@@ -37,9 +38,11 @@ const initialState: NavigateStoreState = {
 
   filterOptions: {
     topicDiagram: {
+      nodeTypes: topicNodeTypes,
       type: "none",
     },
     exploreDiagram: {
+      nodeTypes: exploreNodeTypes,
       type: "none",
     },
   },


### PR DESCRIPTION
required moving context nodes out of explore diagram and into the diagram modification, so that they don't get filtered out by node types (wanted to keep node types select limited to types from the current diagram).

this seems preferable anyway so that we can just add a showContextNodes general filter option, to e.g. show questions in the topic diagram.

### Description of changes

-

### Additional context

-
