### PR TITLE
Node colors corner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@hookform/resolvers": "3.1.1",
         "@mui/icons-material": "5.14.8",
         "@mui/lab": "5.0.0-alpha.149",
-        "@mui/material": "5.14.8",
+        "@mui/material": "5.15.15",
         "@next/bundle-analyzer": "14.2.2",
         "@prisma/client": "5.1.0",
         "@tanstack/react-query": "4.29.23",
@@ -2102,9 +2102,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
-      "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
+      "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -3458,28 +3458,28 @@
       "dev": true
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.4.1.tgz",
-      "integrity": "sha512-jk3WqquEJRlcyu7997NtR5PibI+y5bi+LS3hPmguVClypenMsCY3CBa3LAQnozRCtCrYWSEtAdiskpamuJRFOQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
       "dependencies": {
-        "@floating-ui/utils": "^0.1.1"
+        "@floating-ui/utils": "^0.2.1"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.2.tgz",
-      "integrity": "sha512-6ArmenS6qJEWmwzczWyhvrXRdI/rI78poBcW0h/456+onlabit+2G+QxHx5xTOX60NBJQXjsCLFbW2CmsXpUog==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+      "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
       "dependencies": {
-        "@floating-ui/core": "^1.4.1",
-        "@floating-ui/utils": "^0.1.1"
+        "@floating-ui/core": "^1.0.0",
+        "@floating-ui/utils": "^0.2.0"
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.2.tgz",
-      "integrity": "sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
+      "integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
       "dependencies": {
-        "@floating-ui/dom": "^1.5.1"
+        "@floating-ui/dom": "^1.6.1"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -3487,9 +3487,9 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.2.tgz",
-      "integrity": "sha512-ou3elfqG/hZsbmF4bxeJhPHIf3G2pm0ujc39hYEZrfVqt7Vk/Zji6CXc3W0pmYM8BW1g40U+akTl9DKZhFhInQ=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
     },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
@@ -3972,26 +3972,24 @@
       }
     },
     "node_modules/@mui/base": {
-      "version": "5.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.14.tgz",
-      "integrity": "sha512-Je/9JzzYObsuLCIClgE8XvXNFb55IEz8n2NtStUfASfNiVrwiR8t6VVFFuhofehkyTIN34tq1qbBaOjCnOovBw==",
+      "version": "5.0.0-beta.40",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.40.tgz",
+      "integrity": "sha512-I/lGHztkCzvwlXpjD2+SNmvNQvB4227xBXhISPjEaJUXGImOQ9f3D2Yj/T3KasSI/h0MLWy74X0J6clhPmsRbQ==",
       "dependencies": {
-        "@babel/runtime": "^7.22.10",
-        "@emotion/is-prop-valid": "^1.2.1",
-        "@floating-ui/react-dom": "^2.0.1",
-        "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.14.8",
+        "@babel/runtime": "^7.23.9",
+        "@floating-ui/react-dom": "^2.0.8",
+        "@mui/types": "^7.2.14",
+        "@mui/utils": "^5.15.14",
         "@popperjs/core": "^2.11.8",
-        "clsx": "^2.0.0",
-        "prop-types": "^15.8.1",
-        "react-is": "^18.2.0"
+        "clsx": "^2.1.0",
+        "prop-types": "^15.8.1"
       },
       "engines": {
         "node": ">=12.0.0"
       },
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0",
@@ -4005,25 +4003,20 @@
       }
     },
     "node_modules/@mui/base/node_modules/clsx": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
-      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "engines": {
         "node": ">=6"
       }
     },
