### PR TITLE
feat: include views in download/upload

### DIFF
--- a/src/web/topic/components/Surface/MoreActionsDrawer.tsx
+++ b/src/web/topic/components/Surface/MoreActionsDrawer.tsx
@@ -26,11 +26,8 @@ import {
   Typography,
 } from "@mui/material";
 import { toPng } from "html-to-image";
-import fileDownload from "js-file-download";
 import { getRectOfNodes, getTransformForBounds } from "reactflow";
-import { StorageValue } from "zustand/middleware";
 
-import { errorWithData } from "../../../../common/errorHandling";
 import { NumberInput } from "../../../common/components/NumberInput/NumberInput";
 import {
   toggleFlashlightMode,
@@ -49,48 +46,10 @@ import {
 import { resetView, useFormat } from "../../../view/currentViewStore/store";
 import { resetQuickViews } from "../../../view/quickViewStore/store";
 import { toggleFillNodesWithColor, useFillNodesWithColor } from "../../../view/userConfigStore";
-import { migrate } from "../../store/migrate";
-import { TopicStoreState } from "../../store/store";
+import { downloadTopic, uploadTopic } from "../../loadStores";
 import { useOnPlayground } from "../../store/topicHooks";
-import { getPersistState, resetTopicData, setTopicData } from "../../store/utilActions";
-import { getTopicTitle } from "../../store/utils";
+import { resetTopicData } from "../../store/utilActions";
 import { getDisplayNodes } from "../Diagram/externalFlowStore";
-
-// TODO: might be useful to have downloaded state be more human editable;
-// for this, probably should prettify the JSON, and remove position values (we can re-layout on import)
-const downloadTopic = () => {
-  const persistState = getPersistState();
-
-  const topicState = persistState.state;
-  const topicTitle = getTopicTitle(topicState);
-  const sanitizedFileName = topicTitle.replace(/[^a-z0-9]/gi, "_").toLowerCase(); // thanks https://stackoverflow.com/a/8485137
-
-  fileDownload(JSON.stringify(persistState), `${sanitizedFileName}.json`);
-};
-
-const uploadTopic = (event: React.ChangeEvent<HTMLInputElement>, sessionUsername?: string) => {
-  if (event.target.files === null) return;
-
-  const file = event.target.files[0];
-  if (!file) return;
-
-  file
-    .text()
-    .then((text) => {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- TODO: validate that JSON matches interface
-      const persistState = JSON.parse(text) as StorageValue<TopicStoreState>;
-      if (!persistState.version) {
-        throw errorWithData("No version found in file, cannot migrate old state", persistState);
-      }
-
-      const migratedState = migrate(persistState.state, persistState.version) as TopicStoreState;
-
-      setTopicData(migratedState, sessionUsername);
-    })
-    .catch((error: unknown) => {
-      throw error;
-    });
-};
 
 const imageWidth = 2560;
 const imageHeight = 1440;

--- a/src/web/topic/loadStores.ts
+++ b/src/web/topic/loadStores.ts
@@ -1,0 +1,105 @@
+/**
+ * Logic related to loading/unloading stores.
+ *
+ * Intended to be cross-module e.g. load/unload topic store, view store, with intent that `/web/topic`
+ * might become a cross-module place for topic-related things (and the current `topic` verbiage as in
+ * `TopicStore` can be reworded to something more narrow).
+ */
+
+import fileDownload from "js-file-download";
+import { z } from "zod";
+import { StorageValue } from "zustand/middleware";
+
+import { errorWithData } from "../../common/errorHandling";
+import {
+  QuickViewStoreState,
+  currentVersion as currentViewsVersion,
+  getPersistState as getViewsPersistState,
+  initialStateWithBasicViews,
+  loadQuickViewsFromDownloaded,
+} from "../view/quickViewStore/store";
+import { migrate } from "./store/migrate";
+import { TopicStoreState } from "./store/store";
+import { getPersistState, setTopicData } from "./store/utilActions";
+import { getTopicTitle } from "./store/utils";
+
+const oldDownloadSchema1 = z.object({
+  state: z.record(z.any()),
+  version: z.number(),
+});
+
+const downloadJsonSchema = z.preprocess(
+  (val) => {
+    if (oldDownloadSchema1.safeParse(val).success) {
+      return {
+        topic: val,
+        views: { state: initialStateWithBasicViews(), version: currentViewsVersion },
+      };
+    } else return val;
+  },
+  z.object({
+    topic: z.object({
+      state: z.record(z.any()), // z.record() because without it will result in optional `state`, see https://github.com/colinhacks/zod/issues/1628
+      version: z.number(),
+    }),
+    views: z.object({
+      state: z.record(z.any()),
+      version: z.number(),
+    }),
+  })
+);
+
+interface DownloadJson {
+  topic: StorageValue<TopicStoreState>;
+  views: StorageValue<QuickViewStoreState>;
+}
+
+// TODO: might be useful to have downloaded state be more human editable;
+// for this, probably should prettify the JSON, and remove position values (we can re-layout on import)
+export const downloadTopic = () => {
+  const topicPersistState = getPersistState();
+  const viewsPersistState = getViewsPersistState();
+
+  const topicState = topicPersistState.state;
+  const topicTitle = getTopicTitle(topicState);
+  const sanitizedFileName = topicTitle.replace(/[^a-z0-9]/gi, "_").toLowerCase(); // thanks https://stackoverflow.com/a/8485137
+
+  const downloadJson = { topic: topicPersistState, views: viewsPersistState };
+
+  fileDownload(JSON.stringify(downloadJson), `${sanitizedFileName}.json`);
+};
+
+export const uploadTopic = (
+  event: React.ChangeEvent<HTMLInputElement>,
+  sessionUsername?: string
+) => {
+  if (event.target.files === null) return;
+
+  const file = event.target.files[0];
+  if (!file) return;
+
+  file
+    .text()
+    .then((text) => {
+      const downloadJson = downloadJsonSchema.parse(JSON.parse(text)) as DownloadJson;
+
+      const topicPersistState = downloadJson.topic;
+      if (!topicPersistState.version) {
+        throw errorWithData(
+          "No version found in file, cannot migrate old state",
+          topicPersistState
+        );
+      }
+      const migratedState = migrate(
+        topicPersistState.state,
+        topicPersistState.version
+      ) as TopicStoreState;
+      setTopicData(migratedState, sessionUsername);
+
+      const viewsPersistState = downloadJson.views;
+      loadQuickViewsFromDownloaded(viewsPersistState.state); // TODO: migrate when quick views have migrations
+    })
+    .catch((error: unknown) => {
+      throw error;
+    });
+};

--- a/src/web/topic/store/migrate.ts
+++ b/src/web/topic/store/migrate.ts
@@ -27,6 +27,7 @@ export const migrate = (persistedState: any, version: number) => {
     migrate_18_to_19,
     migrate_19_to_20,
     migrate_20_to_21,
+    migrate_21_to_22,
   ];
 
   let state = persistedState;
@@ -484,5 +485,31 @@ interface FromState20 {
 
 const migrate_20_to_21 = (state: FromState20) => {
   delete state.showImpliedEdges;
+  return state;
+};
+
+interface FromState21 {
+  nodes: Record<string, never>[];
+  edges: Record<string, never>[];
+}
+
+interface Node22 {
+  data: {
+    notes: string;
+  };
+}
+
+interface Edge22 {
+  data: {
+    notes: string;
+  };
+}
+
+// don't remember when notes was added, but we never defaulted it via migration, and we really on notes.length,
+// so we're migrating it now
+const migrate_21_to_22 = (state: FromState21) => {
+  state.nodes.forEach((node) => ((node as unknown as Node22).data.notes = ""));
+  state.edges.forEach((edge) => ((edge as unknown as Edge22).data.notes = ""));
+
   return state;
 };

--- a/src/web/topic/store/store.ts
+++ b/src/web/topic/store/store.ts
@@ -75,7 +75,7 @@ export const useTopicStore = createWithEqualityFn<TopicStoreState>()(
   apiSyncer(
     persist(temporal(devtools(() => initialState, { name: topicStorePlaygroundName })), {
       name: topicStorePlaygroundName,
-      version: 21,
+      version: 22,
       migrate: migrate,
       skipHydration: true,
     })


### PR DESCRIPTION
also extract download/upload logic to /topic/loadStores.ts because there's a lot of logic involved for it to live in a component.

Closes #421 

### Description of changes

-

### Additional context

-
