### PR TITLE
touchup: default problem filter to all details

### DIFF
--- a/src/web/view/components/FilterOptions/FilterOptions.tsx
+++ b/src/web/view/components/FilterOptions/FilterOptions.tsx
@@ -97,6 +97,8 @@ export const FilterOptions = ({ activeDiagram }: Props) => {
         "causes",
         "effects",
         "subproblems",
+        "criteria",
+        "solutions",
       ]),
       centralSolutionId: getProp<string | undefined>(
         filterOptions,


### PR DESCRIPTION
with a large diagram with multiple problems, this seems preferrable, with a small diagram with only one problem there's probably preference for defaulting to not show criteria/solutions, but it doesn't seem worth covering this case.

also, the general node type filter can remove solutions/criteria if users prefer that default.

### Description of changes

-

### Additional context

-
