### PR TITLE
touchup: layout better by node type in layer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@trpc/next": "10.34.0",
         "@trpc/react-query": "10.34.0",
         "@trpc/server": "10.34.0",
-        "elkjs": "0.8.2",
+        "elkjs": "0.9.2",
         "framer-motion": "^10.16.5",
         "html-to-image": "^1.11.11",
         "immer": "10.0.2",
@@ -14831,9 +14831,9 @@
       "dev": true
     },
     "node_modules/elkjs": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.8.2.tgz",
-      "integrity": "sha512-L6uRgvZTH+4OF5NE/MBbzQx/WYpru1xCBE9respNj6qznEewGUIfhzmm7horWWxbNO2M0WckQypGctR8lH79xQ=="
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.9.2.tgz",
+      "integrity": "sha512-2Y/RaA1pdgSHpY0YG4TYuYCD2wh97CRvu22eLG3Kz0pgQ/6KbIFTxsTnDc4MH/6hFlg2L/9qXrDMG0nMjP63iw=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -39719,9 +39719,9 @@
       "dev": true
     },
     "elkjs": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.8.2.tgz",
-      "integrity": "sha512-L6uRgvZTH+4OF5NE/MBbzQx/WYpru1xCBE9respNj6qznEewGUIfhzmm7horWWxbNO2M0WckQypGctR8lH79xQ=="
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.9.2.tgz",
+      "integrity": "sha512-2Y/RaA1pdgSHpY0YG4TYuYCD2wh97CRvu22eLG3Kz0pgQ/6KbIFTxsTnDc4MH/6hFlg2L/9qXrDMG0nMjP63iw=="
     },
     "emoji-regex": {
       "version": "9.2.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@trpc/next": "10.34.0",
     "@trpc/react-query": "10.34.0",
     "@trpc/server": "10.34.0",
-    "elkjs": "0.8.2",
+    "elkjs": "0.9.2",
     "framer-motion": "^10.16.5",
     "html-to-image": "^1.11.11",
     "immer": "10.0.2",


### PR DESCRIPTION
also prefer laying out children closer to their parents.
also upgrade elkjs to 0.9.2 to allow using PREFER_NODES.

all tested layouts seem the same or improved. some layouts do not keep nodes grouped by type within layer, but these appear to significantly improve space usage.

### Description of changes

-

### Additional context

- see [layout-decision topic](https://ameliorate.app/keyserj/layout-decision) for some reasonings, mainly for not sorting by edges, not using elkjs's `position`
- these topics were used to test layout differences:
[regular_appropriation_bill (6).json](https://github.com/amelioro/ameliorate/files/14513786/regular_appropriation_bill.6.json)
[us_political_system_issues.json](https://github.com/amelioro/ameliorate/files/14513787/us_political_system_issues.json)
[layout_test_random.json](https://github.com/amelioro/ameliorate/files/14513788/layout_test_random.json)
[sugar.json](https://github.com/amelioro/ameliorate/files/14513789/sugar.json)
[new_node (11).json](https://github.com/amelioro/ameliorate/files/14513790/new_node.11.json)
[unsustainable_electricity_generation (6).json](https://github.com/amelioro/ameliorate/files/14513791/unsustainable_electricity_generation.6.json)
[cars_going_too_fast_in_my_neighborhood (2).json](https://github.com/amelioro/ameliorate/files/14513792/cars_going_too_fast_in_my_neighborhood.2.json)
[rediscover_tuner_tech_and_master_the_seasons.json](https://github.com/amelioro/ameliorate/files/14513793/rediscover_tuner_tech_and_master_the_seasons.json)
