### PR TITLE
fix: keeps old selected view after load

### DIFF
--- a/src/web/view/quickViewStore/store.ts
+++ b/src/web/view/quickViewStore/store.ts
@@ -266,9 +266,10 @@ export const loadQuickViewsFromApi = (topic: UserTopic, views: QuickView[]) => {
         order: view.order,
         viewState: view.viewState,
       })),
+      selectedViewId: null, // don't remember from previous topic - this will be set after loading current view if it should be
     },
     true,
-    "loadFromApi"
+    "loadQuickViewsFromApi"
   );
 
   // it doesn't make sense to want to undo a page load


### PR DESCRIPTION
reproduce by:
1. select quick view in topic A
2. switch to topic B, which has no quick views
3. make a view state change (e.g. turn force layers on/off)

observe "no view with id [id from topic A]" error in console

### Description of changes

-

### Additional context

-