-    "node_modules/@mui/base/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
-    },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "5.14.8",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.14.8.tgz",
-      "integrity": "sha512-8V7ZOC/lKkM03TRHqaThQFIq6bWPnj7L/ZWPh0ymldYFFyh8XdF0ywTgafsofDNYT4StlNknbaTjVHBma3SNjQ==",
+      "version": "5.15.15",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.15.15.tgz",
+      "integrity": "sha512-aXnw29OWQ6I5A47iuWEI6qSSUfH6G/aCsW9KmW3LiFqr7uXZBK4Ks+z8G+qeIub8k0T5CMqlT2q0L+ZJTMrqpg==",
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
       }
     },
     "node_modules/@mui/icons-material": {
@@ -4132,19 +4125,19 @@
       }
     },
     "node_modules/@mui/material": {
-      "version": "5.14.8",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.14.8.tgz",
-      "integrity": "sha512-fqvDGGF1pXwOOL/f0Gw+KHo/67hasRpf2ApTIJkbuONOk9AUb2jnYMEqCWmL2sUcbbE3ShMbHl8N7HPSsRv1/A==",
+      "version": "5.15.15",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.15.15.tgz",
+      "integrity": "sha512-3zvWayJ+E1kzoIsvwyEvkTUKVKt1AjchFFns+JtluHCuvxgKcLSRJTADw37k0doaRtVAsyh8bz9Afqzv+KYrIA==",
       "dependencies": {
-        "@babel/runtime": "^7.22.10",
-        "@mui/base": "5.0.0-beta.14",
-        "@mui/core-downloads-tracker": "^5.14.8",
-        "@mui/system": "^5.14.8",
-        "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.14.8",
-        "@types/react-transition-group": "^4.4.6",
-        "clsx": "^2.0.0",
-        "csstype": "^3.1.2",
+        "@babel/runtime": "^7.23.9",
+        "@mui/base": "5.0.0-beta.40",
+        "@mui/core-downloads-tracker": "^5.15.15",
+        "@mui/system": "^5.15.15",
+        "@mui/types": "^7.2.14",
+        "@mui/utils": "^5.15.14",
+        "@types/react-transition-group": "^4.4.10",
+        "clsx": "^2.1.0",
+        "csstype": "^3.1.3",
         "prop-types": "^15.8.1",
         "react-is": "^18.2.0",
         "react-transition-group": "^4.4.5"
@@ -4154,7 +4147,7 @@
       },
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
@@ -4176,9 +4169,9 @@
       }
     },
     "node_modules/@mui/material/node_modules/clsx": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
-      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "engines": {
         "node": ">=6"
       }
@@ -4189,12 +4182,12 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/@mui/private-theming": {
-      "version": "5.14.14",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.14.14.tgz",
-      "integrity": "sha512-n77au3CQj9uu16hak2Y+rvbGSBaJKxziG/gEbOLVGrAuqZ+ycVSkorCfN6Y/4XgYOpG/xvmuiY3JwhAEOzY3iA==",
+      "version": "5.15.14",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.15.14.tgz",
+      "integrity": "sha512-UH0EiZckOWcxiXLX3Jbb0K7rC8mxTr9L9l6QhOZxYc4r8FHUkefltV9VDGLrzCaWh30SQiJvAEd7djX3XXY6Xw==",
       "dependencies": {
-        "@babel/runtime": "^7.23.1",
-        "@mui/utils": "^5.14.13",
+        "@babel/runtime": "^7.23.9",
+        "@mui/utils": "^5.15.14",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -4202,7 +4195,7 @@
       },
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0",
@@ -4215,13 +4208,13 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "5.14.14",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.14.14.tgz",
-      "integrity": "sha512-sF3DS2PVG+cFWvkVHQQaGFpL1h6gSwOW3L91pdxPLQDHDZ5mZ/X0SlXU5XA+WjypoysG4urdAQC7CH/BRvUiqg==",
+      "version": "5.15.14",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.15.14.tgz",
+      "integrity": "sha512-RILkuVD8gY6PvjZjqnWhz8fu68dVkqhM5+jYWfB5yhlSQKg+2rHkmEwm75XIeAqI3qwOndK6zELK5H6Zxn4NHw==",
       "dependencies": {
-        "@babel/runtime": "^7.23.1",
+        "@babel/runtime": "^7.23.9",
         "@emotion/cache": "^11.11.0",
-        "csstype": "^3.1.2",
+        "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -4229,7 +4222,7 @@
       },
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
         "@emotion/react": "^11.4.1",
