### PR TITLE
Refactor stores to prep for saved views

### DIFF
--- a/src/common/object.ts
+++ b/src/common/object.ts
@@ -1,0 +1,7 @@
+import mergeWith from "lodash/mergeWith";
+
+export const withDefaults = <T>(value: Partial<T>, defaultValue: T): T => {
+  // thanks https://stackoverflow.com/a/66247134/8409296
+  // empty object to avoid mutation
+  return mergeWith({}, defaultValue, value, (_a, b) => (Array.isArray(b) ? b : undefined));
+};

--- a/src/pages/[username]/[topicTitle].page.tsx
+++ b/src/pages/[username]/[topicTitle].page.tsx
@@ -9,7 +9,7 @@ import { Loading } from "../../web/common/components/Loading/Loading";
 import { useSessionUser } from "../../web/common/hooks";
 import { trpc } from "../../web/common/trpc";
 import { populateDiagramFromApi } from "../../web/topic/store/loadActions";
-import { loadNavigateStore } from "../../web/view/navigateStore";
+import { loadView } from "../../web/view/currentViewStore/store";
 import { setInitialPerspective } from "../../web/view/perspectiveStore";
 
 // Don't render the workspace server-side.
@@ -59,7 +59,7 @@ const Topic: NextPage = () => {
     const populate = async () => {
       setPopulatedFromApi(false);
       populateDiagramFromApi(diagramData);
-      await loadNavigateStore(`${diagramData.creatorName}/${diagramData.title}`);
+      await loadView(`${diagramData.creatorName}/${diagramData.title}`);
       setPopulatedFromApi(true);
     };
     void populate();

--- a/src/pages/[username]/[topicTitle].page.tsx
+++ b/src/pages/[username]/[topicTitle].page.tsx
@@ -9,6 +9,7 @@ import { Loading } from "../../web/common/components/Loading/Loading";
 import { useSessionUser } from "../../web/common/hooks";
 import { trpc } from "../../web/common/trpc";
 import { populateDiagramFromApi } from "../../web/topic/store/loadActions";
+import { loadActionConfig } from "../../web/view/actionConfigStore";
 import { loadView } from "../../web/view/currentViewStore/store";
 import { setInitialPerspective } from "../../web/view/perspectiveStore";
 
@@ -60,6 +61,7 @@ const Topic: NextPage = () => {
       setPopulatedFromApi(false);
       populateDiagramFromApi(diagramData);
       await loadView(`${diagramData.creatorName}/${diagramData.title}`);
+      await loadActionConfig(`${diagramData.creatorName}/${diagramData.title}`);
       setPopulatedFromApi(true);
     };
     void populate();

--- a/src/pages/playground.page.tsx
+++ b/src/pages/playground.page.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from "react";
 import { Loading } from "../web/common/components/Loading/Loading";
 import { populateDiagramFromLocalStorage } from "../web/topic/store/loadActions";
 import { playgroundUsername } from "../web/topic/store/store";
-import { loadNavigateStore } from "../web/view/navigateStore";
+import { loadView } from "../web/view/currentViewStore/store";
 import { setInitialPerspective } from "../web/view/perspectiveStore";
 
 // Don't render the workspace server-side.
@@ -37,7 +37,7 @@ const Playground: NextPage = () => {
   useEffect(() => {
     const populate = async () => {
       await populateDiagramFromLocalStorage();
-      await loadNavigateStore("playground");
+      await loadView("playground");
       setInitiallyPopulated(true);
     };
     void populate();

--- a/src/pages/playground.page.tsx
+++ b/src/pages/playground.page.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 import { Loading } from "../web/common/components/Loading/Loading";
 import { populateDiagramFromLocalStorage } from "../web/topic/store/loadActions";
 import { playgroundUsername } from "../web/topic/store/store";
+import { loadActionConfig } from "../web/view/actionConfigStore";
 import { loadView } from "../web/view/currentViewStore/store";
 import { setInitialPerspective } from "../web/view/perspectiveStore";
 
@@ -38,6 +39,7 @@ const Playground: NextPage = () => {
     const populate = async () => {
       await populateDiagramFromLocalStorage();
       await loadView("playground");
+      await loadActionConfig("playground");
       setInitiallyPopulated(true);
     };
     void populate();

--- a/src/web/common/components/ContextMenu/AddNodeMenuItem.tsx
+++ b/src/web/common/components/ContextMenu/AddNodeMenuItem.tsx
@@ -3,7 +3,8 @@ import { NestedMenuItem } from "mui-nested-menu";
 import { addNodeWithoutParent } from "../../../topic/store/createDeleteActions";
 import { useUserCanEditTopicData } from "../../../topic/store/userHooks";
 import { nodeDecorations } from "../../../topic/utils/node";
-import { useFormat, usePrimaryNodeTypes } from "../../../view/currentViewStore/store";
+import { usePrimaryNodeTypes } from "../../../view/currentViewStore/filter";
+import { useFormat } from "../../../view/currentViewStore/store";
 import { useSessionUser } from "../../hooks";
 import { CloseOnClickMenuItem } from "./CloseOnClickMenuItem";
 

--- a/src/web/common/components/ContextMenu/AddNodeMenuItem.tsx
+++ b/src/web/common/components/ContextMenu/AddNodeMenuItem.tsx
@@ -3,7 +3,7 @@ import { NestedMenuItem } from "mui-nested-menu";
 import { addNodeWithoutParent } from "../../../topic/store/createDeleteActions";
 import { useUserCanEditTopicData } from "../../../topic/store/userHooks";
 import { nodeDecorations } from "../../../topic/utils/node";
-import { useFormat, usePrimaryNodeTypes } from "../../../view/navigateStore";
+import { useFormat, usePrimaryNodeTypes } from "../../../view/currentViewStore/store";
 import { useSessionUser } from "../../hooks";
 import { CloseOnClickMenuItem } from "./CloseOnClickMenuItem";
 

--- a/src/web/common/components/ContextMenu/AlsoShowNodeAndNeighborsMenuItem.tsx
+++ b/src/web/common/components/ContextMenu/AlsoShowNodeAndNeighborsMenuItem.tsx
@@ -1,5 +1,5 @@
 import { Node } from "../../../topic/utils/graph";
-import { showNodeAndNeighbors } from "../../../view/navigateStore";
+import { showNodeAndNeighbors } from "../../../view/currentViewStore/store";
 import { CloseOnClickMenuItem } from "./CloseOnClickMenuItem";
 
 export const AlsoShowNodeAndNeighborsMenuItem = ({ node }: { node: Node }) => {

--- a/src/web/common/components/ContextMenu/AlsoShowNodeAndNeighborsMenuItem.tsx
+++ b/src/web/common/components/ContextMenu/AlsoShowNodeAndNeighborsMenuItem.tsx
@@ -1,5 +1,5 @@
 import { Node } from "../../../topic/utils/graph";
-import { showNodeAndNeighbors } from "../../../view/currentViewStore/store";
+import { showNodeAndNeighbors } from "../../../view/currentViewStore/filter";
 import { CloseOnClickMenuItem } from "./CloseOnClickMenuItem";
 
 export const AlsoShowNodeAndNeighborsMenuItem = ({ node }: { node: Node }) => {

--- a/src/web/common/components/ContextMenu/HideMenuItem.tsx
+++ b/src/web/common/components/ContextMenu/HideMenuItem.tsx
@@ -1,5 +1,5 @@
 import { Node } from "../../../topic/utils/graph";
-import { hideNode } from "../../../view/currentViewStore/store";
+import { hideNode } from "../../../view/currentViewStore/filter";
 import { CloseOnClickMenuItem } from "./CloseOnClickMenuItem";
 
 export const HideMenuItem = ({ node }: { node: Node }) => {

--- a/src/web/common/components/ContextMenu/HideMenuItem.tsx
+++ b/src/web/common/components/ContextMenu/HideMenuItem.tsx
@@ -1,5 +1,5 @@
 import { Node } from "../../../topic/utils/graph";
-import { hideNode } from "../../../view/navigateStore";
+import { hideNode } from "../../../view/currentViewStore/store";
 import { CloseOnClickMenuItem } from "./CloseOnClickMenuItem";
 
 export const HideMenuItem = ({ node }: { node: Node }) => {

--- a/src/web/common/components/ContextMenu/OnlyShowNodeAndNeighborsMenuItem.tsx
+++ b/src/web/common/components/ContextMenu/OnlyShowNodeAndNeighborsMenuItem.tsx
@@ -1,5 +1,5 @@
 import { Node } from "../../../topic/utils/graph";
-import { showNodeAndNeighbors } from "../../../view/currentViewStore/store";
+import { showNodeAndNeighbors } from "../../../view/currentViewStore/filter";
 import { CloseOnClickMenuItem } from "./CloseOnClickMenuItem";
 
 export const OnlyShowNodeAndNeighborsMenuItem = ({ node }: { node: Node }) => {

--- a/src/web/common/components/ContextMenu/OnlyShowNodeAndNeighborsMenuItem.tsx
+++ b/src/web/common/components/ContextMenu/OnlyShowNodeAndNeighborsMenuItem.tsx
@@ -1,5 +1,5 @@
 import { Node } from "../../../topic/utils/graph";
-import { showNodeAndNeighbors } from "../../../view/navigateStore";
+import { showNodeAndNeighbors } from "../../../view/currentViewStore/store";
 import { CloseOnClickMenuItem } from "./CloseOnClickMenuItem";
 
 export const OnlyShowNodeAndNeighborsMenuItem = ({ node }: { node: Node }) => {

--- a/src/web/common/event.ts
+++ b/src/web/common/event.ts
@@ -1,7 +1,7 @@
 import { createNanoEvents } from "nanoevents";
 
 import { Node } from "../topic/utils/graph";
-import { resetNavigation } from "../view/navigateStore";
+import { resetView } from "../view/currentViewStore/store";
 
 interface Events {
   addNode: (node: Node) => void;
@@ -14,5 +14,5 @@ export const emitter = createNanoEvents<Events>();
 
 // could go elsewhere but don't want to put into Diagram components because they usually aren't rendered before loading
 emitter.on("overwroteTopicData", () => {
-  resetNavigation();
+  resetView();
 });

--- a/src/web/topic/components/CriteriaTable/CriteriaTable.tsx
+++ b/src/web/topic/components/CriteriaTable/CriteriaTable.tsx
@@ -12,7 +12,7 @@ import React, { useState } from "react";
 
 import { errorWithData } from "../../../../common/errorHandling";
 import { useSessionUser } from "../../../common/hooks";
-import { useGeneralFilter, useTableFilter } from "../../../view/navigateStore";
+import { useGeneralFilter, useTableFilter } from "../../../view/currentViewStore/store";
 import { getSelectedTradeoffNodes } from "../../../view/utils/diagramFilter";
 import { applyScoreFilter } from "../../../view/utils/generalFilter";
 import { useCriterionSolutionEdges, useDefaultNode, useNodeChildren } from "../../store/nodeHooks";

--- a/src/web/topic/components/CriteriaTable/CriteriaTable.tsx
+++ b/src/web/topic/components/CriteriaTable/CriteriaTable.tsx
@@ -12,7 +12,7 @@ import React, { useState } from "react";
 
 import { errorWithData } from "../../../../common/errorHandling";
 import { useSessionUser } from "../../../common/hooks";
-import { useGeneralFilter, useTableFilter } from "../../../view/currentViewStore/store";
+import { useGeneralFilter, useTableFilter } from "../../../view/currentViewStore/filter";
 import { getSelectedTradeoffNodes } from "../../../view/utils/diagramFilter";
 import { applyScoreFilter } from "../../../view/utils/generalFilter";
 import { useCriterionSolutionEdges, useDefaultNode, useNodeChildren } from "../../store/nodeHooks";

--- a/src/web/topic/components/Diagram/Diagram.tsx
+++ b/src/web/topic/components/Diagram/Diagram.tsx
@@ -14,7 +14,7 @@ import { emitter } from "../../../common/event";
 import { useSessionUser } from "../../../common/hooks";
 import { openContextMenu } from "../../../common/store/contextMenuActions";
 import { useFlashlightMode } from "../../../view/actionConfigStore";
-import { setSelected } from "../../../view/navigateStore";
+import { setSelected } from "../../../view/currentViewStore/store";
 import { useLayoutedDiagram } from "../../hooks/diagramHooks";
 import { useViewportUpdater } from "../../hooks/flowHooks";
 import { connectNodes, reconnectEdge } from "../../store/createDeleteActions";

--- a/src/web/topic/components/Edge/ScoreEdge.tsx
+++ b/src/web/topic/components/Edge/ScoreEdge.tsx
@@ -7,7 +7,7 @@ import { useSessionUser } from "../../../common/hooks";
 import { openContextMenu } from "../../../common/store/contextMenuActions";
 import { infoColor } from "../../../common/theme";
 import { useUnrestrictedEditing } from "../../../view/actionConfigStore";
-import { setSelected } from "../../../view/navigateStore";
+import { setSelected } from "../../../view/currentViewStore/store";
 import { setCustomEdgeLabel } from "../../store/actions";
 import { useIsNodeSelected } from "../../store/edgeHooks";
 import { useUserCanEditTopicData } from "../../store/userHooks";

--- a/src/web/topic/components/Edge/StandaloneEdge.tsx
+++ b/src/web/topic/components/Edge/StandaloneEdge.tsx
@@ -1,7 +1,7 @@
 import { Stack } from "@mui/material";
 import { Position } from "reactflow";
 
-import { useIsGraphPartSelected } from "../../../view/navigateStore";
+import { useIsGraphPartSelected } from "../../../view/currentViewStore/store";
 import { useNode } from "../../store/nodeHooks";
 import { Edge } from "../../utils/graph";
 import { EdgeProps } from "../Diagram/Diagram";

--- a/src/web/topic/components/Indicator/ClaimTreeIndicator.tsx
+++ b/src/web/topic/components/Indicator/ClaimTreeIndicator.tsx
@@ -1,7 +1,7 @@
 import { AccountTree, AccountTreeOutlined } from "@mui/icons-material";
 import { MouseEventHandler, useCallback } from "react";
 
-import { viewJustification } from "../../../view/currentViewStore/store";
+import { viewJustification } from "../../../view/currentViewStore/filter";
 import {
   useExplicitClaimCount,
   useNonTopLevelClaimCount,

--- a/src/web/topic/components/Indicator/ClaimTreeIndicator.tsx
+++ b/src/web/topic/components/Indicator/ClaimTreeIndicator.tsx
@@ -1,7 +1,7 @@
 import { AccountTree, AccountTreeOutlined } from "@mui/icons-material";
 import { MouseEventHandler, useCallback } from "react";
 
-import { viewJustification } from "../../../view/navigateStore";
+import { viewJustification } from "../../../view/currentViewStore/store";
 import {
   useExplicitClaimCount,
   useNonTopLevelClaimCount,

--- a/src/web/topic/components/Indicator/CriteriaTableIndicator.tsx
+++ b/src/web/topic/components/Indicator/CriteriaTableIndicator.tsx
@@ -1,7 +1,7 @@
 import { TableChart, TableChartOutlined } from "@mui/icons-material";
 import { memo, useCallback } from "react";
 
-import { viewCriteriaTable } from "../../../view/navigateStore";
+import { viewCriteriaTable } from "../../../view/currentViewStore/store";
 import { useNode, useNodeChildren } from "../../store/nodeHooks";
 import { Node, ProblemNode } from "../../utils/graph";
 import { Indicator } from "../Indicator/Indicator";

--- a/src/web/topic/components/Indicator/CriteriaTableIndicator.tsx
+++ b/src/web/topic/components/Indicator/CriteriaTableIndicator.tsx
@@ -1,7 +1,7 @@
 import { TableChart, TableChartOutlined } from "@mui/icons-material";
 import { memo, useCallback } from "react";
 
-import { viewCriteriaTable } from "../../../view/currentViewStore/store";
+import { viewCriteriaTable } from "../../../view/currentViewStore/filter";
 import { useNode, useNodeChildren } from "../../store/nodeHooks";
 import { Node, ProblemNode } from "../../utils/graph";
 import { Indicator } from "../Indicator/Indicator";

--- a/src/web/topic/components/Indicator/DetailsIndicator.tsx
+++ b/src/web/topic/components/Indicator/DetailsIndicator.tsx
@@ -1,7 +1,7 @@
 import { Article, ArticleOutlined } from "@mui/icons-material";
 import { useCallback } from "react";
 
-import { setSelected } from "../../../view/navigateStore";
+import { setSelected } from "../../../view/currentViewStore/store";
 import { viewDetails } from "../TopicPane/paneStore";
 import { Indicator } from "./Indicator";
 

--- a/src/web/topic/components/Indicator/ForceShownIndicator.tsx
+++ b/src/web/topic/components/Indicator/ForceShownIndicator.tsx
@@ -2,7 +2,7 @@ import { WbTwilight } from "@mui/icons-material";
 import { type ButtonProps } from "@mui/material";
 import { MouseEventHandler, memo, useCallback } from "react";
 
-import { stopForcingNodeToShow, useIsNodeForcedToShow } from "../../../view/navigateStore";
+import { stopForcingNodeToShow, useIsNodeForcedToShow } from "../../../view/currentViewStore/store";
 import { Indicator } from "./Indicator";
 
 interface Props {

--- a/src/web/topic/components/Indicator/ForceShownIndicator.tsx
+++ b/src/web/topic/components/Indicator/ForceShownIndicator.tsx
@@ -2,7 +2,10 @@ import { WbTwilight } from "@mui/icons-material";
 import { type ButtonProps } from "@mui/material";
 import { MouseEventHandler, memo, useCallback } from "react";
 
-import { stopForcingNodeToShow, useIsNodeForcedToShow } from "../../../view/currentViewStore/store";
+import {
+  stopForcingNodeToShow,
+  useIsNodeForcedToShow,
+} from "../../../view/currentViewStore/filter";
 import { Indicator } from "./Indicator";
 
 interface Props {

--- a/src/web/topic/components/Indicator/FoundResearchIndicator.tsx
+++ b/src/web/topic/components/Indicator/FoundResearchIndicator.tsx
@@ -2,7 +2,7 @@ import { Code, InfoOutlined, School } from "@mui/icons-material";
 import { type ButtonProps } from "@mui/material";
 import { useCallback } from "react";
 
-import { setSelected } from "../../../view/navigateStore";
+import { setSelected } from "../../../view/currentViewStore/store";
 import { useResearchNodes } from "../../store/graphPartHooks";
 import { useDisplayScores } from "../../store/scoreHooks";
 import { Score } from "../../utils/graph";

--- a/src/web/topic/components/Indicator/JustificationIndicator.tsx
+++ b/src/web/topic/components/Indicator/JustificationIndicator.tsx
@@ -2,7 +2,7 @@ import { ThumbDownOutlined, ThumbUpOutlined, ThumbsUpDownOutlined } from "@mui/i
 import { type ButtonProps } from "@mui/material";
 import { useCallback } from "react";
 
-import { setSelected } from "../../../view/navigateStore";
+import { setSelected } from "../../../view/currentViewStore/store";
 import { useTopLevelClaims } from "../../store/graphPartHooks";
 import { useDisplayScores } from "../../store/scoreHooks";
 import { Score } from "../../utils/graph";

--- a/src/web/topic/components/Indicator/QuestionIndicator.tsx
+++ b/src/web/topic/components/Indicator/QuestionIndicator.tsx
@@ -2,7 +2,7 @@ import { QuestionMark } from "@mui/icons-material";
 import { type ButtonProps } from "@mui/material";
 import { useCallback } from "react";
 
-import { setSelected } from "../../../view/navigateStore";
+import { setSelected } from "../../../view/currentViewStore/store";
 import { useResearchNodes } from "../../store/graphPartHooks";
 import { useDisplayScores } from "../../store/scoreHooks";
 import { Score } from "../../utils/graph";

--- a/src/web/topic/components/Node/EditableNode.tsx
+++ b/src/web/topic/components/Node/EditableNode.tsx
@@ -3,8 +3,9 @@ import { memo, useEffect, useRef } from "react";
 
 import { useSessionUser } from "../../../common/hooks";
 import { openContextMenu } from "../../../common/store/contextMenuActions";
-import { useFillNodesWithColor, useUnrestrictedEditing } from "../../../view/actionConfigStore";
+import { useUnrestrictedEditing } from "../../../view/actionConfigStore";
 import { setSelected, useIsGraphPartSelected } from "../../../view/currentViewStore/store";
+import { useFillNodesWithColor } from "../../../view/userConfigStore";
 import { finishAddingNode, setCustomNodeType, setNodeLabel } from "../../store/actions";
 import { useUserCanEditTopicData } from "../../store/userHooks";
 import { Node } from "../../utils/graph";

--- a/src/web/topic/components/Node/EditableNode.tsx
+++ b/src/web/topic/components/Node/EditableNode.tsx
@@ -4,7 +4,7 @@ import { memo, useEffect, useRef } from "react";
 import { useSessionUser } from "../../../common/hooks";
 import { openContextMenu } from "../../../common/store/contextMenuActions";
 import { useFillNodesWithColor, useUnrestrictedEditing } from "../../../view/actionConfigStore";
-import { setSelected, useIsGraphPartSelected } from "../../../view/navigateStore";
+import { setSelected, useIsGraphPartSelected } from "../../../view/currentViewStore/store";
 import { finishAddingNode, setCustomNodeType, setNodeLabel } from "../../store/actions";
 import { useUserCanEditTopicData } from "../../store/userHooks";
 import { Node } from "../../utils/graph";

--- a/src/web/topic/components/Node/FlowNode.tsx
+++ b/src/web/topic/components/Node/FlowNode.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import { useSessionUser } from "../../../common/hooks";
 import { getFlashlightMode } from "../../../view/actionConfigStore";
-import { showNodeAndNeighbors } from "../../../view/currentViewStore/store";
+import { showNodeAndNeighbors } from "../../../view/currentViewStore/filter";
 import { useIsEdgeSelected, useIsNeighborSelected } from "../../store/nodeHooks";
 import { useUserCanEditTopicData } from "../../store/userHooks";
 import { Node } from "../../utils/graph";

--- a/src/web/topic/components/Node/FlowNode.tsx
+++ b/src/web/topic/components/Node/FlowNode.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import { useSessionUser } from "../../../common/hooks";
 import { getFlashlightMode } from "../../../view/actionConfigStore";
-import { showNodeAndNeighbors } from "../../../view/navigateStore";
+import { showNodeAndNeighbors } from "../../../view/currentViewStore/store";
 import { useIsEdgeSelected, useIsNeighborSelected } from "../../store/nodeHooks";
 import { useUserCanEditTopicData } from "../../store/userHooks";
 import { Node } from "../../utils/graph";

--- a/src/web/topic/components/Node/NodeHandle.tsx
+++ b/src/web/topic/components/Node/NodeHandle.tsx
@@ -4,7 +4,7 @@ import { ReactNode, memo } from "react";
 import { Position } from "reactflow";
 
 import { nodeTypes } from "../../../../common/node";
-import { showNode } from "../../../view/navigateStore";
+import { showNode } from "../../../view/currentViewStore/store";
 import { useHiddenNodes } from "../../hooks/flowHooks";
 import { useNeighborsInDirection } from "../../store/nodeHooks";
 import { Node, RelationDirection } from "../../utils/graph";

--- a/src/web/topic/components/Node/NodeHandle.tsx
+++ b/src/web/topic/components/Node/NodeHandle.tsx
@@ -4,7 +4,7 @@ import { ReactNode, memo } from "react";
 import { Position } from "reactflow";
 
 import { nodeTypes } from "../../../../common/node";
-import { showNode } from "../../../view/currentViewStore/store";
+import { showNode } from "../../../view/currentViewStore/filter";
 import { useHiddenNodes } from "../../hooks/flowHooks";
 import { useNeighborsInDirection } from "../../store/nodeHooks";
 import { Node, RelationDirection } from "../../utils/graph";

--- a/src/web/topic/components/Surface/MoreActionsDrawer.tsx
+++ b/src/web/topic/components/Surface/MoreActionsDrawer.tsx
@@ -33,21 +33,26 @@ import { StorageValue } from "zustand/middleware";
 import { errorWithData } from "../../../../common/errorHandling";
 import { NumberInput } from "../../../common/components/NumberInput/NumberInput";
 import {
-  setLayoutThoroughness,
   toggleFillNodesWithColor,
   toggleFlashlightMode,
-  toggleForceNodesIntoLayers,
-  toggleShowImpliedEdges,
   toggleUnrestrictedEditing,
   useFillNodesWithColor,
   useFlashlightMode,
-  useForceNodesIntoLayers,
-  useLayoutThoroughness,
-  useShowImpliedEdges,
   useUnrestrictedEditing,
 } from "../../../view/actionConfigStore";
 import { Perspectives } from "../../../view/components/Perspectives/Perspectives";
-import { resetView, useFormat } from "../../../view/currentViewStore/store";
+import {
+  setLayoutThoroughness,
+  toggleForceNodesIntoLayers,
+  useForceNodesIntoLayers,
+  useLayoutThoroughness,
+} from "../../../view/currentViewStore/layout";
+import {
+  resetView,
+  toggleShowImpliedEdges,
+  useFormat,
+  useShowImpliedEdges,
+} from "../../../view/currentViewStore/store";
 import { migrate } from "../../store/migrate";
 import { TopicStoreState } from "../../store/store";
 import { useOnPlayground } from "../../store/topicHooks";

--- a/src/web/topic/components/Surface/MoreActionsDrawer.tsx
+++ b/src/web/topic/components/Surface/MoreActionsDrawer.tsx
@@ -47,7 +47,7 @@ import {
   useUnrestrictedEditing,
 } from "../../../view/actionConfigStore";
 import { Perspectives } from "../../../view/components/Perspectives/Perspectives";
-import { resetNavigation, useFormat } from "../../../view/navigateStore";
+import { resetView, useFormat } from "../../../view/currentViewStore/store";
 import { migrate } from "../../store/migrate";
 import { TopicStoreState } from "../../store/store";
 import { useOnPlayground } from "../../store/topicHooks";
@@ -213,7 +213,7 @@ export const MoreActionsDrawer = ({
             color="inherit"
             title="Reset Filters"
             aria-label="Reset Filters"
-            onClick={() => resetNavigation(true)}
+            onClick={() => resetView(true)}
           >
             <FilterAltOutlined />
           </IconButton>

--- a/src/web/topic/components/Surface/MoreActionsDrawer.tsx
+++ b/src/web/topic/components/Surface/MoreActionsDrawer.tsx
@@ -41,18 +41,14 @@ import {
   useUnrestrictedEditing,
 } from "../../../view/actionConfigStore";
 import { Perspectives } from "../../../view/components/Perspectives/Perspectives";
+import { toggleShowImpliedEdges, useShowImpliedEdges } from "../../../view/currentViewStore/filter";
 import {
   setLayoutThoroughness,
   toggleForceNodesIntoLayers,
   useForceNodesIntoLayers,
   useLayoutThoroughness,
 } from "../../../view/currentViewStore/layout";
-import {
-  resetView,
-  toggleShowImpliedEdges,
-  useFormat,
-  useShowImpliedEdges,
-} from "../../../view/currentViewStore/store";
+import { resetView, useFormat } from "../../../view/currentViewStore/store";
 import { migrate } from "../../store/migrate";
 import { TopicStoreState } from "../../store/store";
 import { useOnPlayground } from "../../store/topicHooks";

--- a/src/web/topic/components/Surface/MoreActionsDrawer.tsx
+++ b/src/web/topic/components/Surface/MoreActionsDrawer.tsx
@@ -174,9 +174,8 @@ export const MoreActionsDrawer = ({
           <ListItemText primary="More Actions" />
         </ListItem>
 
-        <Divider />
+        <Divider>Actions</Divider>
 
-        {/* actions */}
         <ListItem disablePadding={false}>
           <IconButton
             color="inherit"
@@ -230,29 +229,48 @@ export const MoreActionsDrawer = ({
           )}
         </ListItem>
 
-        <Divider />
+        {!isTableActive && (
+          <>
+            <Divider>Action Config</Divider>
 
-        {/* modes */}
-        <ListItem disablePadding={false}>
-          {userCanEditTopicData && (
-            <>
+            <ListItem disablePadding={false}>
+              {userCanEditTopicData && (
+                <>
+                  <ToggleButton
+                    value={unrestrictedEditing}
+                    title="Unrestrict editing"
+                    aria-label="Unrestrict editing"
+                    color="secondary"
+                    size="small"
+                    selected={unrestrictedEditing}
+                    onClick={() => toggleUnrestrictedEditing(!unrestrictedEditing)}
+                    sx={{ borderRadius: "50%", border: "0" }}
+                  >
+                    <Engineering />
+                  </ToggleButton>
+                </>
+              )}
               <ToggleButton
-                value={unrestrictedEditing}
-                title="Unrestrict editing"
-                aria-label="Unrestrict editing"
+                value={flashlightMode}
+                title="Flashlight mode"
+                aria-label="Flashlight mode"
                 color="secondary"
                 size="small"
-                selected={unrestrictedEditing}
-                onClick={() => toggleUnrestrictedEditing(!unrestrictedEditing)}
+                selected={flashlightMode}
+                onClick={() => toggleFlashlightMode(!flashlightMode)}
                 sx={{ borderRadius: "50%", border: "0" }}
               >
-                <Engineering />
+                <Highlight />
               </ToggleButton>
-            </>
-          )}
+            </ListItem>
+          </>
+        )}
 
-          {!isTableActive && (
-            <>
+        {!isTableActive && (
+          <>
+            <Divider>View Config</Divider>
+
+            <ListItem disablePadding={false}>
               <ToggleButton
                 value={showImpliedEdges}
                 title="Show implied edges"
@@ -277,37 +295,8 @@ export const MoreActionsDrawer = ({
               >
                 <Layers />
               </ToggleButton>
-              <ToggleButton
-                value={flashlightMode}
-                title="Flashlight mode"
-                aria-label="Flashlight mode"
-                color="secondary"
-                size="small"
-                selected={flashlightMode}
-                onClick={() => toggleFlashlightMode(!flashlightMode)}
-                sx={{ borderRadius: "50%", border: "0" }}
-              >
-                <Highlight />
-              </ToggleButton>
-            </>
-          )}
+            </ListItem>
 
-          <ToggleButton
-            value={fillNodesWithColor}
-            title="Fill nodes with color"
-            aria-label="Fill nodes with color"
-            color="secondary"
-            size="small"
-            selected={fillNodesWithColor}
-            onClick={() => toggleFillNodesWithColor(!fillNodesWithColor)}
-            sx={{ borderRadius: "50%", border: "0" }}
-          >
-            <FormatColorFill />
-          </ToggleButton>
-        </ListItem>
-
-        {!isTableActive && (
-          <>
             <ListItem disablePadding={false}>
               <Typography variant="body2">Layout Thoroughness</Typography>
               <Tooltip
@@ -342,10 +331,31 @@ export const MoreActionsDrawer = ({
         )}
 
         {!onPlayground && (
-          <ListItem disablePadding={false}>
-            <Perspectives />
-          </ListItem>
+          <>
+            <Divider>Perspectives</Divider>
+
+            <ListItem disablePadding={false}>
+              <Perspectives />
+            </ListItem>
+          </>
         )}
+
+        <Divider>User Config</Divider>
+
+        <ListItem disablePadding={false}>
+          <ToggleButton
+            value={fillNodesWithColor}
+            title="Fill nodes with color"
+            aria-label="Fill nodes with color"
+            color="secondary"
+            size="small"
+            selected={fillNodesWithColor}
+            onClick={() => toggleFillNodesWithColor(!fillNodesWithColor)}
+            sx={{ borderRadius: "50%", border: "0" }}
+          >
+            <FormatColorFill />
+          </ToggleButton>
+        </ListItem>
       </List>
     </Drawer>
   );

--- a/src/web/topic/components/Surface/MoreActionsDrawer.tsx
+++ b/src/web/topic/components/Surface/MoreActionsDrawer.tsx
@@ -33,10 +33,8 @@ import { StorageValue } from "zustand/middleware";
 import { errorWithData } from "../../../../common/errorHandling";
 import { NumberInput } from "../../../common/components/NumberInput/NumberInput";
 import {
-  toggleFillNodesWithColor,
   toggleFlashlightMode,
   toggleUnrestrictedEditing,
-  useFillNodesWithColor,
   useFlashlightMode,
   useUnrestrictedEditing,
 } from "../../../view/actionConfigStore";
@@ -49,6 +47,7 @@ import {
   useLayoutThoroughness,
 } from "../../../view/currentViewStore/layout";
 import { resetView, useFormat } from "../../../view/currentViewStore/store";
+import { toggleFillNodesWithColor, useFillNodesWithColor } from "../../../view/userConfigStore";
 import { migrate } from "../../store/migrate";
 import { TopicStoreState } from "../../store/store";
 import { useOnPlayground } from "../../store/topicHooks";

--- a/src/web/topic/components/Surface/TopicToolbar.tsx
+++ b/src/web/topic/components/Surface/TopicToolbar.tsx
@@ -20,7 +20,7 @@ import {
   goForward,
   useCanGoBackForward,
   useSelectedGraphPart,
-} from "../../../view/navigateStore";
+} from "../../../view/currentViewStore/store";
 import {
   comparePerspectives,
   resetPerspectives,

--- a/src/web/topic/components/TopicPane/TopicPane.tsx
+++ b/src/web/topic/components/TopicPane/TopicPane.tsx
@@ -2,7 +2,7 @@ import { AutoStories, ChevronLeft, KeyboardArrowDown } from "@mui/icons-material
 import { TabContext, TabList, TabPanel } from "@mui/lab";
 import { Tab } from "@mui/material";
 
-import { useSelectedGraphPart } from "../../../view/navigateStore";
+import { useSelectedGraphPart } from "../../../view/currentViewStore/store";
 import { GraphPartDetails } from "./GraphPartDetails";
 import { TopicDetails } from "./TopicDetails";
 import { PositionedDiv, StyledDrawer, TogglePaneButton } from "./TopicPane.styles";

--- a/src/web/topic/components/TopicPane/TopicViews.tsx
+++ b/src/web/topic/components/TopicPane/TopicViews.tsx
@@ -13,7 +13,7 @@ import { useState } from "react";
 import { GeneralFilters } from "../../../view/components/Filter/GeneralFilters";
 import { InformationFilters } from "../../../view/components/Filter/InformationFilters";
 import { TableFilters } from "../../../view/components/Filter/TableFilters";
-import { setFormat, useFormat } from "../../../view/navigateStore";
+import { setFormat, useFormat } from "../../../view/currentViewStore/store";
 
 export const TopicViews = () => {
   const [isFormatSectionOpen, setIsFormatSectionOpen] = useState(true);

--- a/src/web/topic/components/TopicWorkspace/TopicWorkspace.tsx
+++ b/src/web/topic/components/TopicWorkspace/TopicWorkspace.tsx
@@ -2,7 +2,7 @@ import { Global } from "@emotion/react";
 import { Box, useMediaQuery } from "@mui/material";
 
 import { ContextMenu } from "../../../common/components/ContextMenu/ContextMenu";
-import { useFormat } from "../../../view/navigateStore";
+import { useFormat } from "../../../view/currentViewStore/store";
 import { CriteriaTable } from "../CriteriaTable/CriteriaTable";
 import { Diagram } from "../Diagram/Diagram";
 import { TopicToolbar } from "../Surface/TopicToolbar";

--- a/src/web/topic/hooks/diagramHooks.ts
+++ b/src/web/topic/hooks/diagramHooks.ts
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 import { useForceNodesIntoLayers, useLayoutThoroughness } from "../../view/actionConfigStore";
-import { useSelectedGraphPart } from "../../view/navigateStore";
+import { useSelectedGraphPart } from "../../view/currentViewStore/store";
 import { Diagram, PositionedDiagram, PositionedNode } from "../utils/diagram";
 import { NodePosition, layout } from "../utils/layout";
 

--- a/src/web/topic/hooks/diagramHooks.ts
+++ b/src/web/topic/hooks/diagramHooks.ts
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import { useForceNodesIntoLayers, useLayoutThoroughness } from "../../view/actionConfigStore";
+import { useForceNodesIntoLayers, useLayoutThoroughness } from "../../view/currentViewStore/layout";
 import { useSelectedGraphPart } from "../../view/currentViewStore/store";
 import { Diagram, PositionedDiagram, PositionedNode } from "../utils/diagram";
 import { NodePosition, layout } from "../utils/layout";

--- a/src/web/topic/store/createDeleteActions.ts
+++ b/src/web/topic/store/createDeleteActions.ts
@@ -4,7 +4,7 @@ import { errorWithData } from "../../../common/errorHandling";
 import { structureNodeTypes } from "../../../common/node";
 import { emitter } from "../../common/event";
 import { getUnrestrictedEditing } from "../../view/actionConfigStore";
-import { setSelected } from "../../view/navigateStore";
+import { setSelected } from "../../view/currentViewStore/store";
 import { getImplicitLabel } from "../utils/claim";
 import { Relation, canCreateEdge, getRelation } from "../utils/edge";
 import {

--- a/src/web/topic/store/edgeHooks.ts
+++ b/src/web/topic/store/edgeHooks.ts
@@ -1,6 +1,6 @@
 import { shallow } from "zustand/shallow";
 
-import { useIsAnyGraphPartSelected } from "../../view/navigateStore";
+import { useIsAnyGraphPartSelected } from "../../view/currentViewStore/store";
 import { nodes } from "../utils/edge";
 import { findEdgeOrThrow } from "../utils/graph";
 import { useTopicStore } from "./store";

--- a/src/web/topic/store/nodeHooks.ts
+++ b/src/web/topic/store/nodeHooks.ts
@@ -2,7 +2,7 @@ import { shallow } from "zustand/shallow";
 
 import { errorWithData } from "../../../common/errorHandling";
 import { NodeType } from "../../../common/node";
-import { useIsAnyGraphPartSelected } from "../../view/navigateStore";
+import { useIsAnyGraphPartSelected } from "../../view/currentViewStore/store";
 import { RelationDirection, findNodeOrThrow } from "../utils/graph";
 import { children, edges, neighbors, parents } from "../utils/node";
 import { getDefaultNode } from "./nodeGetters";

--- a/src/web/topic/store/store.ts
+++ b/src/web/topic/store/store.ts
@@ -3,8 +3,11 @@ import { temporal } from "zundo";
 import { devtools, persist } from "zustand/middleware";
 import { createWithEqualityFn } from "zustand/traditional";
 
-import { useShowImpliedEdges } from "../../view/actionConfigStore";
-import { useDiagramFilter, useGeneralFilter } from "../../view/currentViewStore/store";
+import {
+  useDiagramFilter,
+  useGeneralFilter,
+  useShowImpliedEdges,
+} from "../../view/currentViewStore/store";
 import { usePerspectives } from "../../view/perspectiveStore";
 import { applyDiagramFilter } from "../../view/utils/diagramFilter";
 import { applyNodeTypeFilter, applyScoreFilter } from "../../view/utils/generalFilter";

--- a/src/web/topic/store/store.ts
+++ b/src/web/topic/store/store.ts
@@ -7,7 +7,7 @@ import {
   useDiagramFilter,
   useGeneralFilter,
   useShowImpliedEdges,
-} from "../../view/currentViewStore/store";
+} from "../../view/currentViewStore/filter";
 import { usePerspectives } from "../../view/perspectiveStore";
 import { applyDiagramFilter } from "../../view/utils/diagramFilter";
 import { applyNodeTypeFilter, applyScoreFilter } from "../../view/utils/generalFilter";

--- a/src/web/topic/store/store.ts
+++ b/src/web/topic/store/store.ts
@@ -4,7 +4,7 @@ import { devtools, persist } from "zustand/middleware";
 import { createWithEqualityFn } from "zustand/traditional";
 
 import { useShowImpliedEdges } from "../../view/actionConfigStore";
-import { useDiagramFilter, useGeneralFilter } from "../../view/navigateStore";
+import { useDiagramFilter, useGeneralFilter } from "../../view/currentViewStore/store";
 import { usePerspectives } from "../../view/perspectiveStore";
 import { applyDiagramFilter } from "../../view/utils/diagramFilter";
 import { applyNodeTypeFilter, applyScoreFilter } from "../../view/utils/generalFilter";

--- a/src/web/view/actionConfigStore.ts
+++ b/src/web/view/actionConfigStore.ts
@@ -4,13 +4,11 @@ import { persist } from "zustand/middleware";
 interface ActionConfigStoreState {
   unrestrictedEditing: boolean;
   flashlightMode: boolean;
-  fillNodesWithColor: boolean;
 }
 
 const initialState: ActionConfigStoreState = {
   unrestrictedEditing: false,
   flashlightMode: false,
-  fillNodesWithColor: true,
 };
 
 const useActionConfigStore = create<ActionConfigStoreState>()(
@@ -28,10 +26,6 @@ export const useFlashlightMode = () => {
   return useActionConfigStore((state) => state.flashlightMode);
 };
 
-export const useFillNodesWithColor = () => {
-  return useActionConfigStore((state) => state.fillNodesWithColor);
-};
-
 // actions
 export const toggleUnrestrictedEditing = (unrestricted: boolean) => {
   useActionConfigStore.setState({ unrestrictedEditing: unrestricted });
@@ -39,10 +33,6 @@ export const toggleUnrestrictedEditing = (unrestricted: boolean) => {
 
 export const toggleFlashlightMode = (flashlight: boolean) => {
   useActionConfigStore.setState({ flashlightMode: flashlight });
-};
-
-export const toggleFillNodesWithColor = (fill: boolean) => {
-  useActionConfigStore.setState({ fillNodesWithColor: fill });
 };
 
 // utils

--- a/src/web/view/actionConfigStore.ts
+++ b/src/web/view/actionConfigStore.ts
@@ -2,21 +2,15 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
 interface ActionConfigStoreState {
-  showImpliedEdges: boolean;
   unrestrictedEditing: boolean;
-  forceNodesIntoLayers: boolean;
   flashlightMode: boolean;
   fillNodesWithColor: boolean;
-  layoutThoroughness: number;
 }
 
 const initialState: ActionConfigStoreState = {
-  showImpliedEdges: false,
   unrestrictedEditing: false,
-  forceNodesIntoLayers: true,
   flashlightMode: false,
   fillNodesWithColor: true,
-  layoutThoroughness: 1,
 };
 
 const useActionConfigStore = create<ActionConfigStoreState>()(
@@ -26,16 +20,8 @@ const useActionConfigStore = create<ActionConfigStoreState>()(
 );
 
 // hooks
-export const useShowImpliedEdges = () => {
-  return useActionConfigStore((state) => state.showImpliedEdges);
-};
-
 export const useUnrestrictedEditing = () => {
   return useActionConfigStore((state) => state.unrestrictedEditing);
-};
-
-export const useForceNodesIntoLayers = () => {
-  return useActionConfigStore((state) => state.forceNodesIntoLayers);
 };
 
 export const useFlashlightMode = () => {
@@ -46,21 +32,9 @@ export const useFillNodesWithColor = () => {
   return useActionConfigStore((state) => state.fillNodesWithColor);
 };
 
-export const useLayoutThoroughness = () => {
-  return useActionConfigStore((state) => state.layoutThoroughness);
-};
-
 // actions
-export const toggleShowImpliedEdges = (show: boolean) => {
-  useActionConfigStore.setState({ showImpliedEdges: show });
-};
-
 export const toggleUnrestrictedEditing = (unrestricted: boolean) => {
   useActionConfigStore.setState({ unrestrictedEditing: unrestricted });
-};
-
-export const toggleForceNodesIntoLayers = (force: boolean) => {
-  useActionConfigStore.setState({ forceNodesIntoLayers: force });
 };
 
 export const toggleFlashlightMode = (flashlight: boolean) => {
@@ -69,10 +43,6 @@ export const toggleFlashlightMode = (flashlight: boolean) => {
 
 export const toggleFillNodesWithColor = (fill: boolean) => {
   useActionConfigStore.setState({ fillNodesWithColor: fill });
-};
-
-export const setLayoutThoroughness = (thoroughness: number) => {
-  useActionConfigStore.setState({ layoutThoroughness: thoroughness });
 };
 
 // utils

--- a/src/web/view/components/Filter/GeneralFilters.tsx
+++ b/src/web/view/components/Filter/GeneralFilters.tsx
@@ -11,7 +11,8 @@ import { Switch } from "../../../common/components/Form/Switch";
 import { deepIsEqual } from "../../../common/store/utils";
 import { useAllNodes } from "../../../topic/store/nodeHooks";
 import { possibleScores } from "../../../topic/utils/graph";
-import { setGeneralFilter, useFormat, useGeneralFilter } from "../../currentViewStore/store";
+import { setGeneralFilter, useGeneralFilter } from "../../currentViewStore/filter";
+import { useFormat } from "../../currentViewStore/store";
 import { GeneralFilter, generalFilterSchema, scoredComparers } from "../../utils/generalFilter";
 import { ShowSecondaryNeighborsLabel } from "./ShowSecondaryNeighborsLabel";
 

--- a/src/web/view/components/Filter/GeneralFilters.tsx
+++ b/src/web/view/components/Filter/GeneralFilters.tsx
@@ -11,7 +11,7 @@ import { Switch } from "../../../common/components/Form/Switch";
 import { deepIsEqual } from "../../../common/store/utils";
 import { useAllNodes } from "../../../topic/store/nodeHooks";
 import { possibleScores } from "../../../topic/utils/graph";
-import { setGeneralFilter, useFormat, useGeneralFilter } from "../../navigateStore";
+import { setGeneralFilter, useFormat, useGeneralFilter } from "../../currentViewStore/store";
 import { GeneralFilter, generalFilterSchema, scoredComparers } from "../../utils/generalFilter";
 import { ShowSecondaryNeighborsLabel } from "./ShowSecondaryNeighborsLabel";
 

--- a/src/web/view/components/Filter/InformationFilters.tsx
+++ b/src/web/view/components/Filter/InformationFilters.tsx
@@ -1,7 +1,7 @@
 import { AutoStories, School, ThumbsUpDown } from "@mui/icons-material";
 import { FormControlLabel, Switch as MuiSwitch, Stack, Typography } from "@mui/material";
 
-import { setShowInformation, useDiagramFilter } from "../../navigateStore";
+import { setShowInformation, useDiagramFilter } from "../../currentViewStore/store";
 import { StandardFilter } from "./StandardFilter";
 
 export const InformationFilters = () => {

--- a/src/web/view/components/Filter/InformationFilters.tsx
+++ b/src/web/view/components/Filter/InformationFilters.tsx
@@ -1,7 +1,7 @@
 import { AutoStories, School, ThumbsUpDown } from "@mui/icons-material";
 import { FormControlLabel, Switch as MuiSwitch, Stack, Typography } from "@mui/material";
 
-import { setShowInformation, useDiagramFilter } from "../../currentViewStore/store";
+import { setShowInformation, useDiagramFilter } from "../../currentViewStore/filter";
 import { StandardFilter } from "./StandardFilter";
 
 export const InformationFilters = () => {

--- a/src/web/view/components/Filter/StandardFilter.tsx
+++ b/src/web/view/components/Filter/StandardFilter.tsx
@@ -9,7 +9,7 @@ import { NodeSelect } from "../../../common/components/Form/NodeSelect";
 import { Select } from "../../../common/components/Form/Select";
 import { deepIsEqual } from "../../../common/store/utils";
 import { useCriteria, useNodesOfType, useSolutions } from "../../../topic/store/nodeHooks";
-import { getStandardFilterWithFallbacks, setStandardFilter } from "../../navigateStore";
+import { getStandardFilterWithFallbacks, setStandardFilter } from "../../currentViewStore/store";
 import {
   StandardFilter as StandardFilterData,
   infoStandardFilterTypes,

--- a/src/web/view/components/Filter/StandardFilter.tsx
+++ b/src/web/view/components/Filter/StandardFilter.tsx
@@ -9,7 +9,7 @@ import { NodeSelect } from "../../../common/components/Form/NodeSelect";
 import { Select } from "../../../common/components/Form/Select";
 import { deepIsEqual } from "../../../common/store/utils";
 import { useCriteria, useNodesOfType, useSolutions } from "../../../topic/store/nodeHooks";
-import { getStandardFilterWithFallbacks, setStandardFilter } from "../../currentViewStore/store";
+import { getStandardFilterWithFallbacks, setStandardFilter } from "../../currentViewStore/filter";
 import {
   StandardFilter as StandardFilterData,
   infoStandardFilterTypes,

--- a/src/web/view/components/Filter/TableFilters.tsx
+++ b/src/web/view/components/Filter/TableFilters.tsx
@@ -7,7 +7,7 @@ import { FormContext } from "../../../common/components/Form/FormContext";
 import { NodeSelect } from "../../../common/components/Form/NodeSelect";
 import { deepIsEqual } from "../../../common/store/utils";
 import { useCriteria, useNodesOfType, useSolutions } from "../../../topic/store/nodeHooks";
-import { setTableFilter, useTableFilterWithFallbacks } from "../../navigateStore";
+import { setTableFilter, useTableFilterWithFallbacks } from "../../currentViewStore/store";
 import { TableFilter, tableFilterSchema } from "../../utils/tableFilter";
 
 export const TableFilters = () => {

--- a/src/web/view/components/Filter/TableFilters.tsx
+++ b/src/web/view/components/Filter/TableFilters.tsx
@@ -7,7 +7,7 @@ import { FormContext } from "../../../common/components/Form/FormContext";
 import { NodeSelect } from "../../../common/components/Form/NodeSelect";
 import { deepIsEqual } from "../../../common/store/utils";
 import { useCriteria, useNodesOfType, useSolutions } from "../../../topic/store/nodeHooks";
-import { setTableFilter, useTableFilterWithFallbacks } from "../../currentViewStore/store";
+import { setTableFilter, useTableFilterWithFallbacks } from "../../currentViewStore/filter";
 import { TableFilter, tableFilterSchema } from "../../utils/tableFilter";
 
 export const TableFilters = () => {

--- a/src/web/view/currentViewStore/filter.ts
+++ b/src/web/view/currentViewStore/filter.ts
@@ -1,0 +1,239 @@
+import union from "lodash/union";
+import without from "lodash/without";
+import { shallow } from "zustand/shallow";
+
+import { InfoCategory } from "../../../common/infoCategory";
+import { infoNodeTypes } from "../../../common/node";
+import { emitter } from "../../common/event";
+import { getDefaultNode } from "../../topic/store/nodeGetters";
+import { useTopicStore } from "../../topic/store/store";
+import { findNodeOrThrow } from "../../topic/utils/graph";
+import { neighbors } from "../../topic/utils/node";
+import { DiagramFilter, StandardFilter, StandardFilterWithFallbacks } from "../utils/diagramFilter";
+import { GeneralFilter } from "../utils/generalFilter";
+import { TableFilter } from "../utils/tableFilter";
+import { useCurrentViewStore } from "./store";
+
+// hooks
+const useCategoriesToShow = () => {
+  return useCurrentViewStore((state) => state.categoriesToShow, shallow);
+};
+
+const useStandardFilter = (category: InfoCategory) => {
+  return useCurrentViewStore((state) => state[`${category}Filter`], shallow);
+};
+
+export const useDiagramFilter = (): DiagramFilter => {
+  const categoriesToShow = useCategoriesToShow();
+  const structureFilter = useStandardFilter("structure");
+  const researchFilter = useStandardFilter("research");
+  const justificationFilter = useStandardFilter("justification");
+
+  return {
+    structure: { show: categoriesToShow.includes("structure"), ...structureFilter },
+    research: { show: categoriesToShow.includes("research"), ...researchFilter },
+    justification: { show: categoriesToShow.includes("justification"), ...justificationFilter },
+  };
+};
+
+export const useTableFilter = (): TableFilter => {
+  return useCurrentViewStore(
+    (state) => state.tableFilter,
+    (before, after) => JSON.stringify(before) === JSON.stringify(after)
+  );
+};
+
+export const useTableFilterWithFallbacks = (): TableFilter => {
+  const tableFilter = useTableFilter();
+
+  const centralProblemId = getDefaultNode("problem")?.id;
+
+  const tableFilterDefaults = {
+    centralProblemId,
+    solutions: [],
+    criteria: [],
+  };
+
+  return { ...tableFilterDefaults, ...tableFilter };
+};
+
+export const useGeneralFilter = () => {
+  return useCurrentViewStore((state) => state.generalFilter);
+};
+
+export const useIsNodeForcedToShow = (nodeId: string) => {
+  return useCurrentViewStore((state) => state.generalFilter.nodesToShow.includes(nodeId));
+};
+
+export const usePrimaryNodeTypes = () => {
+  return useCurrentViewStore((state) => {
+    return state.categoriesToShow.flatMap((category) => infoNodeTypes[category]);
+  });
+};
+
+export const useShowImpliedEdges = () => {
+  return useCurrentViewStore((state) => state.showImpliedEdges);
+};
+
+// actions
+export const setShowInformation = (category: InfoCategory, show: boolean) => {
+  const oldCategoriesToShow = useCurrentViewStore.getState().categoriesToShow;
+
+  const newCategoriesToShow =
+    show && !oldCategoriesToShow.includes(category)
+      ? [...oldCategoriesToShow, category]
+      : !show && oldCategoriesToShow.includes(category)
+      ? oldCategoriesToShow.filter((c) => c !== category)
+      : null;
+
+  if (newCategoriesToShow) {
+    useCurrentViewStore.setState(
+      { categoriesToShow: newCategoriesToShow },
+      false,
+      "setShowInformation"
+    );
+    emitter.emit("changedDiagramFilter");
+  }
+};
+
+export const setStandardFilter = (category: InfoCategory, filter: StandardFilter) => {
+  const newFilter =
+    category === "structure"
+      ? { structureFilter: filter }
+      : category === "research"
+      ? { researchFilter: filter }
+      : { justificationFilter: filter };
+
+  useCurrentViewStore.setState(newFilter, false, "setStandardFilter");
+
+  emitter.emit("changedDiagramFilter");
+};
+
+export const setTableFilter = (tableFilter: TableFilter) => {
+  useCurrentViewStore.setState({ tableFilter }, false, "setTableFilter");
+};
+
+export const setGeneralFilter = (generalFilter: GeneralFilter) => {
+  useCurrentViewStore.setState({ generalFilter }, false, "setGeneralFilter");
+  emitter.emit("changedDiagramFilter");
+};
+
+export const viewCriteriaTable = (problemNodeId: string) => {
+  useCurrentViewStore.setState(
+    {
+      format: "table",
+      tableFilter: {
+        centralProblemId: problemNodeId,
+        solutions: [],
+        criteria: [],
+      },
+    },
+    false,
+    "viewCriteriaTable"
+  );
+};
+
+export const viewJustification = (arguedDiagramPartId: string) => {
+  useCurrentViewStore.setState(
+    {
+      format: "diagram",
+      categoriesToShow: ["justification"],
+      justificationFilter: { type: "rootClaim", centralRootClaimId: arguedDiagramPartId },
+    },
+    false,
+    "viewJustification"
+  );
+};
+
+/**
+ * @param also true if these nodes should be added to the current filter, false if they should be the only nodes displayed
+ */
+export const showNodeAndNeighbors = (nodeId: string, also: boolean) => {
+  const { categoriesToShow, generalFilter } = useCurrentViewStore.getState();
+  const graph = useTopicStore.getState();
+  const node = findNodeOrThrow(nodeId, graph.nodes);
+
+  const nodeAndNeighbors = [nodeId, ...neighbors(node, graph).map((neighbor) => neighbor.id)];
+
+  useCurrentViewStore.setState({
+    format: "diagram",
+    categoriesToShow: also ? categoriesToShow : [],
+    generalFilter: {
+      ...generalFilter,
+      nodesToShow: also ? union(generalFilter.nodesToShow, nodeAndNeighbors) : nodeAndNeighbors,
+      nodesToHide: without(generalFilter.nodesToHide, ...nodeAndNeighbors),
+    },
+  });
+
+  emitter.emit("changedDiagramFilter");
+};
+
+export const stopForcingNodeToShow = (nodeId: string) => {
+  const generalFilter = useCurrentViewStore.getState().generalFilter;
+
+  useCurrentViewStore.setState({
+    generalFilter: {
+      ...generalFilter,
+      nodesToShow: without(generalFilter.nodesToShow, nodeId),
+    },
+  });
+};
+
+export const showNode = (nodeId: string) => {
+  const generalFilter = useCurrentViewStore.getState().generalFilter;
+
+  useCurrentViewStore.setState({
+    generalFilter: {
+      ...generalFilter,
+      nodesToShow: union(generalFilter.nodesToShow, [nodeId]),
+      nodesToHide: without(generalFilter.nodesToHide, nodeId),
+    },
+  });
+
+  emitter.emit("changedDiagramFilter");
+};
+
+export const hideNode = (nodeId: string) => {
+  const generalFilter = useCurrentViewStore.getState().generalFilter;
+
+  useCurrentViewStore.setState({
+    generalFilter: {
+      ...generalFilter,
+      nodesToShow: without(generalFilter.nodesToShow, nodeId),
+      nodesToHide: union(generalFilter.nodesToHide, [nodeId]),
+    },
+  });
+
+  emitter.emit("changedDiagramFilter");
+};
+
+export const toggleShowImpliedEdges = (show: boolean) => {
+  useCurrentViewStore.setState({ showImpliedEdges: show });
+
+  emitter.emit("changedDiagramFilter");
+};
+
+// helpers
+export const getStandardFilterWithFallbacks = (standardFilter: StandardFilter): StandardFilter => {
+  const centralProblemId = getDefaultNode("problem")?.id;
+  const centralSolutionId = getDefaultNode("solution")?.id;
+  const centralQuestionId = getDefaultNode("question")?.id;
+  const centralSourceId = getDefaultNode("source")?.id;
+  const centralRootClaimId = getDefaultNode("rootClaim")?.id;
+
+  const standardFilterDefaults: StandardFilterWithFallbacks = {
+    type: "none",
+    centralProblemId,
+    problemDetails: ["causes", "effects", "subproblems", "criteria", "solutions"],
+    centralSolutionId,
+    solutionDetail: "all",
+    solutions: [],
+    criteria: [],
+    centralQuestionId,
+    centralSourceId,
+    centralRootClaimId,
+  };
+
+  // override any defaults using the stored filter
+  return { ...standardFilterDefaults, ...standardFilter };
+};

--- a/src/web/view/currentViewStore/layout.ts
+++ b/src/web/view/currentViewStore/layout.ts
@@ -1,0 +1,19 @@
+import { useCurrentViewStore } from "./store";
+
+// hooks
+export const useForceNodesIntoLayers = () => {
+  return useCurrentViewStore((state) => state.forceNodesIntoLayers);
+};
+
+export const useLayoutThoroughness = () => {
+  return useCurrentViewStore((state) => state.layoutThoroughness);
+};
+
+// actions
+export const toggleForceNodesIntoLayers = (force: boolean) => {
+  useCurrentViewStore.setState({ forceNodesIntoLayers: force });
+};
+
+export const setLayoutThoroughness = (thoroughness: number) => {
+  useCurrentViewStore.setState({ layoutThoroughness: thoroughness });
+};

--- a/src/web/view/currentViewStore/store.ts
+++ b/src/web/view/currentViewStore/store.ts
@@ -31,6 +31,13 @@ interface CurrentViewStoreState {
 
   tableFilter: TableFilter;
   generalFilter: GeneralFilter;
+
+  // infrequent options
+  showImpliedEdges: boolean;
+
+  // layout
+  forceNodesIntoLayers: boolean;
+  layoutThoroughness: number;
 }
 
 const initialState: CurrentViewStoreState = {
@@ -56,11 +63,16 @@ const initialState: CurrentViewStoreState = {
     showSecondaryResearch: false,
     showSecondaryStructure: true,
   },
+
+  showImpliedEdges: false,
+
+  forceNodesIntoLayers: true,
+  layoutThoroughness: 1, // by default, prefer keeping node types together over keeping parents close to children
 };
 
 const persistedNameBase = "navigateStore";
 
-const useCurrentViewStore = createWithEqualityFn<CurrentViewStoreState>()(
+export const useCurrentViewStore = createWithEqualityFn<CurrentViewStoreState>()(
   temporal(
     persist(
       devtools(() => initialState),
@@ -160,6 +172,10 @@ export const usePrimaryNodeTypes = () => {
   return useCurrentViewStore((state) => {
     return state.categoriesToShow.flatMap((category) => infoNodeTypes[category]);
   });
+};
+
+export const useShowImpliedEdges = () => {
+  return useCurrentViewStore((state) => state.showImpliedEdges);
 };
 
 export const useCanGoBackForward = () => {
@@ -306,6 +322,12 @@ export const hideNode = (nodeId: string) => {
       nodesToHide: union(generalFilter.nodesToHide, [nodeId]),
     },
   });
+
+  emitter.emit("changedDiagramFilter");
+};
+
+export const toggleShowImpliedEdges = (show: boolean) => {
+  useCurrentViewStore.setState({ showImpliedEdges: show });
 
   emitter.emit("changedDiagramFilter");
 };

--- a/src/web/view/currentViewStore/store.ts
+++ b/src/web/view/currentViewStore/store.ts
@@ -1,4 +1,3 @@
-import mergeWith from "lodash/mergeWith";
 import { temporal } from "zundo";
 import { useStore } from "zustand";
 import { devtools, persist } from "zustand/middleware";
@@ -6,6 +5,7 @@ import { createWithEqualityFn } from "zustand/traditional";
 
 import { Format, InfoCategory } from "../../../common/infoCategory";
 import { nodeTypes } from "../../../common/node";
+import { withDefaults } from "../../../common/object";
 import { emitter } from "../../common/event";
 import { useGraphPart } from "../../topic/store/graphPartHooks";
 import { StandardFilter } from "../utils/diagramFilter";
@@ -141,12 +141,6 @@ export const resetView = (keepHistory = false) => {
   if (!keepHistory) useCurrentViewStore.temporal.getState().clear();
 
   emitter.emit("changedDiagramFilter");
-};
-
-const withDefaults = <T>(value: Partial<T>, defaultValue: T): T => {
-  // thanks https://stackoverflow.com/a/66247134/8409296
-  // empty object to avoid mutation
-  return mergeWith({}, defaultValue, value, (_a, b) => (Array.isArray(b) ? b : undefined));
 };
 
 export const loadView = async (persistId: string) => {

--- a/src/web/view/currentViewStore/store.ts
+++ b/src/web/view/currentViewStore/store.ts
@@ -1,21 +1,14 @@
 import mergeWith from "lodash/mergeWith";
-import union from "lodash/union";
-import without from "lodash/without";
 import { temporal } from "zundo";
 import { useStore } from "zustand";
 import { devtools, persist } from "zustand/middleware";
-import { shallow } from "zustand/shallow";
 import { createWithEqualityFn } from "zustand/traditional";
 
 import { Format, InfoCategory } from "../../../common/infoCategory";
-import { infoNodeTypes, nodeTypes } from "../../../common/node";
+import { nodeTypes } from "../../../common/node";
 import { emitter } from "../../common/event";
 import { useGraphPart } from "../../topic/store/graphPartHooks";
-import { getDefaultNode } from "../../topic/store/nodeGetters";
-import { useTopicStore } from "../../topic/store/store";
-import { findNodeOrThrow } from "../../topic/utils/graph";
-import { neighbors } from "../../topic/utils/node";
-import { DiagramFilter, StandardFilter, StandardFilterWithFallbacks } from "../utils/diagramFilter";
+import { StandardFilter } from "../utils/diagramFilter";
 import { GeneralFilter } from "../utils/generalFilter";
 import { TableFilter } from "../utils/tableFilter";
 
@@ -118,66 +111,6 @@ export const useFormat = () => {
   return useCurrentViewStore((state) => state.format);
 };
 
-const useCategoriesToShow = () => {
-  return useCurrentViewStore((state) => state.categoriesToShow, shallow);
-};
-
-const useStandardFilter = (category: InfoCategory) => {
-  return useCurrentViewStore((state) => state[`${category}Filter`], shallow);
-};
-
-export const useDiagramFilter = (): DiagramFilter => {
-  const categoriesToShow = useCategoriesToShow();
-  const structureFilter = useStandardFilter("structure");
-  const researchFilter = useStandardFilter("research");
-  const justificationFilter = useStandardFilter("justification");
-
-  return {
-    structure: { show: categoriesToShow.includes("structure"), ...structureFilter },
-    research: { show: categoriesToShow.includes("research"), ...researchFilter },
-    justification: { show: categoriesToShow.includes("justification"), ...justificationFilter },
-  };
-};
-
-export const useTableFilter = (): TableFilter => {
-  return useCurrentViewStore(
-    (state) => state.tableFilter,
-    (before, after) => JSON.stringify(before) === JSON.stringify(after)
-  );
-};
-
-export const useTableFilterWithFallbacks = (): TableFilter => {
-  const tableFilter = useTableFilter();
-
-  const centralProblemId = getDefaultNode("problem")?.id;
-
-  const tableFilterDefaults = {
-    centralProblemId,
-    solutions: [],
-    criteria: [],
-  };
-
-  return { ...tableFilterDefaults, ...tableFilter };
-};
-
-export const useGeneralFilter = () => {
-  return useCurrentViewStore((state) => state.generalFilter);
-};
-
-export const useIsNodeForcedToShow = (nodeId: string) => {
-  return useCurrentViewStore((state) => state.generalFilter.nodesToShow.includes(nodeId));
-};
-
-export const usePrimaryNodeTypes = () => {
-  return useCurrentViewStore((state) => {
-    return state.categoriesToShow.flatMap((category) => infoNodeTypes[category]);
-  });
-};
-
-export const useShowImpliedEdges = () => {
-  return useCurrentViewStore((state) => state.showImpliedEdges);
-};
-
 export const useCanGoBackForward = () => {
   const temporalStore = useTemporalStore();
 
@@ -193,143 +126,6 @@ export const setSelected = (graphPartId: string | null) => {
 
 export const setFormat = (format: Format) => {
   useCurrentViewStore.setState({ format }, false, "setFormat");
-};
-
-export const setShowInformation = (category: InfoCategory, show: boolean) => {
-  const oldCategoriesToShow = useCurrentViewStore.getState().categoriesToShow;
-
-  const newCategoriesToShow =
-    show && !oldCategoriesToShow.includes(category)
-      ? [...oldCategoriesToShow, category]
-      : !show && oldCategoriesToShow.includes(category)
-      ? oldCategoriesToShow.filter((c) => c !== category)
-      : null;
-
-  if (newCategoriesToShow) {
-    useCurrentViewStore.setState(
-      { categoriesToShow: newCategoriesToShow },
-      false,
-      "setShowInformation"
-    );
-    emitter.emit("changedDiagramFilter");
-  }
-};
-
-export const setStandardFilter = (category: InfoCategory, filter: StandardFilter) => {
-  const newFilter =
-    category === "structure"
-      ? { structureFilter: filter }
-      : category === "research"
-      ? { researchFilter: filter }
-      : { justificationFilter: filter };
-
-  useCurrentViewStore.setState(newFilter, false, "setStandardFilter");
-
-  emitter.emit("changedDiagramFilter");
-};
-
-export const setTableFilter = (tableFilter: TableFilter) => {
-  useCurrentViewStore.setState({ tableFilter }, false, "setTableFilter");
-};
-
-export const setGeneralFilter = (generalFilter: GeneralFilter) => {
-  useCurrentViewStore.setState({ generalFilter }, false, "setGeneralFilter");
-  emitter.emit("changedDiagramFilter");
-};
-
-export const viewCriteriaTable = (problemNodeId: string) => {
-  useCurrentViewStore.setState(
-    {
-      format: "table",
-      tableFilter: {
-        centralProblemId: problemNodeId,
-        solutions: [],
-        criteria: [],
-      },
-    },
-    false,
-    "viewCriteriaTable"
-  );
-};
-
-export const viewJustification = (arguedDiagramPartId: string) => {
-  useCurrentViewStore.setState(
-    {
-      format: "diagram",
-      categoriesToShow: ["justification"],
-      justificationFilter: { type: "rootClaim", centralRootClaimId: arguedDiagramPartId },
-    },
-    false,
-    "viewJustification"
-  );
-};
-
-/**
- * @param also true if these nodes should be added to the current filter, false if they should be the only nodes displayed
- */
-export const showNodeAndNeighbors = (nodeId: string, also: boolean) => {
-  const { categoriesToShow, generalFilter } = useCurrentViewStore.getState();
-  const graph = useTopicStore.getState();
-  const node = findNodeOrThrow(nodeId, graph.nodes);
-
-  const nodeAndNeighbors = [nodeId, ...neighbors(node, graph).map((neighbor) => neighbor.id)];
-
-  useCurrentViewStore.setState({
-    format: "diagram",
-    categoriesToShow: also ? categoriesToShow : [],
-    generalFilter: {
-      ...generalFilter,
-      nodesToShow: also ? union(generalFilter.nodesToShow, nodeAndNeighbors) : nodeAndNeighbors,
-      nodesToHide: without(generalFilter.nodesToHide, ...nodeAndNeighbors),
-    },
-  });
-
-  emitter.emit("changedDiagramFilter");
-};
-
-export const stopForcingNodeToShow = (nodeId: string) => {
-  const generalFilter = useCurrentViewStore.getState().generalFilter;
-
-  useCurrentViewStore.setState({
-    generalFilter: {
-      ...generalFilter,
-      nodesToShow: without(generalFilter.nodesToShow, nodeId),
-    },
-  });
-};
-
-export const showNode = (nodeId: string) => {
-  const generalFilter = useCurrentViewStore.getState().generalFilter;
-
-  useCurrentViewStore.setState({
-    generalFilter: {
-      ...generalFilter,
-      nodesToShow: union(generalFilter.nodesToShow, [nodeId]),
-      nodesToHide: without(generalFilter.nodesToHide, nodeId),
-    },
-  });
-
-  emitter.emit("changedDiagramFilter");
-};
-
-export const hideNode = (nodeId: string) => {
-  const generalFilter = useCurrentViewStore.getState().generalFilter;
-
-  useCurrentViewStore.setState({
-    generalFilter: {
-      ...generalFilter,
-      nodesToShow: without(generalFilter.nodesToShow, nodeId),
-      nodesToHide: union(generalFilter.nodesToHide, [nodeId]),
-    },
-  });
-
-  emitter.emit("changedDiagramFilter");
-};
-
-export const toggleShowImpliedEdges = (show: boolean) => {
-  useCurrentViewStore.setState({ showImpliedEdges: show });
-
-  emitter.emit("changedDiagramFilter");
 };
 
 export const goBack = () => {
@@ -375,29 +171,4 @@ export const loadView = async (persistId: string) => {
 
   // it doesn't make sense to want to undo a page load
   useCurrentViewStore.temporal.getState().clear();
-};
-
-// helpers
-export const getStandardFilterWithFallbacks = (standardFilter: StandardFilter): StandardFilter => {
-  const centralProblemId = getDefaultNode("problem")?.id;
-  const centralSolutionId = getDefaultNode("solution")?.id;
-  const centralQuestionId = getDefaultNode("question")?.id;
-  const centralSourceId = getDefaultNode("source")?.id;
-  const centralRootClaimId = getDefaultNode("rootClaim")?.id;
-
-  const standardFilterDefaults: StandardFilterWithFallbacks = {
-    type: "none",
-    centralProblemId,
-    problemDetails: ["causes", "effects", "subproblems", "criteria", "solutions"],
-    centralSolutionId,
-    solutionDetail: "all",
-    solutions: [],
-    criteria: [],
-    centralQuestionId,
-    centralSourceId,
-    centralRootClaimId,
-  };
-
-  // override any defaults using the stored filter
-  return { ...standardFilterDefaults, ...standardFilter };
 };

--- a/src/web/view/navigateStore.ts
+++ b/src/web/view/navigateStore.ts
@@ -19,8 +19,6 @@ import { DiagramFilter, StandardFilter, StandardFilterWithFallbacks } from "./ut
 import { GeneralFilter } from "./utils/generalFilter";
 import { TableFilter } from "./utils/tableFilter";
 
-export type View = "topicDiagram" | "researchDiagram" | "criteriaTable" | "claimTree";
-
 interface NavigateStoreState {
   selectedGraphPartId: string | null;
   format: Format;

--- a/src/web/view/userConfigStore.ts
+++ b/src/web/view/userConfigStore.ts
@@ -1,0 +1,26 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface UserConfigStoreState {
+  fillNodesWithColor: boolean;
+}
+
+const initialState: UserConfigStoreState = {
+  fillNodesWithColor: false,
+};
+
+const useUserConfigStore = create<UserConfigStoreState>()(
+  persist(() => initialState, {
+    name: "user-config-storage",
+  })
+);
+
+// hooks
+export const useFillNodesWithColor = () => {
+  return useUserConfigStore((state) => state.fillNodesWithColor);
+};
+
+// actions
+export const toggleFillNodesWithColor = (fill: boolean) => {
+  useUserConfigStore.setState({ fillNodesWithColor: fill });
+};


### PR DESCRIPTION
### Description of changes

- mostly touchups, but main intention here is that a (future, soon) SavedView can now rely entirely on saving a CurrentViewStoreState, rather than grabbing config from elsewhere (e.g. layout config in action config store)

### Additional context

-
