### PR TITLE
fix: docs site postcss build error

### DIFF
--- a/docs-site/postcss.config.js
+++ b/docs-site/postcss.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: {},
+};


### PR DESCRIPTION
was caused by adding postcss in root nextjs project. added empty postcss config to prevent using postcss due to being configured in the root project.

### Description of changes

-

### Additional context

-