@@ -4246,17 +4239,17 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "5.14.14",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.14.14.tgz",
-      "integrity": "sha512-y4InFmCgGGWXnz+iK4jRTWVikY0HgYnABjz4wgiUgEa2W1H8M4ow+27BegExUWPkj4TWthQ2qG9FOGSMtI+PKA==",
+      "version": "5.15.15",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.15.15.tgz",
+      "integrity": "sha512-aulox6N1dnu5PABsfxVGOZffDVmlxPOVgj56HrUnJE8MCSh8lOvvkd47cebIVQQYAjpwieXQXiDPj5pwM40jTQ==",
       "dependencies": {
-        "@babel/runtime": "^7.23.1",
-        "@mui/private-theming": "^5.14.14",
-        "@mui/styled-engine": "^5.14.13",
-        "@mui/types": "^7.2.6",
-        "@mui/utils": "^5.14.13",
-        "clsx": "^2.0.0",
-        "csstype": "^3.1.2",
+        "@babel/runtime": "^7.23.9",
+        "@mui/private-theming": "^5.15.14",
+        "@mui/styled-engine": "^5.15.14",
+        "@mui/types": "^7.2.14",
+        "@mui/utils": "^5.15.14",
+        "clsx": "^2.1.0",
+        "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -4264,7 +4257,7 @@
       },
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
@@ -4285,17 +4278,17 @@
       }
     },
     "node_modules/@mui/system/node_modules/clsx": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
-      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.2.6",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.6.tgz",
-      "integrity": "sha512-7sjLQrUmBwufm/M7jw/quNiPK/oor2+pGUQP2CULRcFCArYTq78oJ3D5esTaL0UMkXKJvDqXn6Ike69yAOBQng==",
+      "version": "7.2.14",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.14.tgz",
+      "integrity": "sha512-MZsBZ4q4HfzBsywtXgM1Ksj6HDThtiwmOKUXH1pKYISI9gAVXCNHNpo7TlGoGrBaYWZTdNoirIN7JsQcQUjmQQ==",
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0"
       },
@@ -4306,12 +4299,12 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.14.14",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.14.tgz",
-      "integrity": "sha512-3AKp8uksje5sRfVrtgG9Q/2TBsHWVBUtA0NaXliZqGcXo8J+A+Agp0qUW2rJ+ivgPWTCCubz9FZVT2IQZ3bGsw==",
+      "version": "5.15.14",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.15.14.tgz",
+      "integrity": "sha512-0lF/7Hh/ezDv5X7Pry6enMsbYyGKjADzvHyo3Qrc/SSlTsQ1VkbDMbH0m2t3OR5iIVLwMoxwM7yGd+6FCMtTFA==",
       "dependencies": {
-        "@babel/runtime": "^7.23.1",
-        "@types/prop-types": "^15.7.7",
+        "@babel/runtime": "^7.23.9",
+        "@types/prop-types": "^15.7.11",
         "prop-types": "^15.8.1",
         "react-is": "^18.2.0"
       },
@@ -4320,7 +4313,7 @@
       },
       "funding": {
         "type": "opencollective",
-        "url": "https://opencollective.com/mui"
+        "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0",
@@ -10842,9 +10835,9 @@
       "dev": true
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.9",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.9.tgz",
-      "integrity": "sha512-n1yyPsugYNSmHgxDFjicaI2+gCNjsBck8UX9kuofAKlc0h1bL+20oSF72KeNaW2DUlesbEVCFgyV2dPGTiY42g=="
+      "version": "15.7.12",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
+      "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q=="
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
@@ -10877,9 +10870,9 @@
       }
     },
     "node_modules/@types/react-transition-group": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.6.tgz",
-      "integrity": "sha512-VnCdSxfcm08KjsJVQcfBmhEQAPnLB8G08hAxn39azX1qYBQ/5RVQuoHuKIcfKOdncuaUvEpFKFzEvbtIMsfVew==",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
+      "integrity": "sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -14291,9 +14284,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/d3-color": {
       "version": "3.1.0",
@@ -30980,9 +30973,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
-      "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
+      "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
       "requires": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -31940,34 +31933,34 @@
       "dev": true
     },
     "@floating-ui/core": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.4.1.tgz",
-      "integrity": "sha512-jk3WqquEJRlcyu7997NtR5PibI+y5bi+LS3hPmguVClypenMsCY3CBa3LAQnozRCtCrYWSEtAdiskpamuJRFOQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
       "requires": {
-        "@floating-ui/utils": "^0.1.1"
+        "@floating-ui/utils": "^0.2.1"
       }
     },
     "@floating-ui/dom": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.2.tgz",
