### PR TITLE
touchup: eye instead of eye-off for hidden nodes

### DIFF
--- a/src/web/topic/components/Node/NodeHandle.tsx
+++ b/src/web/topic/components/Node/NodeHandle.tsx
@@ -1,4 +1,4 @@
-import { VisibilityOff } from "@mui/icons-material";
+import { Visibility } from "@mui/icons-material";
 import { IconButton, Tooltip, Typography } from "@mui/material";
 import { ReactNode, memo } from "react";
 import { Position } from "reactflow";
@@ -64,7 +64,7 @@ const NodeHandleBase = ({ node, direction, orientation }: Props) => {
                 node={neighbor}
                 beforeSlot={
                   <IconButton className="p-0" onClick={() => showNode(neighbor.id)}>
-                    {<VisibilityOff />}
+                    {<Visibility />}
                   </IconButton>
                 }
               />


### PR DESCRIPTION
argument being that reveal-password buttons use this strategy. argument against could be that reveal-password buttons always work with asterisks, which indicate the password is being hidden, and the blue handle indicator isn't as obvious at showing hiddenness. But really it could go either way.

### Description of changes

-

### Additional context

-