-      "integrity": "sha512-6ArmenS6qJEWmwzczWyhvrXRdI/rI78poBcW0h/456+onlabit+2G+QxHx5xTOX60NBJQXjsCLFbW2CmsXpUog==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+      "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
       "requires": {
-        "@floating-ui/core": "^1.4.1",
-        "@floating-ui/utils": "^0.1.1"
+        "@floating-ui/core": "^1.0.0",
+        "@floating-ui/utils": "^0.2.0"
       }
     },
     "@floating-ui/react-dom": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.2.tgz",
-      "integrity": "sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
+      "integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
       "requires": {
-        "@floating-ui/dom": "^1.5.1"
+        "@floating-ui/dom": "^1.6.1"
       }
     },
     "@floating-ui/utils": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.2.tgz",
-      "integrity": "sha512-ou3elfqG/hZsbmF4bxeJhPHIf3G2pm0ujc39hYEZrfVqt7Vk/Zji6CXc3W0pmYM8BW1g40U+akTl9DKZhFhInQ=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
     },
     "@hapi/hoek": {
       "version": "9.3.0",
@@ -32342,37 +32335,30 @@
       }
     },
     "@mui/base": {
-      "version": "5.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.14.tgz",
-      "integrity": "sha512-Je/9JzzYObsuLCIClgE8XvXNFb55IEz8n2NtStUfASfNiVrwiR8t6VVFFuhofehkyTIN34tq1qbBaOjCnOovBw==",
+      "version": "5.0.0-beta.40",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.40.tgz",
+      "integrity": "sha512-I/lGHztkCzvwlXpjD2+SNmvNQvB4227xBXhISPjEaJUXGImOQ9f3D2Yj/T3KasSI/h0MLWy74X0J6clhPmsRbQ==",
       "requires": {
-        "@babel/runtime": "^7.22.10",
-        "@emotion/is-prop-valid": "^1.2.1",
-        "@floating-ui/react-dom": "^2.0.1",
-        "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.14.8",
+        "@babel/runtime": "^7.23.9",
+        "@floating-ui/react-dom": "^2.0.8",
+        "@mui/types": "^7.2.14",
+        "@mui/utils": "^5.15.14",
         "@popperjs/core": "^2.11.8",
-        "clsx": "^2.0.0",
-        "prop-types": "^15.8.1",
-        "react-is": "^18.2.0"
+        "clsx": "^2.1.0",
+        "prop-types": "^15.8.1"
       },
       "dependencies": {
         "clsx": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
-          "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q=="
-        },
-        "react-is": {
-          "version": "18.2.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+          "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
         }
       }
     },
     "@mui/core-downloads-tracker": {
-      "version": "5.14.8",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.14.8.tgz",
-      "integrity": "sha512-8V7ZOC/lKkM03TRHqaThQFIq6bWPnj7L/ZWPh0ymldYFFyh8XdF0ywTgafsofDNYT4StlNknbaTjVHBma3SNjQ=="
+      "version": "5.15.15",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.15.15.tgz",
+      "integrity": "sha512-aXnw29OWQ6I5A47iuWEI6qSSUfH6G/aCsW9KmW3LiFqr7uXZBK4Ks+z8G+qeIub8k0T5CMqlT2q0L+ZJTMrqpg=="
     },
     "@mui/icons-material": {
       "version": "5.14.8",
@@ -32419,28 +32405,28 @@
       }
     },
     "@mui/material": {
-      "version": "5.14.8",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.14.8.tgz",
-      "integrity": "sha512-fqvDGGF1pXwOOL/f0Gw+KHo/67hasRpf2ApTIJkbuONOk9AUb2jnYMEqCWmL2sUcbbE3ShMbHl8N7HPSsRv1/A==",
+      "version": "5.15.15",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.15.15.tgz",
+      "integrity": "sha512-3zvWayJ+E1kzoIsvwyEvkTUKVKt1AjchFFns+JtluHCuvxgKcLSRJTADw37k0doaRtVAsyh8bz9Afqzv+KYrIA==",
       "requires": {
-        "@babel/runtime": "^7.22.10",
-        "@mui/base": "5.0.0-beta.14",
-        "@mui/core-downloads-tracker": "^5.14.8",
-        "@mui/system": "^5.14.8",
-        "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.14.8",
-        "@types/react-transition-group": "^4.4.6",
-        "clsx": "^2.0.0",
-        "csstype": "^3.1.2",
+        "@babel/runtime": "^7.23.9",
+        "@mui/base": "5.0.0-beta.40",
+        "@mui/core-downloads-tracker": "^5.15.15",
+        "@mui/system": "^5.15.15",
+        "@mui/types": "^7.2.14",
+        "@mui/utils": "^5.15.14",
+        "@types/react-transition-group": "^4.4.10",
+        "clsx": "^2.1.0",
+        "csstype": "^3.1.3",
         "prop-types": "^15.8.1",
         "react-is": "^18.2.0",
         "react-transition-group": "^4.4.5"
       },
       "dependencies": {
         "clsx": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
-          "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q=="
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+          "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
         },
         "react-is": {
           "version": "18.2.0",
@@ -32450,60 +32436,60 @@
       }
     },
     "@mui/private-theming": {
-      "version": "5.14.14",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.14.14.tgz",
-      "integrity": "sha512-n77au3CQj9uu16hak2Y+rvbGSBaJKxziG/gEbOLVGrAuqZ+ycVSkorCfN6Y/4XgYOpG/xvmuiY3JwhAEOzY3iA==",
+      "version": "5.15.14",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.15.14.tgz",
+      "integrity": "sha512-UH0EiZckOWcxiXLX3Jbb0K7rC8mxTr9L9l6QhOZxYc4r8FHUkefltV9VDGLrzCaWh30SQiJvAEd7djX3XXY6Xw==",
       "requires": {
-        "@babel/runtime": "^7.23.1",
-        "@mui/utils": "^5.14.13",
+        "@babel/runtime": "^7.23.9",
+        "@mui/utils": "^5.15.14",
         "prop-types": "^15.8.1"
       }
     },
     "@mui/styled-engine": {
-      "version": "5.14.14",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.14.14.tgz",
-      "integrity": "sha512-sF3DS2PVG+cFWvkVHQQaGFpL1h6gSwOW3L91pdxPLQDHDZ5mZ/X0SlXU5XA+WjypoysG4urdAQC7CH/BRvUiqg==",
+      "version": "5.15.14",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.15.14.tgz",
+      "integrity": "sha512-RILkuVD8gY6PvjZjqnWhz8fu68dVkqhM5+jYWfB5yhlSQKg+2rHkmEwm75XIeAqI3qwOndK6zELK5H6Zxn4NHw==",
       "requires": {
-        "@babel/runtime": "^7.23.1",
+        "@babel/runtime": "^7.23.9",
         "@emotion/cache": "^11.11.0",
-        "csstype": "^3.1.2",
+        "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
       }
     },
     "@mui/system": {
-      "version": "5.14.14",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.14.14.tgz",
-      "integrity": "sha512-y4InFmCgGGWXnz+iK4jRTWVikY0HgYnABjz4wgiUgEa2W1H8M4ow+27BegExUWPkj4TWthQ2qG9FOGSMtI+PKA==",
+      "version": "5.15.15",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.15.15.tgz",
+      "integrity": "sha512-aulox6N1dnu5PABsfxVGOZffDVmlxPOVgj56HrUnJE8MCSh8lOvvkd47cebIVQQYAjpwieXQXiDPj5pwM40jTQ==",
       "requires": {
-        "@babel/runtime": "^7.23.1",
-        "@mui/private-theming": "^5.14.14",
-        "@mui/styled-engine": "^5.14.13",
-        "@mui/types": "^7.2.6",
-        "@mui/utils": "^5.14.13",
-        "clsx": "^2.0.0",
-        "csstype": "^3.1.2",
+        "@babel/runtime": "^7.23.9",
+        "@mui/private-theming": "^5.15.14",
+        "@mui/styled-engine": "^5.15.14",
+        "@mui/types": "^7.2.14",
+        "@mui/utils": "^5.15.14",
+        "clsx": "^2.1.0",
+        "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
       },
       "dependencies": {
         "clsx": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
-          "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q=="
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+          "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
         }
       }
     },
     "@mui/types": {
-      "version": "7.2.6",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.6.tgz",
-      "integrity": "sha512-7sjLQrUmBwufm/M7jw/quNiPK/oor2+pGUQP2CULRcFCArYTq78oJ3D5esTaL0UMkXKJvDqXn6Ike69yAOBQng=="
+      "version": "7.2.14",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.14.tgz",
+      "integrity": "sha512-MZsBZ4q4HfzBsywtXgM1Ksj6HDThtiwmOKUXH1pKYISI9gAVXCNHNpo7TlGoGrBaYWZTdNoirIN7JsQcQUjmQQ=="
     },
     "@mui/utils": {
-      "version": "5.14.14",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.14.tgz",
-      "integrity": "sha512-3AKp8uksje5sRfVrtgG9Q/2TBsHWVBUtA0NaXliZqGcXo8J+A+Agp0qUW2rJ+ivgPWTCCubz9FZVT2IQZ3bGsw==",
+      "version": "5.15.14",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.15.14.tgz",
+      "integrity": "sha512-0lF/7Hh/ezDv5X7Pry6enMsbYyGKjADzvHyo3Qrc/SSlTsQ1VkbDMbH0m2t3OR5iIVLwMoxwM7yGd+6FCMtTFA==",
       "requires": {
-        "@babel/runtime": "^7.23.1",
-        "@types/prop-types": "^15.7.7",
+        "@babel/runtime": "^7.23.9",
+        "@types/prop-types": "^15.7.11",
         "prop-types": "^15.8.1",
         "react-is": "^18.2.0"
       },
@@ -37073,9 +37059,9 @@
       "dev": true
     },
     "@types/prop-types": {
-      "version": "15.7.9",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.9.tgz",
-      "integrity": "sha512-n1yyPsugYNSmHgxDFjicaI2+gCNjsBck8UX9kuofAKlc0h1bL+20oSF72KeNaW2DUlesbEVCFgyV2dPGTiY42g=="
+      "version": "15.7.12",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
+      "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q=="
     },
     "@types/qs": {
       "version": "6.9.7",
@@ -37108,9 +37094,9 @@
       }
     },
     "@types/react-transition-group": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.6.tgz",
-      "integrity": "sha512-VnCdSxfcm08KjsJVQcfBmhEQAPnLB8G08hAxn39azX1qYBQ/5RVQuoHuKIcfKOdncuaUvEpFKFzEvbtIMsfVew==",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
+      "integrity": "sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==",
       "requires": {
         "@types/react": "*"
       }
@@ -39651,9 +39637,9 @@
       "dev": true
     },
     "csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "d3-color": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@hookform/resolvers": "3.1.1",
     "@mui/icons-material": "5.14.8",
     "@mui/lab": "5.0.0-alpha.149",
-    "@mui/material": "5.14.8",
+    "@mui/material": "5.15.15",
     "@next/bundle-analyzer": "14.2.2",
     "@prisma/client": "5.1.0",
     "@tanstack/react-query": "4.29.23",

--- a/src/web/topic/components/Node/EditableNode.styles.tsx
+++ b/src/web/topic/components/Node/EditableNode.styles.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { TextareaAutosize } from "@mui/material";
+import { Box, TextareaAutosize } from "@mui/material";
 
 import { htmlDefaultFontSize } from "../../../../pages/_document.page";
 
@@ -15,15 +15,16 @@ export const YEdgeDiv = styled.div`
   min-height: 24px;
 `;
 
-export const NodeTypeDiv = styled.div`
+export const NodeTypeBox = styled(Box)`
   display: flex;
-  padding: 4px;
+  height: 24px;
+  align-items: center;
 `;
 
 export const NodeTypeSpan = styled.span`
   font-size: 0.875rem;
   line-height: 1;
-  padding-left: 4px;
+  padding-right: 4px;
 `;
 
 export const IndicatorDiv = styled.div`
@@ -41,18 +42,14 @@ export const MiddleDiv = styled.div`
   padding: 4px 4px 8px;
 `;
 
-interface StyledTextareaProps {
-  color: string;
-}
-
-export const StyledTextareaAutosize = styled(TextareaAutosize)<StyledTextareaProps>`
+export const StyledTextareaAutosize = styled(TextareaAutosize)`
   padding: 0;
   border: 0;
   resize: none;
   outline: none;
   text-align: center;
   align-self: center;
-  background-color: ${({ color }) => color};
+  background-color: transparent;
   width: 100%;
   font-size: 1rem;
   line-height: 1;
@@ -67,19 +64,10 @@ export const StyledTextareaAutosize = styled(TextareaAutosize)<StyledTextareaPro
   }
 `;
 
-interface NodeDivProps {
-  color: string;
-}
-
-const options = {
-  shouldForwardProp: (prop: string) => !["color"].includes(prop),
-};
-
 /* some copied from https://github.com/wbkd/react-flow/blob/147656b22f577bb4141664d000e62ada9b490473/src/theme-default.css#L42-L77 */
-export const NodeDiv = styled("div", options)<NodeDivProps>`
+export const NodeBox = styled(Box)`
   width: ${nodeWidthRem}rem;
 
-  background: ${({ color }) => color};
   padding: 0px;
   display: flex;
   flex-direction: column;
@@ -87,7 +75,6 @@ export const NodeDiv = styled("div", options)<NodeDivProps>`
   border-radius: 6px;
   border-width: 2px;
   border-style: solid;
-  border-color: #1a192b;
 
   // react-flow sets this to pan hand because nodes can't be moved, so dragging a node will pan, but
   // we want to indicate that the node is selectable.
@@ -102,6 +89,7 @@ export const NodeDiv = styled("div", options)<NodeDivProps>`
 
   // TODO: make this work for table nodes as well; need to manage node.selected within EditableNode instead of letting reactflow handle it
   &.selected {
-    box-shadow: 0 0 0 1px #1a192b;
+    border-color: black;
+    box-shadow: 0 0 0 1px black;
   }
 `;

--- a/src/web/topic/components/Node/FlowNode.styles.tsx
+++ b/src/web/topic/components/Node/FlowNode.styles.tsx
@@ -73,24 +73,14 @@ export const AddNodeButtonGroupChild = styled(StyledAddNodeButtonGroup)<{
   }}
 `;
 
-interface NodeProps {
-  spotlight: Spotlight;
-}
-
-const options = {
-  shouldForwardProp: (prop: string) => !["spotlight"].includes(prop),
-};
-
-export const StyledEditableNode = styled(EditableNode, options)<NodeProps>`
-  ${({ theme, spotlight }) => {
-    if (spotlight === "primary") {
-      return css``;
-    } else if (spotlight === "secondary") {
-      return css`
+export const StyledEditableNode = styled(EditableNode)`
+  ${({ theme }) => {
+    return css`
+      &.spotlight-secondary {
         border-color: ${theme.palette.info.main};
         z-index: ${zIndex.secondary};
-      `;
-    }
+      }
+    `;
   }};
 `;
 

--- a/src/web/topic/components/Node/FlowNode.tsx
+++ b/src/web/topic/components/Node/FlowNode.tsx
@@ -72,7 +72,7 @@ export const FlowNode = (flowNode: NodeProps) => {
         style={{ pointerEvents: "none" }}
       >
         <NodeHandle node={node} direction="parent" orientation={orientation} />
-        <StyledEditableNode node={node} spotlight={spotlight} />
+        <StyledEditableNode node={node} className={`spotlight-${spotlight}`} />
         <NodeHandle node={node} direction="child" orientation={orientation} />
       </motion.div>
 

--- a/src/web/topic/components/Surface/MoreActionsDrawer.tsx
+++ b/src/web/topic/components/Surface/MoreActionsDrawer.tsx
@@ -4,6 +4,7 @@ import {
   Close,
   Download,
   Engineering,
+  FormatColorFill,
   Image as ImageIcon,
   Info,
   Layers,
@@ -31,9 +32,11 @@ import { errorWithData } from "../../../../common/errorHandling";
 import { NumberInput } from "../../../common/components/NumberInput/NumberInput";
 import {
   setLayoutThoroughness,
+  toggleFillNodesWithColor,
   toggleForceNodesIntoLayers,
   toggleShowImpliedEdges,
   toggleUnrestrictedEditing,
+  useFillNodesWithColor,
   useForceNodesIntoLayers,
   useLayoutThoroughness,
   useShowImpliedEdges,
@@ -138,6 +141,7 @@ export const MoreActionsDrawer = ({
   const showImpliedEdges = useShowImpliedEdges();
   const unrestrictedEditing = useUnrestrictedEditing();
   const forceNodesIntoLayers = useForceNodesIntoLayers();
+  const fillNodesWithColor = useFillNodesWithColor();
   const layoutThoroughness = useLayoutThoroughness();
 
   return (
@@ -256,6 +260,19 @@ export const MoreActionsDrawer = ({
               </ToggleButton>
             </>
           )}
+
+          <ToggleButton
+            value={fillNodesWithColor}
+            title="Fill nodes with color"
+            aria-label="Fill nodes with color"
+            color="secondary"
+            size="small"
+            selected={fillNodesWithColor}
+            onClick={() => toggleFillNodesWithColor(!fillNodesWithColor)}
+            sx={{ borderRadius: "50%", border: "0" }}
+          >
+            <FormatColorFill />
+          </ToggleButton>
         </ListItem>
 
         {!isTableActive && (

--- a/src/web/view/actionConfigStore.ts
+++ b/src/web/view/actionConfigStore.ts
@@ -5,6 +5,7 @@ interface ActionConfigStoreState {
   showImpliedEdges: boolean;
   unrestrictedEditing: boolean;
   forceNodesIntoLayers: boolean;
+  fillNodesWithColor: boolean;
   layoutThoroughness: number;
 }
 
@@ -12,6 +13,7 @@ const initialState: ActionConfigStoreState = {
   showImpliedEdges: false,
   unrestrictedEditing: false,
   forceNodesIntoLayers: true,
+  fillNodesWithColor: true,
   layoutThoroughness: 1,
 };
 
@@ -34,6 +36,10 @@ export const useForceNodesIntoLayers = () => {
   return useActionConfigStore((state) => state.forceNodesIntoLayers);
 };
 
+export const useFillNodesWithColor = () => {
+  return useActionConfigStore((state) => state.fillNodesWithColor);
+};
+
 export const useLayoutThoroughness = () => {
   return useActionConfigStore((state) => state.layoutThoroughness);
 };
@@ -49,6 +55,10 @@ export const toggleUnrestrictedEditing = (unrestricted: boolean) => {
 
 export const toggleForceNodesIntoLayers = (force: boolean) => {
   useActionConfigStore.setState({ forceNodesIntoLayers: force });
+};
+
+export const toggleFillNodesWithColor = (fill: boolean) => {
+  useActionConfigStore.setState({ fillNodesWithColor: fill });
 };
 
 export const setLayoutThoroughness = (thoroughness: number) => {


### PR DESCRIPTION
Closes #360 

### Description of changes

- add toggle (in MoreActionsDrawer) to choose not to fill the entire node with color
- also upgraded MUI to fix mui text area autosize error messages

### Additional context

the chosen option is: only color background of node icon, type, and border; this
- seems clear enough for a zoomed-out diagram with many nodes to be able to distinguish types still
- distinguishes node type from node text
- however, not sure how I feel about the node details, because node text is no longer well-distinguished from node notes (both white background)

![image](https://github.com/amelioro/ameliorate/assets/13872370/c311aae9-4ce2-445e-8c30-5e108a3e0c8e)

<details>
<summary>Other considered options</summary>

- only highlight node icon and type; somewhat hard to see and awkwardly narrow coloring:
![image](https://github.com/amelioro/ameliorate/assets/13872370/0e8aa35c-c44b-4c19-892b-0fa8c325eba6)

- only color background of node icon; neatly in the corner but hard to see:
![image](https://github.com/amelioro/ameliorate/assets/13872370/600bbd24-c498-4e75-bf88-d1dc32efc05c)

- only color background of node icon and type: less neatly in the corner, but easier to see, still not blatant when quickly looking at a large number of nodes:
![image](https://github.com/amelioro/ameliorate/assets/13872370/ca27f74f-6cc9-4ad0-9947-db68a9f895f2)

- only color foreground of node icon, but with border too; icon is hard to see for some colors:
![image](https://github.com/amelioro/ameliorate/assets/13872370/c49b844a-452e-47c2-8d53-b04c3e4eb727)

- only color background of node icon, but with border too; easier to tell type, but type text not obviously distinguished from node text:
![image](https://github.com/amelioro/ameliorate/assets/13872370/58e9562c-bec1-44a4-b87a-471acfd34fe7)

</details>