### PR TITLE
refactor: use absolute file paths

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,7 @@
     "plugin:tailwindcss/recommended",
     "prettier"
   ],
-  "plugins": ["functional", "import"],
+  "plugins": ["functional", "import", "no-relative-import-paths"],
   "overrides": [
     // don't use ts checking for js files https://stackoverflow.com/a/64488475
     {
@@ -51,6 +51,14 @@
             "args": "all",
             "argsIgnorePattern": "^_",
             "varsIgnorePattern": "^_"
+          }
+        ],
+        "no-relative-import-paths/no-relative-import-paths": [
+          "error",
+          {
+            "allowSameFolder": false,
+            "rootDir": "src",
+            "prefix": "@"
           }
         ]
       }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
   "files.associations": {
     "*.css": "tailwindcss"
   },
+  "typescript.preferences.importModuleSpecifier": "non-relative",
   "[prisma]": {
     "editor.defaultFormatter": "Prisma.prisma"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,7 @@
         "eslint-config-prettier": "8.5.0",
         "eslint-plugin-functional": "^6.0.0",
         "eslint-plugin-import": "2.26.0",
+        "eslint-plugin-no-relative-import-paths": "1.5.4",
         "eslint-plugin-storybook": "0.6.7",
         "eslint-plugin-tailwindcss": "3.15.1",
         "execa": "7.1.1",
@@ -16607,6 +16608,12 @@
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
       }
+    },
+    "node_modules/eslint-plugin-no-relative-import-paths": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-relative-import-paths/-/eslint-plugin-no-relative-import-paths-1.5.4.tgz",
+      "integrity": "sha512-2smViH7R3682NR6dwgYr8Vm7emqNP1gEjBku6DbvUy3Ef/2Fz+mhwsFjZGSixzWzazMCj4MAgIWTsHELCCDJKA==",
+      "dev": true
     },
     "node_modules/eslint-plugin-react": {
       "version": "7.33.2",
@@ -41736,6 +41743,12 @@
         "object.entries": "^1.1.7",
         "object.fromentries": "^2.0.7"
       }
+    },
+    "eslint-plugin-no-relative-import-paths": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-relative-import-paths/-/eslint-plugin-no-relative-import-paths-1.5.4.tgz",
+      "integrity": "sha512-2smViH7R3682NR6dwgYr8Vm7emqNP1gEjBku6DbvUy3Ef/2Fz+mhwsFjZGSixzWzazMCj4MAgIWTsHELCCDJKA==",
+      "dev": true
     },
     "eslint-plugin-react": {
       "version": "7.33.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,6 +100,7 @@
         "tailwindcss": "3.4.3",
         "tsx": "4.11.0",
         "typescript": "5.4.5",
+        "vite-tsconfig-paths": "^4.3.2",
         "vitest": "0.34.6",
         "yargs": "17.7.2"
       }
@@ -18326,6 +18327,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -28075,6 +28082,26 @@
       "integrity": "sha512-pefrkcd4lmIVR0LA49Imjf9DYLK8vtWhqBPA3Ya1ir8xCW0O2yjL9dsCVvI7pCodLC5q7smNpEtDR2yVulQxOg==",
       "dev": true
     },
+    "node_modules/tsconfck": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.0.tgz",
+      "integrity": "sha512-CMjc5zMnyAjcS9sPLytrbFmj89st2g+JYtY/c02ug4Q+CZaAtCgbyviI0n1YvjZE/pzoc6FbNsINS13DOL1B9w==",
+      "dev": true,
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -29310,6 +29337,25 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-4.3.2.tgz",
+      "integrity": "sha512-0Vd/a6po6Q+86rPlntHye7F31zA2URZMbH8M3saAZ/xR9QoGN/L21bxEGfXdWmFdNkqPpRdxFT7nmNe12e9/uA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite/node_modules/esbuild": {
@@ -43066,6 +43112,12 @@
         "slash": "^3.0.0"
       }
     },
+    "globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
+    },
     "gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -50162,6 +50214,12 @@
       "integrity": "sha512-pefrkcd4lmIVR0LA49Imjf9DYLK8vtWhqBPA3Ya1ir8xCW0O2yjL9dsCVvI7pCodLC5q7smNpEtDR2yVulQxOg==",
       "dev": true
     },
+    "tsconfck": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.0.tgz",
+      "integrity": "sha512-CMjc5zMnyAjcS9sPLytrbFmj89st2g+JYtY/c02ug4Q+CZaAtCgbyviI0n1YvjZE/pzoc6FbNsINS13DOL1B9w==",
+      "dev": true
+    },
     "tsconfig-paths": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -51051,6 +51109,17 @@
         "pathe": "^1.1.1",
         "picocolors": "^1.0.0",
         "vite": "^3.0.0 || ^4.0.0 || ^5.0.0-0"
+      }
+    },
+    "vite-tsconfig-paths": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-4.3.2.tgz",
+      "integrity": "sha512-0Vd/a6po6Q+86rPlntHye7F31zA2URZMbH8M3saAZ/xR9QoGN/L21bxEGfXdWmFdNkqPpRdxFT7nmNe12e9/uA==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
       }
     },
     "vitest": {

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "tailwindcss": "3.4.3",
     "tsx": "4.11.0",
     "typescript": "5.4.5",
+    "vite-tsconfig-paths": "^4.3.2",
     "vitest": "0.34.6",
     "yargs": "17.7.2"
   }

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-functional": "^6.0.0",
     "eslint-plugin-import": "2.26.0",
+    "eslint-plugin-no-relative-import-paths": "1.5.4",
     "eslint-plugin-storybook": "0.6.7",
     "eslint-plugin-tailwindcss": "3.15.1",
     "execa": "7.1.1",

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,6 +1,6 @@
 import { TRPCError } from "@trpc/server";
 
-import { middleware } from "./trpc";
+import { middleware } from "@/api/trpc";
 
 export const isAuthenticated = middleware(async (opts) => {
   const { ctx } = opts;

--- a/src/api/context.ts
+++ b/src/api/context.ts
@@ -1,8 +1,8 @@
 import { inferAsyncReturnType } from "@trpc/server";
 import { CreateNextContextOptions } from "@trpc/server/adapters/next";
 
-import { xprisma } from "../db/extendedPrisma";
-import { auth0 } from "./initAuth0";
+import { auth0 } from "@/api/initAuth0";
+import { xprisma } from "@/db/extendedPrisma";
 
 export const createContext = async ({ req, res }: CreateNextContextOptions) => {
   const session = await auth0.getSession(req, res);

--- a/src/api/routers/_app.ts
+++ b/src/api/routers/_app.ts
@@ -1,8 +1,8 @@
-import { router } from "../trpc";
-import { commentRouter } from "./comment";
-import { topicRouter } from "./topic";
-import { userRouter } from "./user";
-import { viewRouter } from "./view";
+import { commentRouter } from "@/api/routers/comment";
+import { topicRouter } from "@/api/routers/topic";
+import { userRouter } from "@/api/routers/user";
+import { viewRouter } from "@/api/routers/view";
+import { router } from "@/api/trpc";
 
 export const appRouter = router({
   topic: topicRouter,

--- a/src/api/routers/comment.test.ts
+++ b/src/api/routers/comment.test.ts
@@ -3,9 +3,9 @@ import { Topic, User } from "@prisma/client";
 import shortUUID from "short-uuid";
 import { beforeEach, describe, expect, test } from "vitest";
 
-import { Comment } from "../../common/comment";
-import { xprisma } from "../../db/extendedPrisma";
-import { appRouter } from "./_app";
+import { appRouter } from "@/api/routers/_app";
+import { Comment } from "@/common/comment";
+import { xprisma } from "@/db/extendedPrisma";
 
 let creatorOfTopic: User;
 let notCreatorOfTopic: User;

--- a/src/api/routers/comment.ts
+++ b/src/api/routers/comment.ts
@@ -1,12 +1,12 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
-import { Comment, commentSchema, userCanDeleteComment } from "../../common/comment";
-import { topicSchema } from "../../common/topic";
-import { deepIsEqual } from "../../common/utils";
-import { xprisma } from "../../db/extendedPrisma";
-import { isLoggedIn } from "../auth";
-import { procedure, router } from "../trpc";
+import { isLoggedIn } from "@/api/auth";
+import { procedure, router } from "@/api/trpc";
+import { Comment, commentSchema, userCanDeleteComment } from "@/common/comment";
+import { topicSchema } from "@/common/topic";
+import { deepIsEqual } from "@/common/utils";
+import { xprisma } from "@/db/extendedPrisma";
 
 const isOnlyModifyingResolved = (commentToUpdate: Comment, foundComment: Comment) => {
   return (

--- a/src/api/routers/topic.test.ts
+++ b/src/api/routers/topic.test.ts
@@ -3,8 +3,8 @@ import { Topic, User } from "@prisma/client";
 import { v4 as uuid } from "uuid";
 import { beforeEach, describe, expect, test } from "vitest";
 
-import { xprisma } from "../../db/extendedPrisma";
-import { appRouter } from "./_app";
+import { appRouter } from "@/api/routers/_app";
+import { xprisma } from "@/db/extendedPrisma";
 
 let userWithTopics: User;
 let otherUser: User;

--- a/src/api/routers/topic.ts
+++ b/src/api/routers/topic.ts
@@ -2,15 +2,15 @@ import { TRPCError } from "@trpc/server";
 import _ from "lodash";
 import { z } from "zod";
 
-import { edgeSchema } from "../../common/edge";
-import { getNewTopicProblemNode, nodeSchema } from "../../common/node";
-import { topicSchema } from "../../common/topic";
-import { userSchema } from "../../common/user";
-import { userScoreSchema } from "../../common/userScore";
-import { quickViewSchema } from "../../common/view";
-import { xprisma } from "../../db/extendedPrisma";
-import { isLoggedIn } from "../auth";
-import { procedure, router } from "../trpc";
+import { isLoggedIn } from "@/api/auth";
+import { procedure, router } from "@/api/trpc";
+import { edgeSchema } from "@/common/edge";
+import { getNewTopicProblemNode, nodeSchema } from "@/common/node";
+import { topicSchema } from "@/common/topic";
+import { userSchema } from "@/common/user";
+import { userScoreSchema } from "@/common/userScore";
+import { quickViewSchema } from "@/common/view";
+import { xprisma } from "@/db/extendedPrisma";
 
 export const topicRouter = router({
   findByUsernameAndTitle: procedure

--- a/src/api/routers/user.test.ts
+++ b/src/api/routers/user.test.ts
@@ -2,8 +2,8 @@
 import { Topic, User } from "@prisma/client";
 import { beforeEach, describe, expect, test } from "vitest";
 
-import { xprisma } from "../../db/extendedPrisma";
-import { appRouter } from "./_app";
+import { appRouter } from "@/api/routers/_app";
+import { xprisma } from "@/db/extendedPrisma";
 
 let userWithTopics: User;
 let publicTopic: Topic;

--- a/src/api/routers/user.ts
+++ b/src/api/routers/user.ts
@@ -1,10 +1,10 @@
 import { TRPCError } from "@trpc/server";
 import _ from "lodash";
 
-import { userSchema } from "../../common/user";
-import { xprisma } from "../../db/extendedPrisma";
-import { isAuthenticated, isEmailVerified } from "../auth";
-import { procedure, router } from "../trpc";
+import { isAuthenticated, isEmailVerified } from "@/api/auth";
+import { procedure, router } from "@/api/trpc";
+import { userSchema } from "@/common/user";
+import { xprisma } from "@/db/extendedPrisma";
 
 export const userRouter = router({
   findByUsername: procedure

--- a/src/api/routers/view.ts
+++ b/src/api/routers/view.ts
@@ -1,11 +1,11 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
-import { topicSchema } from "../../common/topic";
-import { quickViewSchema } from "../../common/view";
-import { xprisma } from "../../db/extendedPrisma";
-import { isLoggedIn } from "../auth";
-import { procedure, router } from "../trpc";
+import { isLoggedIn } from "@/api/auth";
+import { procedure, router } from "@/api/trpc";
+import { topicSchema } from "@/common/topic";
+import { quickViewSchema } from "@/common/view";
+import { xprisma } from "@/db/extendedPrisma";
 
 export const viewRouter = router({
   handleChangesets: procedure

--- a/src/api/trpc.ts
+++ b/src/api/trpc.ts
@@ -1,7 +1,7 @@
 import { initTRPC } from "@trpc/server";
 import superjson from "superjson";
 
-import { Context } from "./context";
+import { Context } from "@/api/context";
 
 // Avoid exporting the entire t-object
 // since it's not very descriptive.

--- a/src/common/comment.ts
+++ b/src/common/comment.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
-import { topicSchema } from "./topic";
-import { userSchema } from "./user";
+import { topicSchema } from "@/common/topic";
+import { userSchema } from "@/common/user";
 
 export const commentParentTypes = ["topic", "node", "edge", "comment"] as const;
 export const zCommentParentTypes = z.enum(commentParentTypes);

--- a/src/common/edge.ts
+++ b/src/common/edge.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { InfoCategory } from "./infoCategory";
+import { InfoCategory } from "@/common/infoCategory";
 
 // not sure how to guarantee that this matches the schema enum
 export const relationNames = [

--- a/src/common/node.ts
+++ b/src/common/node.ts
@@ -2,7 +2,7 @@ import lowerCase from "lodash/lowerCase";
 import { v4 as uuid } from "uuid";
 import { z } from "zod";
 
-import { InfoCategory } from "./infoCategory";
+import { InfoCategory } from "@/common/infoCategory";
 
 // Not sure how to guarantee that this matches the schema enum.
 // This order is generally used for sorting, e.g.:

--- a/src/common/topic.ts
+++ b/src/common/topic.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
-import { reservedSecondLevelEndpointNames } from "./reservedEndpointNames";
-import { userSchema } from "./user";
+import { reservedSecondLevelEndpointNames } from "@/common/reservedEndpointNames";
+import { userSchema } from "@/common/user";
 
 // not sure how to guarantee that this matches the schema enum
 export const visibilityTypes = ["private", "unlisted", "public"] as const;

--- a/src/common/user.ts
+++ b/src/common/user.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { reservedFirstLevelEndpointNames } from "./reservedEndpointNames";
+import { reservedFirstLevelEndpointNames } from "@/common/reservedEndpointNames";
 
 export const userSchema = z.object({
   id: z.number(),

--- a/src/common/userScore.ts
+++ b/src/common/userScore.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { userSchema } from "./user";
+import { userSchema } from "@/common/user";
 
 export const userScoreSchema = z.object({
   username: userSchema.shape.username,

--- a/src/common/view.ts
+++ b/src/common/view.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { topicSchema } from "./topic";
+import { topicSchema } from "@/common/topic";
 
 export const savedViewTypes = ["shared", "quick"] as const;
 export const zSavedViewTypes = z.enum(savedViewTypes);

--- a/src/db/extendedPrisma.ts
+++ b/src/db/extendedPrisma.ts
@@ -1,4 +1,4 @@
-import { prisma } from "./basePrisma";
+import { prisma } from "@/db/basePrisma";
 
 // can add extensions like
 // export const xprisma = prisma.$extends(componentExtension).$extends(topicExtension);

--- a/src/pages/[username].page.tsx
+++ b/src/pages/[username].page.tsx
@@ -12,11 +12,11 @@ import Head from "next/head";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
 
-import { NotFoundError, QueryError } from "../web/common/components/Error/Error";
-import { Link } from "../web/common/components/Link";
-import { Loading } from "../web/common/components/Loading/Loading";
-import { useSessionUser } from "../web/common/hooks";
-import { trpc } from "../web/common/trpc";
+import { NotFoundError, QueryError } from "@/web/common/components/Error/Error";
+import { Link } from "@/web/common/components/Link";
+import { Loading } from "@/web/common/components/Loading/Loading";
+import { useSessionUser } from "@/web/common/hooks";
+import { trpc } from "@/web/common/trpc";
 
 type RowData = Topic;
 

--- a/src/pages/[username]/[topicTitle].page.tsx
+++ b/src/pages/[username]/[topicTitle].page.tsx
@@ -4,18 +4,18 @@ import Head from "next/head";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
-import { loadCommentsFromApi } from "../../web/comment/store/commentStore";
-import { loadDraftsFromLocalStorage } from "../../web/comment/store/draftStore";
-import { NotFoundError, QueryError } from "../../web/common/components/Error/Error";
-import { Loading } from "../../web/common/components/Loading/Loading";
-import { useSessionUser } from "../../web/common/hooks";
-import { trpc } from "../../web/common/trpc";
-import { populateDiagramFromApi } from "../../web/topic/store/loadActions";
-import { loadActionConfig } from "../../web/view/actionConfigStore";
-import { loadView } from "../../web/view/currentViewStore/store";
-import { loadMiscTopicConfig } from "../../web/view/miscTopicConfigStore";
-import { setInitialPerspective } from "../../web/view/perspectiveStore";
-import { QuickView, loadQuickViewsFromApi } from "../../web/view/quickViewStore/store";
+import { loadCommentsFromApi } from "@/web/comment/store/commentStore";
+import { loadDraftsFromLocalStorage } from "@/web/comment/store/draftStore";
+import { NotFoundError, QueryError } from "@/web/common/components/Error/Error";
+import { Loading } from "@/web/common/components/Loading/Loading";
+import { useSessionUser } from "@/web/common/hooks";
+import { trpc } from "@/web/common/trpc";
+import { populateDiagramFromApi } from "@/web/topic/store/loadActions";
+import { loadActionConfig } from "@/web/view/actionConfigStore";
+import { loadView } from "@/web/view/currentViewStore/store";
+import { loadMiscTopicConfig } from "@/web/view/miscTopicConfigStore";
+import { setInitialPerspective } from "@/web/view/perspectiveStore";
+import { QuickView, loadQuickViewsFromApi } from "@/web/view/quickViewStore/store";
 
 // Don't render the workspace server-side.
 // Known reasons:

--- a/src/pages/[username]/[topicTitle]/settings.page.tsx
+++ b/src/pages/[username]/[topicTitle]/settings.page.tsx
@@ -2,15 +2,11 @@ import { NextPage } from "next";
 import Head from "next/head";
 import { useRouter } from "next/router";
 
-import {
-  NotFoundError,
-  NotLoggedInError,
-  QueryError,
-} from "../../../web/common/components/Error/Error";
-import { Loading } from "../../../web/common/components/Loading/Loading";
-import { useSessionUser } from "../../../web/common/hooks";
-import { trpc } from "../../../web/common/trpc";
-import { EditTopicForm } from "../../../web/topic/components/TopicForm/TopicForm";
+import { NotFoundError, NotLoggedInError, QueryError } from "@/web/common/components/Error/Error";
+import { Loading } from "@/web/common/components/Loading/Loading";
+import { useSessionUser } from "@/web/common/hooks";
+import { trpc } from "@/web/common/trpc";
+import { EditTopicForm } from "@/web/topic/components/TopicForm/TopicForm";
 
 const TopicSettings: NextPage = () => {
   const router = useRouter();

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -6,11 +6,11 @@ import type { AppProps } from "next/app";
 import Head from "next/head";
 import { useEffect } from "react";
 
-import Layout from "../web/common/components/Layout";
-import { getThemeOptions } from "../web/common/theme";
-import { trpc } from "../web/common/trpc";
-import { globals } from "./_app.styles";
-import "../web/common/globals.css";
+import { globals } from "@/pages/_app.styles";
+import Layout from "@/web/common/components/Layout";
+import { getThemeOptions } from "@/web/common/theme";
+import { trpc } from "@/web/common/trpc";
+import "@/web/common/globals.css";
 
 // eslint-disable-next-line functional/no-let -- jank way to enable trpc queries outside of react tree, e.g. from zustand middleware https://github.com/trpc/trpc/discussions/2926#discussioncomment-5647033
 export let trpcClient = null as unknown as ReturnType<typeof trpc.useContext>["client"];

--- a/src/pages/api/auth/[...auth0].page.ts
+++ b/src/pages/api/auth/[...auth0].page.ts
@@ -1,8 +1,8 @@
 import { AfterCallback } from "@auth0/nextjs-auth0";
 import { UserProfile } from "@auth0/nextjs-auth0/client";
 
-import { auth0 } from "../../../api/initAuth0";
-import { xprisma } from "../../../db/extendedPrisma";
+import { auth0 } from "@/api/initAuth0";
+import { xprisma } from "@/db/extendedPrisma";
 
 const afterCallback: AfterCallback = async (_req, res, session, state) => {
   const userClaims = session.user as UserProfile;

--- a/src/pages/api/panel.page.ts
+++ b/src/pages/api/panel.page.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { renderTrpcPanel } from "trpc-panel";
 
-import { appRouter } from "../../api/routers/_app";
-import { getBaseUrl } from "../../common/utils";
+import { appRouter } from "@/api/routers/_app";
+import { getBaseUrl } from "@/common/utils";
 
 export default function handler(_: NextApiRequest, res: NextApiResponse) {
   res.status(200).send(

--- a/src/pages/api/trpc/[trpc].page.ts
+++ b/src/pages/api/trpc/[trpc].page.ts
@@ -1,7 +1,7 @@
 import * as trpcNext from "@trpc/server/adapters/next";
 
-import { createContext } from "../../../api/context";
-import { appRouter } from "../../../api/routers/_app";
+import { createContext } from "@/api/context";
+import { appRouter } from "@/api/routers/_app";
 
 // export API handler
 // @see https://trpc.io/docs/server/adapters

--- a/src/pages/choose-username.page.tsx
+++ b/src/pages/choose-username.page.tsx
@@ -6,10 +6,10 @@ import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
-import { userSchema } from "../common/user";
-import { Loading } from "../web/common/components/Loading/Loading";
-import { useSessionUser } from "../web/common/hooks";
-import { trpc } from "../web/common/trpc";
+import { userSchema } from "@/common/user";
+import { Loading } from "@/web/common/components/Loading/Loading";
+import { useSessionUser } from "@/web/common/hooks";
+import { trpc } from "@/web/common/trpc";
 
 // not sure if extracting the queries into a method is a good pattern, but it was
 // really annoying to have so much code to read through in the component

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -4,14 +4,15 @@ import type { NextPage } from "next";
 import Head from "next/head";
 import Image from "next/image";
 
+import { StyledBox, StyledCarousel } from "@/pages/index.style";
+import { Blog } from "@/web/common/components/Blog.styles";
+import { SubscribeForm } from "@/web/common/components/SubscribeForm/SubscribeForm";
+import { YoutubeEmbed } from "@/web/common/components/YoutubeEmbed/YoutubeEmbed";
+import { youtubeLivestreams } from "@/web/common/urls";
+
 import comparingSolutions from "../../public/Comparing-Solutions.png";
 import justifyingAndCritiquingClaims from "../../public/Justifying-And-Critiquing-Claims.png";
 import mappingSolutionsToProblems from "../../public/Mapping-Solutions-To-Problems.png";
-import { Blog } from "../web/common/components/Blog.styles";
-import { SubscribeForm } from "../web/common/components/SubscribeForm/SubscribeForm";
-import { YoutubeEmbed } from "../web/common/components/YoutubeEmbed/YoutubeEmbed";
-import { youtubeLivestreams } from "../web/common/urls";
-import { StyledBox, StyledCarousel } from "./index.style";
 
 const Home: NextPage = () => {
   return (

--- a/src/pages/new.page.tsx
+++ b/src/pages/new.page.tsx
@@ -1,10 +1,10 @@
 import { NextPage } from "next";
 import Head from "next/head";
 
-import { NotLoggedInError } from "../web/common/components/Error/Error";
-import { Loading } from "../web/common/components/Loading/Loading";
-import { useSessionUser } from "../web/common/hooks";
-import { CreateTopicForm } from "../web/topic/components/TopicForm/TopicForm";
+import { NotLoggedInError } from "@/web/common/components/Error/Error";
+import { Loading } from "@/web/common/components/Loading/Loading";
+import { useSessionUser } from "@/web/common/hooks";
+import { CreateTopicForm } from "@/web/topic/components/TopicForm/TopicForm";
 
 const NewTopic: NextPage = () => {
   const { sessionUser, isLoading: sessionUserIsLoading } = useSessionUser();

--- a/src/pages/playground.page.tsx
+++ b/src/pages/playground.page.tsx
@@ -3,16 +3,16 @@ import dynamic from "next/dynamic";
 import Head from "next/head";
 import { useEffect, useState } from "react";
 
-import { loadCommentsFromLocalStorage } from "../web/comment/store/commentStore";
-import { loadDraftsFromLocalStorage } from "../web/comment/store/draftStore";
-import { Loading } from "../web/common/components/Loading/Loading";
-import { populateDiagramFromLocalStorage } from "../web/topic/store/loadActions";
-import { playgroundUsername } from "../web/topic/store/store";
-import { loadActionConfig } from "../web/view/actionConfigStore";
-import { loadView } from "../web/view/currentViewStore/store";
-import { loadMiscTopicConfig } from "../web/view/miscTopicConfigStore";
-import { setInitialPerspective } from "../web/view/perspectiveStore";
-import { loadQuickViewsFromLocalStorage } from "../web/view/quickViewStore/store";
+import { loadCommentsFromLocalStorage } from "@/web/comment/store/commentStore";
+import { loadDraftsFromLocalStorage } from "@/web/comment/store/draftStore";
+import { Loading } from "@/web/common/components/Loading/Loading";
+import { populateDiagramFromLocalStorage } from "@/web/topic/store/loadActions";
+import { playgroundUsername } from "@/web/topic/store/store";
+import { loadActionConfig } from "@/web/view/actionConfigStore";
+import { loadView } from "@/web/view/currentViewStore/store";
+import { loadMiscTopicConfig } from "@/web/view/miscTopicConfigStore";
+import { setInitialPerspective } from "@/web/view/perspectiveStore";
+import { loadQuickViewsFromLocalStorage } from "@/web/view/quickViewStore/store";
 
 // Don't render the workspace server-side.
 // Known reasons:

--- a/src/web/comment/components/Comment.tsx
+++ b/src/web/comment/components/Comment.tsx
@@ -3,15 +3,15 @@ import { Check, MoreHoriz, RemoveDone } from "@mui/icons-material";
 import { Button, IconButton, MenuItem } from "@mui/material";
 import { useState } from "react";
 
-import { isRootComment as checkIsRootComment } from "../../../common/comment";
-import { Menu } from "../../common/components/Menu/Menu";
-import { ProfileIcon } from "../../common/components/ProfileIcon/ProfileIcon";
-import { useSessionUser } from "../../common/hooks";
-import { useOnPlayground } from "../../topic/store/topicHooks";
-import { useUserCanEditTopicData } from "../../topic/store/userHooks";
-import { StoreComment, deleteComment, resolveComment } from "../store/commentStore";
-import { deleteDraft, useDraft } from "../store/draftStore";
-import { Draft } from "./Draft";
+import { isRootComment as checkIsRootComment } from "@/common/comment";
+import { Draft } from "@/web/comment/components/Draft";
+import { StoreComment, deleteComment, resolveComment } from "@/web/comment/store/commentStore";
+import { deleteDraft, useDraft } from "@/web/comment/store/draftStore";
+import { Menu } from "@/web/common/components/Menu/Menu";
+import { ProfileIcon } from "@/web/common/components/ProfileIcon/ProfileIcon";
+import { useSessionUser } from "@/web/common/hooks";
+import { useOnPlayground } from "@/web/topic/store/topicHooks";
+import { useUserCanEditTopicData } from "@/web/topic/store/userHooks";
 
 interface Props {
   comment: StoreComment;

--- a/src/web/comment/components/Draft.tsx
+++ b/src/web/comment/components/Draft.tsx
@@ -1,9 +1,9 @@
 import { Button, TextField } from "@mui/material";
 import { useRef, useState } from "react";
 
-import { CommentParentType } from "../../../common/comment";
-import { upsertComment } from "../store/commentStore";
-import { deleteDraft, setDraft } from "../store/draftStore";
+import { CommentParentType } from "@/common/comment";
+import { upsertComment } from "@/web/comment/store/commentStore";
+import { deleteDraft, setDraft } from "@/web/comment/store/draftStore";
 
 interface Props {
   authorName: string;

--- a/src/web/comment/components/Thread.tsx
+++ b/src/web/comment/components/Thread.tsx
@@ -1,7 +1,7 @@
-import { StoreComment, useThreadChildrenComments } from "../store/commentStore";
-import { useDraft } from "../store/draftStore";
-import { Comment } from "./Comment";
-import { Draft } from "./Draft";
+import { Comment } from "@/web/comment/components/Comment";
+import { Draft } from "@/web/comment/components/Draft";
+import { StoreComment, useThreadChildrenComments } from "@/web/comment/store/commentStore";
+import { useDraft } from "@/web/comment/store/draftStore";
 
 interface Props {
   myUsername: string | undefined;

--- a/src/web/comment/store/apiSyncerMiddleware.ts
+++ b/src/web/comment/store/apiSyncerMiddleware.ts
@@ -1,11 +1,11 @@
 import diff from "microdiff";
 import { StateCreator, StoreMutatorIdentifier } from "zustand";
 
-import { Comment } from "../../../common/comment";
-import { trpcClient } from "../../../pages/_app.page";
-import { emitter } from "../../common/event";
-import { isPlaygroundTopic } from "../../topic/store/utils";
-import { CommentStoreState } from "./commentStore";
+import { Comment } from "@/common/comment";
+import { trpcClient } from "@/pages/_app.page";
+import { CommentStoreState } from "@/web/comment/store/commentStore";
+import { emitter } from "@/web/common/event";
+import { isPlaygroundTopic } from "@/web/topic/store/utils";
 
 const getCrudDiffs = <T extends object>(
   before: T[],

--- a/src/web/comment/store/commentStore.ts
+++ b/src/web/comment/store/commentStore.ts
@@ -2,11 +2,11 @@ import shortUUID from "short-uuid";
 import { devtools, persist } from "zustand/middleware";
 import { createWithEqualityFn } from "zustand/traditional";
 
-import { Comment, CommentParentType, isRootComment } from "../../../common/comment";
-import { withDefaults } from "../../../common/object";
-import { storageWithDates } from "../../common/store/utils";
-import { StoreTopic, UserTopic } from "../../topic/store/store";
-import { apiSyncer } from "./apiSyncerMiddleware";
+import { Comment, CommentParentType, isRootComment } from "@/common/comment";
+import { withDefaults } from "@/common/object";
+import { apiSyncer } from "@/web/comment/store/apiSyncerMiddleware";
+import { storageWithDates } from "@/web/common/store/utils";
+import { StoreTopic, UserTopic } from "@/web/topic/store/store";
 
 export type StoreComment = Omit<Comment, "topicId">;
 

--- a/src/web/comment/store/draftStore.ts
+++ b/src/web/comment/store/draftStore.ts
@@ -5,9 +5,9 @@
 import { devtools, persist } from "zustand/middleware";
 import { createWithEqualityFn } from "zustand/traditional";
 
-import { CommentParentType } from "../../../common/comment";
-import { withDefaults } from "../../../common/object";
-import { storageWithDates } from "../../common/store/utils";
+import { CommentParentType } from "@/common/comment";
+import { withDefaults } from "@/common/object";
+import { storageWithDates } from "@/web/common/store/utils";
 
 interface Draft {
   parentId: string | null;

--- a/src/web/common/components/ContextMenu/AddNodeMenuItem.tsx
+++ b/src/web/common/components/ContextMenu/AddNodeMenuItem.tsx
@@ -1,12 +1,12 @@
 import { NestedMenuItem } from "mui-nested-menu";
 
-import { addNodeWithoutParent } from "../../../topic/store/createDeleteActions";
-import { useUserCanEditTopicData } from "../../../topic/store/userHooks";
-import { nodeDecorations } from "../../../topic/utils/node";
-import { usePrimaryNodeTypes } from "../../../view/currentViewStore/filter";
-import { useFormat } from "../../../view/currentViewStore/store";
-import { useSessionUser } from "../../hooks";
-import { CloseOnClickMenuItem } from "./CloseOnClickMenuItem";
+import { CloseOnClickMenuItem } from "@/web/common/components/ContextMenu/CloseOnClickMenuItem";
+import { useSessionUser } from "@/web/common/hooks";
+import { addNodeWithoutParent } from "@/web/topic/store/createDeleteActions";
+import { useUserCanEditTopicData } from "@/web/topic/store/userHooks";
+import { nodeDecorations } from "@/web/topic/utils/node";
+import { usePrimaryNodeTypes } from "@/web/view/currentViewStore/filter";
+import { useFormat } from "@/web/view/currentViewStore/store";
 
 interface Props {
   parentMenuOpen: boolean;

--- a/src/web/common/components/ContextMenu/AlsoShowNodeAndNeighborsMenuItem.tsx
+++ b/src/web/common/components/ContextMenu/AlsoShowNodeAndNeighborsMenuItem.tsx
@@ -1,6 +1,6 @@
-import { Node } from "../../../topic/utils/graph";
-import { showNodeAndNeighbors } from "../../../view/currentViewStore/filter";
-import { CloseOnClickMenuItem } from "./CloseOnClickMenuItem";
+import { CloseOnClickMenuItem } from "@/web/common/components/ContextMenu/CloseOnClickMenuItem";
+import { Node } from "@/web/topic/utils/graph";
+import { showNodeAndNeighbors } from "@/web/view/currentViewStore/filter";
 
 export const AlsoShowNodeAndNeighborsMenuItem = ({ node }: { node: Node }) => {
   return (

--- a/src/web/common/components/ContextMenu/ChangeEdgeTypeMenuItem.tsx
+++ b/src/web/common/components/ContextMenu/ChangeEdgeTypeMenuItem.tsx
@@ -1,12 +1,12 @@
 import lowerCase from "lodash/lowerCase";
 import { NestedMenuItem } from "mui-nested-menu";
 
-import { getSameCategoryEdgeTypes } from "../../../../common/edge";
-import { changeEdgeType } from "../../../topic/store/actions";
-import { useUserCanEditTopicData } from "../../../topic/store/userHooks";
-import { Edge } from "../../../topic/utils/graph";
-import { useSessionUser } from "../../hooks";
-import { CloseOnClickMenuItem } from "./CloseOnClickMenuItem";
+import { getSameCategoryEdgeTypes } from "@/common/edge";
+import { CloseOnClickMenuItem } from "@/web/common/components/ContextMenu/CloseOnClickMenuItem";
+import { useSessionUser } from "@/web/common/hooks";
+import { changeEdgeType } from "@/web/topic/store/actions";
+import { useUserCanEditTopicData } from "@/web/topic/store/userHooks";
+import { Edge } from "@/web/topic/utils/graph";
 
 interface Props {
   edge: Edge;

--- a/src/web/common/components/ContextMenu/ChangeNodeTypeMenuItem.tsx
+++ b/src/web/common/components/ContextMenu/ChangeNodeTypeMenuItem.tsx
@@ -1,12 +1,12 @@
 import { NestedMenuItem } from "mui-nested-menu";
 
-import { getSameCategoryNodeTypes } from "../../../../common/node";
-import { changeNodeType } from "../../../topic/store/actions";
-import { useUserCanEditTopicData } from "../../../topic/store/userHooks";
-import { Node } from "../../../topic/utils/graph";
-import { nodeDecorations } from "../../../topic/utils/node";
-import { useSessionUser } from "../../hooks";
-import { CloseOnClickMenuItem } from "./CloseOnClickMenuItem";
+import { getSameCategoryNodeTypes } from "@/common/node";
+import { CloseOnClickMenuItem } from "@/web/common/components/ContextMenu/CloseOnClickMenuItem";
+import { useSessionUser } from "@/web/common/hooks";
+import { changeNodeType } from "@/web/topic/store/actions";
+import { useUserCanEditTopicData } from "@/web/topic/store/userHooks";
+import { Node } from "@/web/topic/utils/graph";
+import { nodeDecorations } from "@/web/topic/utils/node";
 
 interface Props {
   node: Node;

--- a/src/web/common/components/ContextMenu/CloseOnClickMenuItem.tsx
+++ b/src/web/common/components/ContextMenu/CloseOnClickMenuItem.tsx
@@ -1,6 +1,6 @@
 import { MenuItem, type MenuItemProps } from "@mui/material";
 
-import { closeContextMenu } from "../../store/contextMenuActions";
+import { closeContextMenu } from "@/web/common/store/contextMenuActions";
 
 /**
  * Context menu items have their own components, which makes it harder to enhance their onClick

--- a/src/web/common/components/ContextMenu/ContextMenu.tsx
+++ b/src/web/common/components/ContextMenu/ContextMenu.tsx
@@ -1,16 +1,16 @@
 import { Menu as MuiMenu } from "@mui/material";
 
-import { closeContextMenu } from "../../store/contextMenuActions";
-import { useAnchorPosition, useContextMenuContext } from "../../store/contextMenuStore";
-import { AddNodeMenuItem } from "./AddNodeMenuItem";
-import { AlsoShowNodeAndNeighborsMenuItem } from "./AlsoShowNodeAndNeighborsMenuItem";
-import { ChangeEdgeTypeMenuItem } from "./ChangeEdgeTypeMenuItem";
-import { ChangeNodeTypeMenuItem } from "./ChangeNodeTypeMenuItem";
-import { CloseOnClickMenuItem } from "./CloseOnClickMenuItem";
-import { DeleteEdgeMenuItem } from "./DeleteEdgeMenuItem";
-import { DeleteNodeMenuItem } from "./DeleteNodeMenuItem";
-import { HideMenuItem } from "./HideMenuItem";
-import { OnlyShowNodeAndNeighborsMenuItem } from "./OnlyShowNodeAndNeighborsMenuItem";
+import { AddNodeMenuItem } from "@/web/common/components/ContextMenu/AddNodeMenuItem";
+import { AlsoShowNodeAndNeighborsMenuItem } from "@/web/common/components/ContextMenu/AlsoShowNodeAndNeighborsMenuItem";
+import { ChangeEdgeTypeMenuItem } from "@/web/common/components/ContextMenu/ChangeEdgeTypeMenuItem";
+import { ChangeNodeTypeMenuItem } from "@/web/common/components/ContextMenu/ChangeNodeTypeMenuItem";
+import { CloseOnClickMenuItem } from "@/web/common/components/ContextMenu/CloseOnClickMenuItem";
+import { DeleteEdgeMenuItem } from "@/web/common/components/ContextMenu/DeleteEdgeMenuItem";
+import { DeleteNodeMenuItem } from "@/web/common/components/ContextMenu/DeleteNodeMenuItem";
+import { HideMenuItem } from "@/web/common/components/ContextMenu/HideMenuItem";
+import { OnlyShowNodeAndNeighborsMenuItem } from "@/web/common/components/ContextMenu/OnlyShowNodeAndNeighborsMenuItem";
+import { closeContextMenu } from "@/web/common/store/contextMenuActions";
+import { useAnchorPosition, useContextMenuContext } from "@/web/common/store/contextMenuStore";
 
 export const ContextMenu = () => {
   const anchorPosition = useAnchorPosition();

--- a/src/web/common/components/ContextMenu/DeleteEdgeMenuItem.tsx
+++ b/src/web/common/components/ContextMenu/DeleteEdgeMenuItem.tsx
@@ -1,9 +1,9 @@
-import { justificationRelationNames } from "../../../../common/edge";
-import { deleteEdge } from "../../../topic/store/createDeleteActions";
-import { useUserCanEditTopicData } from "../../../topic/store/userHooks";
-import { Edge } from "../../../topic/utils/graph";
-import { useSessionUser } from "../../hooks";
-import { CloseOnClickMenuItem } from "./CloseOnClickMenuItem";
+import { justificationRelationNames } from "@/common/edge";
+import { CloseOnClickMenuItem } from "@/web/common/components/ContextMenu/CloseOnClickMenuItem";
+import { useSessionUser } from "@/web/common/hooks";
+import { deleteEdge } from "@/web/topic/store/createDeleteActions";
+import { useUserCanEditTopicData } from "@/web/topic/store/userHooks";
+import { Edge } from "@/web/topic/utils/graph";
 
 export const DeleteEdgeMenuItem = ({ edge }: { edge: Edge }) => {
   const { sessionUser } = useSessionUser();

--- a/src/web/common/components/ContextMenu/DeleteNodeMenuItem.tsx
+++ b/src/web/common/components/ContextMenu/DeleteNodeMenuItem.tsx
@@ -1,8 +1,8 @@
-import { deleteNode } from "../../../topic/store/createDeleteActions";
-import { useUserCanEditTopicData } from "../../../topic/store/userHooks";
-import { Node } from "../../../topic/utils/graph";
-import { useSessionUser } from "../../hooks";
-import { CloseOnClickMenuItem } from "./CloseOnClickMenuItem";
+import { CloseOnClickMenuItem } from "@/web/common/components/ContextMenu/CloseOnClickMenuItem";
+import { useSessionUser } from "@/web/common/hooks";
+import { deleteNode } from "@/web/topic/store/createDeleteActions";
+import { useUserCanEditTopicData } from "@/web/topic/store/userHooks";
+import { Node } from "@/web/topic/utils/graph";
 
 export const DeleteNodeMenuItem = ({ node }: { node: Node }) => {
   const { sessionUser } = useSessionUser();

--- a/src/web/common/components/ContextMenu/HideMenuItem.tsx
+++ b/src/web/common/components/ContextMenu/HideMenuItem.tsx
@@ -1,6 +1,6 @@
-import { Node } from "../../../topic/utils/graph";
-import { hideNode } from "../../../view/currentViewStore/filter";
-import { CloseOnClickMenuItem } from "./CloseOnClickMenuItem";
+import { CloseOnClickMenuItem } from "@/web/common/components/ContextMenu/CloseOnClickMenuItem";
+import { Node } from "@/web/topic/utils/graph";
+import { hideNode } from "@/web/view/currentViewStore/filter";
 
 export const HideMenuItem = ({ node }: { node: Node }) => {
   return <CloseOnClickMenuItem onClick={() => hideNode(node.id)}>Hide node</CloseOnClickMenuItem>;

--- a/src/web/common/components/ContextMenu/OnlyShowNodeAndNeighborsMenuItem.tsx
+++ b/src/web/common/components/ContextMenu/OnlyShowNodeAndNeighborsMenuItem.tsx
@@ -1,6 +1,6 @@
-import { Node } from "../../../topic/utils/graph";
-import { showNodeAndNeighbors } from "../../../view/currentViewStore/filter";
-import { CloseOnClickMenuItem } from "./CloseOnClickMenuItem";
+import { CloseOnClickMenuItem } from "@/web/common/components/ContextMenu/CloseOnClickMenuItem";
+import { Node } from "@/web/topic/utils/graph";
+import { showNodeAndNeighbors } from "@/web/view/currentViewStore/filter";
 
 export const OnlyShowNodeAndNeighborsMenuItem = ({ node }: { node: Node }) => {
   return (

--- a/src/web/common/components/Form/NodeSelect.tsx
+++ b/src/web/common/components/Form/NodeSelect.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 
-import { Node } from "../../../topic/utils/graph";
-import { Select } from "./Select";
+import { Select } from "@/web/common/components/Form/Select";
+import { Node } from "@/web/topic/utils/graph";
 
 interface Props {
   name: string;

--- a/src/web/common/components/Form/Select.tsx
+++ b/src/web/common/components/Form/Select.tsx
@@ -3,7 +3,7 @@ import { startCase } from "lodash";
 import { useContext, useMemo } from "react";
 import { useController } from "react-hook-form";
 
-import { FormContext } from "./FormContext";
+import { FormContext } from "@/web/common/components/Form/FormContext";
 
 interface Props {
   name: string;

--- a/src/web/common/components/Form/Switch.tsx
+++ b/src/web/common/components/Form/Switch.tsx
@@ -3,7 +3,7 @@ import startCase from "lodash/startCase";
 import { ReactNode, useContext } from "react";
 import { useController } from "react-hook-form";
 
-import { FormContext } from "./FormContext";
+import { FormContext } from "@/web/common/components/Form/FormContext";
 
 interface Props {
   name: string; // not sure how to ensure this is actually a field on the form schema

--- a/src/web/common/components/Layout.tsx
+++ b/src/web/common/components/Layout.tsx
@@ -15,13 +15,14 @@ import Image from "next/image";
 import { useRouter } from "next/router";
 import { ReactNode, forwardRef, useEffect, useState } from "react";
 
+import { Link } from "@/web/common/components/Link";
+import { ProfileIcon } from "@/web/common/components/ProfileIcon/ProfileIcon";
+import { SiteDrawer } from "@/web/common/components/SiteDrawer/SiteDrawer";
+import { UserDrawer } from "@/web/common/components/UserDrawer/UserDrawer";
+import { useSessionUser } from "@/web/common/hooks";
+import { discordInvite, githubRepo } from "@/web/common/urls";
+
 import favicon from "../../../../public/favicon.png";
-import { useSessionUser } from "../hooks";
-import { discordInvite, githubRepo } from "../urls";
-import { Link } from "./Link";
-import { ProfileIcon } from "./ProfileIcon/ProfileIcon";
-import { SiteDrawer } from "./SiteDrawer/SiteDrawer";
-import { UserDrawer } from "./UserDrawer/UserDrawer";
 
 const NavLink = forwardRef<HTMLAnchorElement, LinkProps>(function NavLink(props, ref) {
   return <Link ref={ref} {...props} underline="hover" />;

--- a/src/web/common/components/SiteDrawer/SiteDrawer.tsx
+++ b/src/web/common/components/SiteDrawer/SiteDrawer.tsx
@@ -15,8 +15,9 @@ import {
 import Image from "next/image";
 import NextLink from "next/link";
 
+import { discordInvite, facebookPage, githubRepo } from "@/web/common/urls";
+
 import favicon from "../../../../../public/favicon.png";
-import { discordInvite, facebookPage, githubRepo } from "../../urls";
 
 interface Props {
   isSiteDrawerOpen: boolean;

--- a/src/web/common/components/UserDrawer/UserDrawer.tsx
+++ b/src/web/common/components/UserDrawer/UserDrawer.tsx
@@ -11,7 +11,7 @@ import {
 } from "@mui/material";
 import NextLink from "next/link";
 
-import { ProfileIcon } from "../ProfileIcon/ProfileIcon";
+import { ProfileIcon } from "@/web/common/components/ProfileIcon/ProfileIcon";
 
 interface Props {
   user: { username: string };

--- a/src/web/common/components/YoutubeEmbed/YoutubeEmbed.tsx
+++ b/src/web/common/components/YoutubeEmbed/YoutubeEmbed.tsx
@@ -1,4 +1,4 @@
-import { StyledIframe } from "./YoutubeEmbed.styles";
+import { StyledIframe } from "@/web/common/components/YoutubeEmbed/YoutubeEmbed.styles";
 
 // thanks https://dev.to/bravemaster619/simplest-way-to-embed-a-youtube-video-in-your-react-app-3bk2
 export const YoutubeEmbed = ({ embedId }: { embedId: string }) => (

--- a/src/web/common/event.ts
+++ b/src/web/common/event.ts
@@ -1,7 +1,7 @@
 import { createNanoEvents } from "nanoevents";
 
-import { Node } from "../topic/utils/graph";
-import { type ViewState } from "../view/currentViewStore/store";
+import { Node } from "@/web/topic/utils/graph";
+import { type ViewState } from "@/web/view/currentViewStore/store";
 
 interface Events {
   addNode: (node: Node) => void;

--- a/src/web/common/hooks.ts
+++ b/src/web/common/hooks.ts
@@ -1,8 +1,8 @@
 import { useUser as useAuthUser } from "@auth0/nextjs-auth0/client";
 import { useState } from "react";
 
-import { MenuPosition } from "./store/contextMenuStore";
-import { trpc } from "./trpc";
+import { MenuPosition } from "@/web/common/store/contextMenuStore";
+import { trpc } from "@/web/common/trpc";
 
 /**
  * @example <caption>(since there aren't currently usages of this method)</caption>

--- a/src/web/common/store/contextMenuActions.ts
+++ b/src/web/common/store/contextMenuActions.ts
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { Context, useContextMenuStore } from "./contextMenuStore";
+import { Context, useContextMenuStore } from "@/web/common/store/contextMenuStore";
 
 export const openContextMenu = (event: React.MouseEvent, context: Context) => {
   event.preventDefault(); // prevent opening default context menu

--- a/src/web/common/store/contextMenuStore.ts
+++ b/src/web/common/store/contextMenuStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 
-import { Edge, Node } from "../../topic/utils/graph";
+import { Edge, Node } from "@/web/topic/utils/graph";
 
 export interface MenuPosition {
   top: number;

--- a/src/web/common/theme.ts
+++ b/src/web/common/theme.ts
@@ -12,7 +12,7 @@ import {
 } from "@mui/material";
 import { grey, orange, yellow } from "@mui/material/colors";
 
-import { FlowNodeType } from "../topic/utils/node";
+import { FlowNodeType } from "@/web/topic/utils/node";
 
 // adding colors to theme documented at https://mui.com/material-ui/customization/palette/#adding-new-colors
 

--- a/src/web/common/trpc.ts
+++ b/src/web/common/trpc.ts
@@ -3,8 +3,8 @@ import { httpBatchLink } from "@trpc/client";
 import { createTRPCNext } from "@trpc/next";
 import superjson from "superjson";
 
-import type { AppRouter } from "../../api/routers/_app";
-import { getBaseUrl } from "../../common/utils";
+import type { AppRouter } from "@/api/routers/_app";
+import { getBaseUrl } from "@/common/utils";
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/src/web/topic/components/CriteriaTable/CriteriaTable.tsx
+++ b/src/web/topic/components/CriteriaTable/CriteriaTable.tsx
@@ -10,22 +10,26 @@ import {
 } from "material-react-table";
 import React, { useState } from "react";
 
-import { errorWithData } from "../../../../common/errorHandling";
-import { useSessionUser } from "../../../common/hooks";
-import { useGeneralFilter, useTableFilter } from "../../../view/currentViewStore/filter";
-import { getSelectedTradeoffNodes } from "../../../view/utils/diagramFilter";
-import { applyScoreFilter } from "../../../view/utils/generalFilter";
-import { useCriterionSolutionEdges, useDefaultNode, useNodeChildren } from "../../store/nodeHooks";
-import { useDisplayScores } from "../../store/scoreHooks";
-import { useUserCanEditTopicData } from "../../store/userHooks";
-import { getConnectingEdge } from "../../utils/edge";
-import { Edge, Node } from "../../utils/graph";
-import { EdgeCell } from "../CriteriaTable/EdgeCell";
-import { NodeCell } from "../CriteriaTable/NodeCell";
-import { AddNodeButton } from "../Node/AddNodeButton";
-import { tableStyles } from "./CriteriaTable.styles";
-import { SolutionTotalCell } from "./SolutionTotalCell";
-import { TotalsHeaderCell } from "./TotalsHeaderCell";
+import { errorWithData } from "@/common/errorHandling";
+import { useSessionUser } from "@/web/common/hooks";
+import { tableStyles } from "@/web/topic/components/CriteriaTable/CriteriaTable.styles";
+import { EdgeCell } from "@/web/topic/components/CriteriaTable/EdgeCell";
+import { NodeCell } from "@/web/topic/components/CriteriaTable/NodeCell";
+import { SolutionTotalCell } from "@/web/topic/components/CriteriaTable/SolutionTotalCell";
+import { TotalsHeaderCell } from "@/web/topic/components/CriteriaTable/TotalsHeaderCell";
+import { AddNodeButton } from "@/web/topic/components/Node/AddNodeButton";
+import {
+  useCriterionSolutionEdges,
+  useDefaultNode,
+  useNodeChildren,
+} from "@/web/topic/store/nodeHooks";
+import { useDisplayScores } from "@/web/topic/store/scoreHooks";
+import { useUserCanEditTopicData } from "@/web/topic/store/userHooks";
+import { getConnectingEdge } from "@/web/topic/utils/edge";
+import { Edge, Node } from "@/web/topic/utils/graph";
+import { useGeneralFilter, useTableFilter } from "@/web/view/currentViewStore/filter";
+import { getSelectedTradeoffNodes } from "@/web/view/utils/diagramFilter";
+import { applyScoreFilter } from "@/web/view/utils/generalFilter";
 
 interface RowData {
   rowHeader: HeaderCell;

--- a/src/web/topic/components/CriteriaTable/EdgeCell.tsx
+++ b/src/web/topic/components/CriteriaTable/EdgeCell.tsx
@@ -1,6 +1,6 @@
-import { Edge } from "../../utils/graph";
-import { CommonIndicators } from "../Indicator/CommonIndicators";
-import { ContentIndicators } from "../Indicator/ContentIndicators";
+import { CommonIndicators } from "@/web/topic/components/Indicator/CommonIndicators";
+import { ContentIndicators } from "@/web/topic/components/Indicator/ContentIndicators";
+import { Edge } from "@/web/topic/utils/graph";
 
 export const EdgeCell = ({ edge }: { edge: Edge }) => {
   return (

--- a/src/web/topic/components/CriteriaTable/NodeCell.styles.tsx
+++ b/src/web/topic/components/CriteriaTable/NodeCell.styles.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 
-import { nodeWidthPx } from "../Node/EditableNode.styles";
+import { nodeWidthPx } from "@/web/topic/components/Node/EditableNode.styles";
 
 export const StyledDiv = styled.div`
   height: 100%; // expand to fill cell in case other cells are bigger due to nodes having more rows of text

--- a/src/web/topic/components/CriteriaTable/NodeCell.tsx
+++ b/src/web/topic/components/CriteriaTable/NodeCell.tsx
@@ -1,6 +1,6 @@
-import { Node } from "../../utils/graph";
-import { EditableNode } from "../Node/EditableNode";
-import { StyledDiv } from "./NodeCell.styles";
+import { StyledDiv } from "@/web/topic/components/CriteriaTable/NodeCell.styles";
+import { EditableNode } from "@/web/topic/components/Node/EditableNode";
+import { Node } from "@/web/topic/utils/graph";
 
 export const NodeCell = ({ node }: { node: Node }) => {
   return (

--- a/src/web/topic/components/CriteriaTable/SolutionTotalCell.tsx
+++ b/src/web/topic/components/CriteriaTable/SolutionTotalCell.tsx
@@ -1,7 +1,7 @@
 import { Box } from "@mui/material";
 
-import { useSolutionTotal } from "../../store/scoreHooks";
-import { Node } from "../../utils/graph";
+import { useSolutionTotal } from "@/web/topic/store/scoreHooks";
+import { Node } from "@/web/topic/utils/graph";
 
 interface Props {
   solution: Node;

--- a/src/web/topic/components/Diagram/Diagram.tsx
+++ b/src/web/topic/components/Diagram/Diagram.tsx
@@ -9,24 +9,24 @@ import {
   useStore,
 } from "reactflow";
 
-import { Loading } from "../../../common/components/Loading/Loading";
-import { emitter } from "../../../common/event";
-import { useSessionUser } from "../../../common/hooks";
-import { openContextMenu } from "../../../common/store/contextMenuActions";
-import { useFlashlightMode } from "../../../view/actionConfigStore";
-import { setSelected } from "../../../view/currentViewStore/store";
-import { useLayoutedDiagram } from "../../hooks/diagramHooks";
-import { useViewportUpdater } from "../../hooks/flowHooks";
-import { connectNodes, reconnectEdge } from "../../store/createDeleteActions";
-import { useDiagram } from "../../store/store";
-import { useUserCanEditTopicData } from "../../store/userHooks";
-import { Diagram as DiagramData } from "../../utils/diagram";
-import { type Edge, type Node } from "../../utils/graph";
-import { FlowNodeType } from "../../utils/node";
-import { FlowEdge } from "../Edge/FlowEdge";
-import { FlowNode } from "../Node/FlowNode";
-import { StyledReactFlow } from "./Diagram.styles";
-import { setDisplayNodesGetter } from "./externalFlowStore";
+import { Loading } from "@/web/common/components/Loading/Loading";
+import { emitter } from "@/web/common/event";
+import { useSessionUser } from "@/web/common/hooks";
+import { openContextMenu } from "@/web/common/store/contextMenuActions";
+import { StyledReactFlow } from "@/web/topic/components/Diagram/Diagram.styles";
+import { setDisplayNodesGetter } from "@/web/topic/components/Diagram/externalFlowStore";
+import { FlowEdge } from "@/web/topic/components/Edge/FlowEdge";
+import { FlowNode } from "@/web/topic/components/Node/FlowNode";
+import { useLayoutedDiagram } from "@/web/topic/hooks/diagramHooks";
+import { useViewportUpdater } from "@/web/topic/hooks/flowHooks";
+import { connectNodes, reconnectEdge } from "@/web/topic/store/createDeleteActions";
+import { useDiagram } from "@/web/topic/store/store";
+import { useUserCanEditTopicData } from "@/web/topic/store/userHooks";
+import { Diagram as DiagramData } from "@/web/topic/utils/diagram";
+import { type Edge, type Node } from "@/web/topic/utils/graph";
+import { FlowNodeType } from "@/web/topic/utils/node";
+import { useFlashlightMode } from "@/web/view/actionConfigStore";
+import { setSelected } from "@/web/view/currentViewStore/store";
 
 const buildNodeComponent = (type: FlowNodeType) => {
   // eslint-disable-next-line react/display-name -- react flow dynamically creates these components without name anyway

--- a/src/web/topic/components/Edge/FlowEdge.tsx
+++ b/src/web/topic/components/Edge/FlowEdge.tsx
@@ -1,6 +1,6 @@
 import { EdgeProps } from "reactflow";
 
-import { ScoreEdge } from "./ScoreEdge";
+import { ScoreEdge } from "@/web/topic/components/Edge/ScoreEdge";
 
 export const FlowEdge = (flowEdge: EdgeProps) => {
   return <ScoreEdge inReactFlow={true} {...flowEdge} />;

--- a/src/web/topic/components/Edge/ScoreEdge.styles.tsx
+++ b/src/web/topic/components/Edge/ScoreEdge.styles.tsx
@@ -1,8 +1,8 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 
-import { infoColor } from "../../../common/theme";
-import { Spotlight, zIndex } from "../Diagram/Diagram.styles";
+import { infoColor } from "@/web/common/theme";
+import { Spotlight, zIndex } from "@/web/topic/components/Diagram/Diagram.styles";
 
 const highlightedEdgeWidth = "2px";
 export const edgeColor = "#b1b1b7"; // react flow default

--- a/src/web/topic/components/Edge/ScoreEdge.tsx
+++ b/src/web/topic/components/Edge/ScoreEdge.tsx
@@ -2,25 +2,30 @@ import { Box, Typography } from "@mui/material";
 import lowerCase from "lodash/lowerCase";
 import { EdgeLabelRenderer, getBezierPath } from "reactflow";
 
-import { RelationName } from "../../../../common/edge";
-import { useSessionUser } from "../../../common/hooks";
-import { openContextMenu } from "../../../common/store/contextMenuActions";
-import { infoColor } from "../../../common/theme";
-import { useUnrestrictedEditing } from "../../../view/actionConfigStore";
-import { setSelected } from "../../../view/currentViewStore/store";
-import { setCustomEdgeLabel } from "../../store/actions";
-import { useIsNodeSelected } from "../../store/edgeHooks";
-import { useUserCanEditTopicData } from "../../store/userHooks";
-import { Edge } from "../../utils/graph";
-import { EdgeProps } from "../Diagram/Diagram";
-import { Spotlight } from "../Diagram/Diagram.styles";
-import { CommonIndicators } from "../Indicator/CommonIndicators";
+import { RelationName } from "@/common/edge";
+import { useSessionUser } from "@/web/common/hooks";
+import { openContextMenu } from "@/web/common/store/contextMenuActions";
+import { infoColor } from "@/web/common/theme";
+import { EdgeProps } from "@/web/topic/components/Diagram/Diagram";
+import { Spotlight } from "@/web/topic/components/Diagram/Diagram.styles";
+import {
+  StyledDiv,
+  StyledPath,
+  edgeColor,
+  highlightedEdgeColor,
+} from "@/web/topic/components/Edge/ScoreEdge.styles";
+import { CommonIndicators } from "@/web/topic/components/Indicator/CommonIndicators";
 import {
   LeftCornerStatusIndicators,
   RightCornerContentIndicators,
   nodeWidthPx,
-} from "../Node/EditableNode.styles";
-import { StyledDiv, StyledPath, edgeColor, highlightedEdgeColor } from "./ScoreEdge.styles";
+} from "@/web/topic/components/Node/EditableNode.styles";
+import { setCustomEdgeLabel } from "@/web/topic/store/actions";
+import { useIsNodeSelected } from "@/web/topic/store/edgeHooks";
+import { useUserCanEditTopicData } from "@/web/topic/store/userHooks";
+import { Edge } from "@/web/topic/utils/graph";
+import { useUnrestrictedEditing } from "@/web/view/actionConfigStore";
+import { setSelected } from "@/web/view/currentViewStore/store";
 
 const flowMarkerId = "flowMarker";
 const nonFlowMarkerId = "nonFlowMarker";

--- a/src/web/topic/components/Edge/StandaloneEdge.tsx
+++ b/src/web/topic/components/Edge/StandaloneEdge.tsx
@@ -1,13 +1,13 @@
 import { Stack } from "@mui/material";
 import { Position } from "reactflow";
 
-import { useIsGraphPartSelected } from "../../../view/currentViewStore/store";
-import { useNode } from "../../store/nodeHooks";
-import { Edge } from "../../utils/graph";
-import { EdgeProps } from "../Diagram/Diagram";
-import { EditableNode } from "../Node/EditableNode";
-import { nodeWidthPx } from "../Node/EditableNode.styles";
-import { ScoreEdge } from "./ScoreEdge";
+import { EdgeProps } from "@/web/topic/components/Diagram/Diagram";
+import { ScoreEdge } from "@/web/topic/components/Edge/ScoreEdge";
+import { EditableNode } from "@/web/topic/components/Node/EditableNode";
+import { nodeWidthPx } from "@/web/topic/components/Node/EditableNode.styles";
+import { useNode } from "@/web/topic/store/nodeHooks";
+import { Edge } from "@/web/topic/utils/graph";
+import { useIsGraphPartSelected } from "@/web/view/currentViewStore/store";
 
 const convertToStandaloneFlowEdge = (edge: Edge, selected: boolean): EdgeProps => {
   return {

--- a/src/web/topic/components/Indicator/ClaimTreeIndicator.tsx
+++ b/src/web/topic/components/Indicator/ClaimTreeIndicator.tsx
@@ -1,13 +1,13 @@
 import { AccountTree, AccountTreeOutlined } from "@mui/icons-material";
 import { MouseEventHandler, useCallback } from "react";
 
-import { viewJustification } from "../../../view/currentViewStore/filter";
+import { Indicator } from "@/web/topic/components/Indicator/Indicator";
 import {
   useExplicitClaimCount,
   useNonTopLevelClaimCount,
   useRootClaim,
-} from "../../store/graphPartHooks";
-import { Indicator } from "./Indicator";
+} from "@/web/topic/store/graphPartHooks";
+import { viewJustification } from "@/web/view/currentViewStore/filter";
 
 interface Props {
   graphPartId: string;

--- a/src/web/topic/components/Indicator/CommentIndicator.tsx
+++ b/src/web/topic/components/Indicator/CommentIndicator.tsx
@@ -2,12 +2,12 @@ import { ChatBubbleOutline } from "@mui/icons-material";
 import { type ButtonProps } from "@mui/material";
 import { useCallback } from "react";
 
-import { useCommentCount } from "../../../comment/store/commentStore";
-import { setSelected } from "../../../view/currentViewStore/store";
-import { useShowResolvedComments } from "../../../view/miscTopicConfigStore";
-import { GraphPartType } from "../../utils/graph";
-import { viewDetails } from "../TopicPane/paneStore";
-import { Indicator } from "./Indicator";
+import { useCommentCount } from "@/web/comment/store/commentStore";
+import { Indicator } from "@/web/topic/components/Indicator/Indicator";
+import { viewDetails } from "@/web/topic/components/TopicPane/paneStore";
+import { GraphPartType } from "@/web/topic/utils/graph";
+import { setSelected } from "@/web/view/currentViewStore/store";
+import { useShowResolvedComments } from "@/web/view/miscTopicConfigStore";
 
 interface Props {
   graphPartId: string;

--- a/src/web/topic/components/Indicator/CommonIndicators.tsx
+++ b/src/web/topic/components/Indicator/CommonIndicators.tsx
@@ -1,9 +1,9 @@
 import { Stack } from "@mui/material";
 import { memo } from "react";
 
-import { Score } from "../Score/Score";
-import { CriteriaTableIndicator } from "./CriteriaTableIndicator";
-import { DetailsIndicator } from "./DetailsIndicator";
+import { CriteriaTableIndicator } from "@/web/topic/components/Indicator/CriteriaTableIndicator";
+import { DetailsIndicator } from "@/web/topic/components/Indicator/DetailsIndicator";
+import { Score } from "@/web/topic/components/Score/Score";
 
 interface Props {
   graphPartId: string;

--- a/src/web/topic/components/Indicator/ContentIndicators.tsx
+++ b/src/web/topic/components/Indicator/ContentIndicators.tsx
@@ -1,11 +1,11 @@
 import { type ButtonProps, Stack } from "@mui/material";
 import { memo } from "react";
 
-import { GraphPartType } from "../../utils/graph";
-import { CommentIndicator } from "./CommentIndicator";
-import { FoundResearchIndicator } from "./FoundResearchIndicator";
-import { JustificationIndicator } from "./JustificationIndicator";
-import { QuestionIndicator } from "./QuestionIndicator";
+import { CommentIndicator } from "@/web/topic/components/Indicator/CommentIndicator";
+import { FoundResearchIndicator } from "@/web/topic/components/Indicator/FoundResearchIndicator";
+import { JustificationIndicator } from "@/web/topic/components/Indicator/JustificationIndicator";
+import { QuestionIndicator } from "@/web/topic/components/Indicator/QuestionIndicator";
+import { GraphPartType } from "@/web/topic/utils/graph";
 
 interface Props {
   graphPartId: string;

--- a/src/web/topic/components/Indicator/CriteriaTableIndicator.tsx
+++ b/src/web/topic/components/Indicator/CriteriaTableIndicator.tsx
@@ -1,10 +1,10 @@
 import { TableChart, TableChartOutlined } from "@mui/icons-material";
 import { memo, useCallback } from "react";
 
-import { viewCriteriaTable } from "../../../view/currentViewStore/filter";
-import { useNode, useNodeChildren } from "../../store/nodeHooks";
-import { Node, ProblemNode } from "../../utils/graph";
-import { Indicator } from "../Indicator/Indicator";
+import { Indicator } from "@/web/topic/components/Indicator/Indicator";
+import { useNode, useNodeChildren } from "@/web/topic/store/nodeHooks";
+import { Node, ProblemNode } from "@/web/topic/utils/graph";
+import { viewCriteriaTable } from "@/web/view/currentViewStore/filter";
 
 const isProblem = (node: Node): node is ProblemNode => node.type === "problem";
 

--- a/src/web/topic/components/Indicator/DetailsIndicator.tsx
+++ b/src/web/topic/components/Indicator/DetailsIndicator.tsx
@@ -1,9 +1,9 @@
 import { Article, ArticleOutlined } from "@mui/icons-material";
 import { useCallback } from "react";
 
-import { setSelected } from "../../../view/currentViewStore/store";
-import { viewDetails } from "../TopicPane/paneStore";
-import { Indicator } from "./Indicator";
+import { Indicator } from "@/web/topic/components/Indicator/Indicator";
+import { viewDetails } from "@/web/topic/components/TopicPane/paneStore";
+import { setSelected } from "@/web/view/currentViewStore/store";
 
 interface Props {
   graphPartId: string;

--- a/src/web/topic/components/Indicator/ForceShownIndicator.tsx
+++ b/src/web/topic/components/Indicator/ForceShownIndicator.tsx
@@ -2,11 +2,8 @@ import { WbTwilight } from "@mui/icons-material";
 import { type ButtonProps } from "@mui/material";
 import { MouseEventHandler, memo, useCallback } from "react";
 
-import {
-  stopForcingNodeToShow,
-  useIsNodeForcedToShow,
-} from "../../../view/currentViewStore/filter";
-import { Indicator } from "./Indicator";
+import { Indicator } from "@/web/topic/components/Indicator/Indicator";
+import { stopForcingNodeToShow, useIsNodeForcedToShow } from "@/web/view/currentViewStore/filter";
 
 interface Props {
   nodeId: string;

--- a/src/web/topic/components/Indicator/FoundResearchIndicator.tsx
+++ b/src/web/topic/components/Indicator/FoundResearchIndicator.tsx
@@ -2,13 +2,13 @@ import { Code, InfoOutlined, School } from "@mui/icons-material";
 import { type ButtonProps } from "@mui/material";
 import { useCallback } from "react";
 
-import { setSelected } from "../../../view/currentViewStore/store";
-import { useResearchNodes } from "../../store/graphPartHooks";
-import { useDisplayScores } from "../../store/scoreHooks";
-import { Score } from "../../utils/graph";
-import { getNumericScore, scoreColors } from "../../utils/score";
-import { viewDetails } from "../TopicPane/paneStore";
-import { Indicator } from "./Indicator";
+import { Indicator } from "@/web/topic/components/Indicator/Indicator";
+import { viewDetails } from "@/web/topic/components/TopicPane/paneStore";
+import { useResearchNodes } from "@/web/topic/store/graphPartHooks";
+import { useDisplayScores } from "@/web/topic/store/scoreHooks";
+import { Score } from "@/web/topic/utils/graph";
+import { getNumericScore, scoreColors } from "@/web/topic/utils/score";
+import { setSelected } from "@/web/view/currentViewStore/store";
 
 interface Props {
   graphPartId: string;

--- a/src/web/topic/components/Indicator/Indicator.styles.tsx
+++ b/src/web/topic/components/Indicator/Indicator.styles.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { Button } from "@mui/material";
 
-import { indicatorLengthRem } from "../../utils/node";
+import { indicatorLengthRem } from "@/web/topic/utils/node";
 
 export const StyledButton = styled(Button)`
   width: ${indicatorLengthRem}rem;

--- a/src/web/topic/components/Indicator/Indicator.tsx
+++ b/src/web/topic/components/Indicator/Indicator.tsx
@@ -2,8 +2,8 @@ import { type ButtonProps } from "@mui/material";
 import Tooltip from "@mui/material/Tooltip";
 import { MouseEventHandler } from "react";
 
-import { MuiIcon } from "../../utils/node";
-import { StyledButton } from "./Indicator.styles";
+import { StyledButton } from "@/web/topic/components/Indicator/Indicator.styles";
+import { MuiIcon } from "@/web/topic/utils/node";
 
 interface IndicatorProps {
   Icon: MuiIcon;

--- a/src/web/topic/components/Indicator/JustificationIndicator.tsx
+++ b/src/web/topic/components/Indicator/JustificationIndicator.tsx
@@ -2,13 +2,13 @@ import { ThumbDownOutlined, ThumbUpOutlined, ThumbsUpDownOutlined } from "@mui/i
 import { type ButtonProps } from "@mui/material";
 import { useCallback } from "react";
 
-import { setSelected } from "../../../view/currentViewStore/store";
-import { useTopLevelClaims } from "../../store/graphPartHooks";
-import { useDisplayScores } from "../../store/scoreHooks";
-import { Score } from "../../utils/graph";
-import { getNumericScore, scoreColors } from "../../utils/score";
-import { viewDetails } from "../TopicPane/paneStore";
-import { Indicator } from "./Indicator";
+import { Indicator } from "@/web/topic/components/Indicator/Indicator";
+import { viewDetails } from "@/web/topic/components/TopicPane/paneStore";
+import { useTopLevelClaims } from "@/web/topic/store/graphPartHooks";
+import { useDisplayScores } from "@/web/topic/store/scoreHooks";
+import { Score } from "@/web/topic/utils/graph";
+import { getNumericScore, scoreColors } from "@/web/topic/utils/score";
+import { setSelected } from "@/web/view/currentViewStore/store";
 
 interface Props {
   graphPartId: string;

--- a/src/web/topic/components/Indicator/QuestionIndicator.tsx
+++ b/src/web/topic/components/Indicator/QuestionIndicator.tsx
@@ -2,13 +2,13 @@ import { QuestionMark } from "@mui/icons-material";
 import { type ButtonProps } from "@mui/material";
 import { useCallback } from "react";
 
-import { setSelected } from "../../../view/currentViewStore/store";
-import { useResearchNodes } from "../../store/graphPartHooks";
-import { useDisplayScores } from "../../store/scoreHooks";
-import { Score } from "../../utils/graph";
-import { getNumericScore, scoreColors } from "../../utils/score";
-import { viewDetails } from "../TopicPane/paneStore";
-import { Indicator } from "./Indicator";
+import { Indicator } from "@/web/topic/components/Indicator/Indicator";
+import { viewDetails } from "@/web/topic/components/TopicPane/paneStore";
+import { useResearchNodes } from "@/web/topic/store/graphPartHooks";
+import { useDisplayScores } from "@/web/topic/store/scoreHooks";
+import { Score } from "@/web/topic/utils/graph";
+import { getNumericScore, scoreColors } from "@/web/topic/utils/score";
+import { setSelected } from "@/web/view/currentViewStore/store";
 
 interface Props {
   graphPartId: string;

--- a/src/web/topic/components/Indicator/StatusIndicators.tsx
+++ b/src/web/topic/components/Indicator/StatusIndicators.tsx
@@ -1,7 +1,7 @@
 import { type ButtonProps, Stack } from "@mui/material";
 import { memo } from "react";
 
-import { ForceShownIndicator } from "./ForceShownIndicator";
+import { ForceShownIndicator } from "@/web/topic/components/Indicator/ForceShownIndicator";
 
 interface Props {
   graphPartId: string;

--- a/src/web/topic/components/Node/AddNodeButton.tsx
+++ b/src/web/topic/components/Node/AddNodeButton.tsx
@@ -1,11 +1,11 @@
-import { NodeType } from "../../../../common/node";
-import { useSessionUser } from "../../../common/hooks";
-import { addNode } from "../../store/createDeleteActions";
-import { useUserCanEditTopicData } from "../../store/userHooks";
-import { Relation } from "../../utils/edge";
-import { type RelationDirection } from "../../utils/graph";
-import { nodeDecorations } from "../../utils/node";
-import { StyledButton } from "./AddNodeButton.styles";
+import { NodeType } from "@/common/node";
+import { useSessionUser } from "@/web/common/hooks";
+import { StyledButton } from "@/web/topic/components/Node/AddNodeButton.styles";
+import { addNode } from "@/web/topic/store/createDeleteActions";
+import { useUserCanEditTopicData } from "@/web/topic/store/userHooks";
+import { Relation } from "@/web/topic/utils/edge";
+import { type RelationDirection } from "@/web/topic/utils/graph";
+import { nodeDecorations } from "@/web/topic/utils/node";
 
 interface Props {
   fromPartId: string;

--- a/src/web/topic/components/Node/AddNodeButtonGroup.stories.tsx
+++ b/src/web/topic/components/Node/AddNodeButtonGroup.stories.tsx
@@ -1,6 +1,6 @@
 import { type Meta, type StoryFn } from "@storybook/react";
 
-import { AddNodeButtonGroup } from "./AddNodeButtonGroup";
+import { AddNodeButtonGroup } from "@/web/topic/components/Node/AddNodeButtonGroup";
 
 export default { component: AddNodeButtonGroup } as Meta<typeof AddNodeButtonGroup>;
 

--- a/src/web/topic/components/Node/AddNodeButtonGroup.tsx
+++ b/src/web/topic/components/Node/AddNodeButtonGroup.tsx
@@ -1,12 +1,12 @@
 import { ButtonGroup } from "@mui/material";
 import { memo } from "react";
 
-import { NodeType, structureNodeTypes } from "../../../../common/node";
-import { useUnrestrictedEditing } from "../../../view/actionConfigStore";
-import { Relation, addableRelationsFrom } from "../../utils/edge";
-import { type RelationDirection } from "../../utils/graph";
-import { Orientation } from "../../utils/layout";
-import { AddNodeButton } from "../Node/AddNodeButton";
+import { NodeType, structureNodeTypes } from "@/common/node";
+import { AddNodeButton } from "@/web/topic/components/Node/AddNodeButton";
+import { Relation, addableRelationsFrom } from "@/web/topic/utils/edge";
+import { type RelationDirection } from "@/web/topic/utils/graph";
+import { Orientation } from "@/web/topic/utils/layout";
+import { useUnrestrictedEditing } from "@/web/view/actionConfigStore";
 
 interface Props {
   className?: string;

--- a/src/web/topic/components/Node/EditableNode.styles.tsx
+++ b/src/web/topic/components/Node/EditableNode.styles.tsx
@@ -1,9 +1,9 @@
 import styled from "@emotion/styled";
 import { Box, TextareaAutosize } from "@mui/material";
 
-import { htmlDefaultFontSize } from "../../../../pages/_document.page";
-import { ContentIndicators } from "../Indicator/ContentIndicators";
-import { StatusIndicators } from "../Indicator/StatusIndicators";
+import { htmlDefaultFontSize } from "@/pages/_document.page";
+import { ContentIndicators } from "@/web/topic/components/Indicator/ContentIndicators";
+import { StatusIndicators } from "@/web/topic/components/Indicator/StatusIndicators";
 
 export const nodeWidthRem = 11;
 

--- a/src/web/topic/components/Node/EditableNode.tsx
+++ b/src/web/topic/components/Node/EditableNode.tsx
@@ -1,16 +1,9 @@
 import { type ButtonProps, type SxProps, useTheme } from "@mui/material";
 import { memo, useEffect, useRef } from "react";
 
-import { useSessionUser } from "../../../common/hooks";
-import { openContextMenu } from "../../../common/store/contextMenuActions";
-import { useUnrestrictedEditing } from "../../../view/actionConfigStore";
-import { setSelected, useIsGraphPartSelected } from "../../../view/currentViewStore/store";
-import { useFillNodesWithColor } from "../../../view/userConfigStore";
-import { finishAddingNode, setCustomNodeType, setNodeLabel } from "../../store/actions";
-import { useUserCanEditTopicData } from "../../store/userHooks";
-import { Node } from "../../utils/graph";
-import { nodeDecorations } from "../../utils/node";
-import { CommonIndicators } from "../Indicator/CommonIndicators";
+import { useSessionUser } from "@/web/common/hooks";
+import { openContextMenu } from "@/web/common/store/contextMenuActions";
+import { CommonIndicators } from "@/web/topic/components/Indicator/CommonIndicators";
 import {
   LeftCornerStatusIndicators,
   MiddleDiv,
@@ -20,7 +13,14 @@ import {
   RightCornerContentIndicators,
   StyledTextareaAutosize,
   YEdgeBox,
-} from "./EditableNode.styles";
+} from "@/web/topic/components/Node/EditableNode.styles";
+import { finishAddingNode, setCustomNodeType, setNodeLabel } from "@/web/topic/store/actions";
+import { useUserCanEditTopicData } from "@/web/topic/store/userHooks";
+import { Node } from "@/web/topic/utils/graph";
+import { nodeDecorations } from "@/web/topic/utils/node";
+import { useUnrestrictedEditing } from "@/web/view/actionConfigStore";
+import { setSelected, useIsGraphPartSelected } from "@/web/view/currentViewStore/store";
+import { useFillNodesWithColor } from "@/web/view/userConfigStore";
 
 interface Props {
   node: Node;

--- a/src/web/topic/components/Node/FlowNode.styles.tsx
+++ b/src/web/topic/components/Node/FlowNode.styles.tsx
@@ -1,11 +1,11 @@
 import styled from "@emotion/styled";
 import { css } from "@mui/material";
 
-import { Node } from "../../utils/graph";
-import { Orientation } from "../../utils/layout";
-import { Spotlight, zIndex } from "../Diagram/Diagram.styles";
-import { AddNodeButtonGroup } from "../Node/AddNodeButtonGroup";
-import { EditableNode } from "./EditableNode";
+import { Spotlight, zIndex } from "@/web/topic/components/Diagram/Diagram.styles";
+import { AddNodeButtonGroup } from "@/web/topic/components/Node/AddNodeButtonGroup";
+import { EditableNode } from "@/web/topic/components/Node/EditableNode";
+import { Node } from "@/web/topic/utils/graph";
+import { Orientation } from "@/web/topic/utils/layout";
 
 const gap = 16;
 

--- a/src/web/topic/components/Node/FlowNode.tsx
+++ b/src/web/topic/components/Node/FlowNode.tsx
@@ -2,24 +2,24 @@ import { Global } from "@emotion/react";
 import { motion } from "framer-motion";
 import { useEffect, useMemo, useState } from "react";
 
-import { useSessionUser } from "../../../common/hooks";
-import { getFlashlightMode } from "../../../view/actionConfigStore";
-import { showNodeAndNeighbors } from "../../../view/currentViewStore/filter";
-import { useIsEdgeSelected, useIsNeighborSelected } from "../../store/nodeHooks";
-import { useUserCanEditTopicData } from "../../store/userHooks";
-import { Node } from "../../utils/graph";
-import { orientation } from "../../utils/layout";
-import { FlowNodeType } from "../../utils/node";
-import { NodeProps } from "../Diagram/Diagram";
-import { Spotlight } from "../Diagram/Diagram.styles";
+import { useSessionUser } from "@/web/common/hooks";
+import { NodeProps } from "@/web/topic/components/Diagram/Diagram";
+import { Spotlight } from "@/web/topic/components/Diagram/Diagram.styles";
 import {
   AddNodeButtonGroupChild,
   AddNodeButtonGroupParent,
   HoverBridgeDiv,
   StyledEditableNode,
   nodeStyles,
-} from "./FlowNode.styles";
-import { NodeHandle } from "./NodeHandle";
+} from "@/web/topic/components/Node/FlowNode.styles";
+import { NodeHandle } from "@/web/topic/components/Node/NodeHandle";
+import { useIsEdgeSelected, useIsNeighborSelected } from "@/web/topic/store/nodeHooks";
+import { useUserCanEditTopicData } from "@/web/topic/store/userHooks";
+import { Node } from "@/web/topic/utils/graph";
+import { orientation } from "@/web/topic/utils/layout";
+import { FlowNodeType } from "@/web/topic/utils/node";
+import { getFlashlightMode } from "@/web/view/actionConfigStore";
+import { showNodeAndNeighbors } from "@/web/view/currentViewStore/filter";
 
 const convertToNode = (flowNode: NodeProps): Node => {
   return {

--- a/src/web/topic/components/Node/NodeHandle.tsx
+++ b/src/web/topic/components/Node/NodeHandle.tsx
@@ -3,14 +3,14 @@ import { IconButton, Tooltip, Typography } from "@mui/material";
 import { ReactNode, memo } from "react";
 import { Position } from "reactflow";
 
-import { nodeTypes } from "../../../../common/node";
-import { showNode } from "../../../view/currentViewStore/filter";
-import { useHiddenNodes } from "../../hooks/flowHooks";
-import { useNeighborsInDirection } from "../../store/nodeHooks";
-import { Node, RelationDirection } from "../../utils/graph";
-import { Orientation } from "../../utils/layout";
-import { nodeDecorations } from "../../utils/node";
-import { StyledHandle } from "./NodeHandle.styles";
+import { nodeTypes } from "@/common/node";
+import { StyledHandle } from "@/web/topic/components/Node/NodeHandle.styles";
+import { useHiddenNodes } from "@/web/topic/hooks/flowHooks";
+import { useNeighborsInDirection } from "@/web/topic/store/nodeHooks";
+import { Node, RelationDirection } from "@/web/topic/utils/graph";
+import { Orientation } from "@/web/topic/utils/layout";
+import { nodeDecorations } from "@/web/topic/utils/node";
+import { showNode } from "@/web/view/currentViewStore/filter";
 
 const NodeSummary = ({ node, beforeSlot }: { node: Node; beforeSlot?: ReactNode }) => {
   const { NodeIcon, title } = nodeDecorations[node.type];

--- a/src/web/topic/components/Score/PieChart.tsx
+++ b/src/web/topic/components/Score/PieChart.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { PieChart as ReactMinimalPieChart } from "react-minimal-pie-chart";
 import { BaseDataEntry, Data } from "react-minimal-pie-chart/types/commonTypes";
 
-import { errorWithData } from "../../../../common/errorHandling";
+import { errorWithData } from "@/common/errorHandling";
 
 export interface CustomDataEntry extends BaseDataEntry {
   hoverColor: string;

--- a/src/web/topic/components/Score/Score.stories.tsx
+++ b/src/web/topic/components/Score/Score.stories.tsx
@@ -1,6 +1,6 @@
 import { type Meta, type StoryFn } from "@storybook/react";
 
-import { Score } from "./Score";
+import { Score } from "@/web/topic/components/Score/Score";
 
 export default { component: Score } as Meta<typeof Score>;
 

--- a/src/web/topic/components/Score/Score.tsx
+++ b/src/web/topic/components/Score/Score.tsx
@@ -1,16 +1,16 @@
 import { useRef, useState } from "react";
 
-import { htmlDefaultFontSize } from "../../../../pages/_document.page";
-import { useSessionUser } from "../../../common/hooks";
-import { usePerspectives } from "../../../view/perspectiveStore";
-import { useFlowZoom } from "../../hooks/flowHooks";
-import { useUserScores } from "../../store/scoreHooks";
-import { playgroundUsername } from "../../store/store";
-import { useOnPlayground } from "../../store/topicHooks";
-import { BackdropPopper, CircleDiv, ScorePopper } from "./Score.styles";
-import { ScoreButton, buttonDiameterRem } from "./ScoreButton";
-import { ScoreCompare } from "./ScoreCompare";
-import { ScoreSelect } from "./ScoreSelect";
+import { htmlDefaultFontSize } from "@/pages/_document.page";
+import { useSessionUser } from "@/web/common/hooks";
+import { BackdropPopper, CircleDiv, ScorePopper } from "@/web/topic/components/Score/Score.styles";
+import { ScoreButton, buttonDiameterRem } from "@/web/topic/components/Score/ScoreButton";
+import { ScoreCompare } from "@/web/topic/components/Score/ScoreCompare";
+import { ScoreSelect } from "@/web/topic/components/Score/ScoreSelect";
+import { useFlowZoom } from "@/web/topic/hooks/flowHooks";
+import { useUserScores } from "@/web/topic/store/scoreHooks";
+import { playgroundUsername } from "@/web/topic/store/store";
+import { useOnPlayground } from "@/web/topic/store/topicHooks";
+import { usePerspectives } from "@/web/view/perspectiveStore";
 
 const circleDiameter = 6 * buttonDiameterRem; // no collisions for fitting 10 elements
 

--- a/src/web/topic/components/Score/ScoreButton.tsx
+++ b/src/web/topic/components/Score/ScoreButton.tsx
@@ -1,11 +1,11 @@
 import { Box, type ButtonProps } from "@mui/material";
 import { MutableRefObject } from "react";
 
-import { type Score as ScoreData } from "../../utils/graph";
-import { indicatorLengthRem } from "../../utils/node";
-import { getAverageScore, scoreColors } from "../../utils/score";
-import { StyledButton } from "./ScoreButton.styles";
-import { ScoreCompare } from "./ScoreCompare";
+import { StyledButton } from "@/web/topic/components/Score/ScoreButton.styles";
+import { ScoreCompare } from "@/web/topic/components/Score/ScoreCompare";
+import { type Score as ScoreData } from "@/web/topic/utils/graph";
+import { indicatorLengthRem } from "@/web/topic/utils/node";
+import { getAverageScore, scoreColors } from "@/web/topic/utils/score";
 
 export const buttonDiameterRem = indicatorLengthRem; //rem
 

--- a/src/web/topic/components/Score/ScoreCompare.tsx
+++ b/src/web/topic/components/Score/ScoreCompare.tsx
@@ -5,9 +5,9 @@ import reduce from "lodash/reduce";
 import set from "lodash/set";
 import { Data } from "react-minimal-pie-chart/types/commonTypes";
 
-import { Score } from "../../utils/graph";
-import { scoreColors } from "../../utils/score";
-import { CustomDataEntry, PieChart } from "./PieChart";
+import { CustomDataEntry, PieChart } from "@/web/topic/components/Score/PieChart";
+import { Score } from "@/web/topic/utils/graph";
+import { scoreColors } from "@/web/topic/utils/score";
 
 interface Props {
   userScores: Record<string, Score>;

--- a/src/web/topic/components/Score/ScoreSelect.tsx
+++ b/src/web/topic/components/Score/ScoreSelect.tsx
@@ -2,10 +2,10 @@ import { useTheme } from "@emotion/react";
 import { type PaletteColor } from "@mui/material";
 import { Data } from "react-minimal-pie-chart/types/commonTypes";
 
-import { setScore } from "../../store/actions";
-import { Score, possibleScores } from "../../utils/graph";
-import { scoreColors } from "../../utils/score";
-import { CustomDataEntry, PieChart } from "./PieChart";
+import { CustomDataEntry, PieChart } from "@/web/topic/components/Score/PieChart";
+import { setScore } from "@/web/topic/store/actions";
+import { Score, possibleScores } from "@/web/topic/utils/graph";
+import { scoreColors } from "@/web/topic/utils/score";
 
 interface Props {
   username: string;

--- a/src/web/topic/components/Surface/MoreActionsDrawer.tsx
+++ b/src/web/topic/components/Surface/MoreActionsDrawer.tsx
@@ -30,32 +30,32 @@ import {
 import { toPng } from "html-to-image";
 import { getRectOfNodes, getTransformForBounds } from "reactflow";
 
-import { NumberInput } from "../../../common/components/NumberInput/NumberInput";
+import { NumberInput } from "@/web/common/components/NumberInput/NumberInput";
+import { getDisplayNodes } from "@/web/topic/components/Diagram/externalFlowStore";
+import { downloadTopic, uploadTopic } from "@/web/topic/loadStores";
+import { useOnPlayground } from "@/web/topic/store/topicHooks";
+import { resetTopicData } from "@/web/topic/store/utilActions";
 import {
   toggleFlashlightMode,
   toggleUnrestrictedEditing,
   useFlashlightMode,
   useUnrestrictedEditing,
-} from "../../../view/actionConfigStore";
-import { Perspectives } from "../../../view/components/Perspectives/Perspectives";
-import { toggleShowImpliedEdges, useShowImpliedEdges } from "../../../view/currentViewStore/filter";
+} from "@/web/view/actionConfigStore";
+import { Perspectives } from "@/web/view/components/Perspectives/Perspectives";
+import { toggleShowImpliedEdges, useShowImpliedEdges } from "@/web/view/currentViewStore/filter";
 import {
   setLayoutThoroughness,
   toggleForceNodesIntoLayers,
   useForceNodesIntoLayers,
   useLayoutThoroughness,
-} from "../../../view/currentViewStore/layout";
-import { resetView, useFormat } from "../../../view/currentViewStore/store";
+} from "@/web/view/currentViewStore/layout";
+import { resetView, useFormat } from "@/web/view/currentViewStore/store";
 import {
   toggleShowResolvedComments,
   useShowResolvedComments,
-} from "../../../view/miscTopicConfigStore";
-import { resetQuickViews } from "../../../view/quickViewStore/store";
-import { toggleFillNodesWithColor, useFillNodesWithColor } from "../../../view/userConfigStore";
-import { downloadTopic, uploadTopic } from "../../loadStores";
-import { useOnPlayground } from "../../store/topicHooks";
-import { resetTopicData } from "../../store/utilActions";
-import { getDisplayNodes } from "../Diagram/externalFlowStore";
+} from "@/web/view/miscTopicConfigStore";
+import { resetQuickViews } from "@/web/view/quickViewStore/store";
+import { toggleFillNodesWithColor, useFillNodesWithColor } from "@/web/view/userConfigStore";
 
 const imageWidth = 2560;
 const imageHeight = 1440;

--- a/src/web/topic/components/Surface/TopicToolbar.tsx
+++ b/src/web/topic/components/Surface/TopicToolbar.tsx
@@ -12,26 +12,26 @@ import {
 import { AppBar, Divider, IconButton, ToggleButton, Toolbar, Tooltip } from "@mui/material";
 import { useEffect, useState } from "react";
 
-import { emitter } from "../../../common/event";
-import { useSessionUser } from "../../../common/hooks";
-import { toggleFlashlightMode, useFlashlightMode } from "../../../view/actionConfigStore";
+import { emitter } from "@/web/common/event";
+import { useSessionUser } from "@/web/common/hooks";
+import { MoreActionsDrawer } from "@/web/topic/components/Surface/MoreActionsDrawer";
+import { deleteGraphPart } from "@/web/topic/store/createDeleteActions";
+import { useOnPlayground } from "@/web/topic/store/topicHooks";
+import { useUserCanEditTopicData } from "@/web/topic/store/userHooks";
+import { redo, undo } from "@/web/topic/store/utilActions";
+import { useTemporalHooks } from "@/web/topic/store/utilHooks";
+import { toggleFlashlightMode, useFlashlightMode } from "@/web/view/actionConfigStore";
 import {
   goBack,
   goForward,
   useCanGoBackForward,
   useSelectedGraphPart,
-} from "../../../view/currentViewStore/store";
+} from "@/web/view/currentViewStore/store";
 import {
   comparePerspectives,
   resetPerspectives,
   useIsComparingPerspectives,
-} from "../../../view/perspectiveStore";
-import { deleteGraphPart } from "../../store/createDeleteActions";
-import { useOnPlayground } from "../../store/topicHooks";
-import { useUserCanEditTopicData } from "../../store/userHooks";
-import { redo, undo } from "../../store/utilActions";
-import { useTemporalHooks } from "../../store/utilHooks";
-import { MoreActionsDrawer } from "./MoreActionsDrawer";
+} from "@/web/view/perspectiveStore";
 
 export const TopicToolbar = () => {
   const { sessionUser } = useSessionUser();

--- a/src/web/topic/components/TopicForm/TopicForm.tsx
+++ b/src/web/topic/components/TopicForm/TopicForm.tsx
@@ -23,9 +23,9 @@ import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { z } from "zod";
 
-import { topicSchema, visibilityTypes } from "../../../../common/topic";
-import { trpc } from "../../../common/trpc";
-import { generateBasicViews } from "../../../view/quickViewStore/store";
+import { topicSchema, visibilityTypes } from "@/common/topic";
+import { trpc } from "@/web/common/trpc";
+import { generateBasicViews } from "@/web/view/quickViewStore/store";
 
 export const CreateTopicForm = ({ user }: { user: User }) => {
   const utils = trpc.useContext();

--- a/src/web/topic/components/TopicPane/AnswerDetails.tsx
+++ b/src/web/topic/components/TopicPane/AnswerDetails.tsx
@@ -1,9 +1,9 @@
 import { QuestionMark } from "@mui/icons-material";
 import { ListItem, ListItemIcon, ListItemText, Stack, Typography } from "@mui/material";
 
-import { useAnswerDetails } from "../../store/nodeTypeHooks";
-import { Node } from "../../utils/graph";
-import { EditableNode } from "../Node/EditableNode";
+import { EditableNode } from "@/web/topic/components/Node/EditableNode";
+import { useAnswerDetails } from "@/web/topic/store/nodeTypeHooks";
+import { Node } from "@/web/topic/utils/graph";
 
 interface Props {
   answerNode: Node & { type: "answer" };

--- a/src/web/topic/components/TopicPane/CommentSection.tsx
+++ b/src/web/topic/components/TopicPane/CommentSection.tsx
@@ -1,15 +1,15 @@
 import { ChatBubble } from "@mui/icons-material";
 import { ListItem, ListItemIcon, ListItemText } from "@mui/material";
 
-import { CommentParentType } from "../../../../common/comment";
-import { Draft } from "../../../comment/components/Draft";
-import { Thread } from "../../../comment/components/Thread";
-import { useRootComments } from "../../../comment/store/commentStore";
-import { useDraft } from "../../../comment/store/draftStore";
-import { useSessionUser } from "../../../common/hooks";
-import { useShowResolvedComments } from "../../../view/miscTopicConfigStore";
-import { playgroundUsername } from "../../store/store";
-import { useOnPlayground } from "../../store/topicHooks";
+import { CommentParentType } from "@/common/comment";
+import { Draft } from "@/web/comment/components/Draft";
+import { Thread } from "@/web/comment/components/Thread";
+import { useRootComments } from "@/web/comment/store/commentStore";
+import { useDraft } from "@/web/comment/store/draftStore";
+import { useSessionUser } from "@/web/common/hooks";
+import { playgroundUsername } from "@/web/topic/store/store";
+import { useOnPlayground } from "@/web/topic/store/topicHooks";
+import { useShowResolvedComments } from "@/web/view/miscTopicConfigStore";
 
 interface Props {
   parentId: string | null;

--- a/src/web/topic/components/TopicPane/DetailsClaimsSection.tsx
+++ b/src/web/topic/components/TopicPane/DetailsClaimsSection.tsx
@@ -1,14 +1,14 @@
 import { ThumbsUpDown } from "@mui/icons-material";
 import { ListItem, ListItemIcon, ListItemText, Stack, Typography } from "@mui/material";
 
-import { justificationNodeTypes } from "../../../../common/node";
-import { useTopLevelClaims } from "../../store/graphPartHooks";
-import { isClaimEdge } from "../../utils/claim";
-import { GraphPart, isNode } from "../../utils/graph";
-import { ClaimTreeIndicator } from "../Indicator/ClaimTreeIndicator";
-import { AddNodeButton } from "../Node/AddNodeButton";
-import { EditableNode } from "../Node/EditableNode";
-import { nodeWidthPx } from "../Node/EditableNode.styles";
+import { justificationNodeTypes } from "@/common/node";
+import { ClaimTreeIndicator } from "@/web/topic/components/Indicator/ClaimTreeIndicator";
+import { AddNodeButton } from "@/web/topic/components/Node/AddNodeButton";
+import { EditableNode } from "@/web/topic/components/Node/EditableNode";
+import { nodeWidthPx } from "@/web/topic/components/Node/EditableNode.styles";
+import { useTopLevelClaims } from "@/web/topic/store/graphPartHooks";
+import { isClaimEdge } from "@/web/topic/utils/claim";
+import { GraphPart, isNode } from "@/web/topic/utils/graph";
 
 interface Props {
   graphPart: GraphPart;

--- a/src/web/topic/components/TopicPane/DetailsResearchSection.tsx
+++ b/src/web/topic/components/TopicPane/DetailsResearchSection.tsx
@@ -1,10 +1,10 @@
 import { School } from "@mui/icons-material";
 import { ListItem, ListItemIcon, ListItemText, Stack, Typography } from "@mui/material";
 
-import { useResearchNodes } from "../../store/graphPartHooks";
-import { Node } from "../../utils/graph";
-import { AddNodeButton } from "../Node/AddNodeButton";
-import { EditableNode } from "../Node/EditableNode";
+import { AddNodeButton } from "@/web/topic/components/Node/AddNodeButton";
+import { EditableNode } from "@/web/topic/components/Node/EditableNode";
+import { useResearchNodes } from "@/web/topic/store/graphPartHooks";
+import { Node } from "@/web/topic/utils/graph";
 
 interface Props {
   node: Node;

--- a/src/web/topic/components/TopicPane/FactDetails.tsx
+++ b/src/web/topic/components/TopicPane/FactDetails.tsx
@@ -1,11 +1,11 @@
 import { Code, Schema } from "@mui/icons-material";
 import { ListItem, ListItemIcon, ListItemText, Stack, Typography } from "@mui/material";
 
-import { useFactDetails } from "../../store/nodeTypeHooks";
-import { Node } from "../../utils/graph";
-import { StandaloneEdge } from "../Edge/StandaloneEdge";
-import { AddNodeButton } from "../Node/AddNodeButton";
-import { EditableNode } from "../Node/EditableNode";
+import { StandaloneEdge } from "@/web/topic/components/Edge/StandaloneEdge";
+import { AddNodeButton } from "@/web/topic/components/Node/AddNodeButton";
+import { EditableNode } from "@/web/topic/components/Node/EditableNode";
+import { useFactDetails } from "@/web/topic/store/nodeTypeHooks";
+import { Node } from "@/web/topic/utils/graph";
 
 interface Props {
   factNode: Node & { type: "fact" };

--- a/src/web/topic/components/TopicPane/GraphPartDetails.tsx
+++ b/src/web/topic/components/TopicPane/GraphPartDetails.tsx
@@ -6,21 +6,21 @@ import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
-import { nodeSchema, researchNodeTypes } from "../../../../common/node";
-import { useSessionUser } from "../../../common/hooks";
-import { setGraphPartNotes } from "../../store/actions";
-import { useUserCanEditTopicData } from "../../store/userHooks";
-import { GraphPart, isNode, isNodeType } from "../../utils/graph";
-import { nodeDecorations } from "../../utils/node";
-import { StandaloneEdge } from "../Edge/StandaloneEdge";
-import { EditableNode } from "../Node/EditableNode";
-import { AnswerDetails } from "./AnswerDetails";
-import { CommentSection } from "./CommentSection";
-import { DetailsClaimsSection } from "./DetailsClaimsSection";
-import { DetailsResearchSection } from "./DetailsResearchSection";
-import { FactDetails } from "./FactDetails";
-import { QuestionDetails } from "./QuestionDetails";
-import { SourceDetails } from "./SourceDetails";
+import { nodeSchema, researchNodeTypes } from "@/common/node";
+import { useSessionUser } from "@/web/common/hooks";
+import { StandaloneEdge } from "@/web/topic/components/Edge/StandaloneEdge";
+import { EditableNode } from "@/web/topic/components/Node/EditableNode";
+import { AnswerDetails } from "@/web/topic/components/TopicPane/AnswerDetails";
+import { CommentSection } from "@/web/topic/components/TopicPane/CommentSection";
+import { DetailsClaimsSection } from "@/web/topic/components/TopicPane/DetailsClaimsSection";
+import { DetailsResearchSection } from "@/web/topic/components/TopicPane/DetailsResearchSection";
+import { FactDetails } from "@/web/topic/components/TopicPane/FactDetails";
+import { QuestionDetails } from "@/web/topic/components/TopicPane/QuestionDetails";
+import { SourceDetails } from "@/web/topic/components/TopicPane/SourceDetails";
+import { setGraphPartNotes } from "@/web/topic/store/actions";
+import { useUserCanEditTopicData } from "@/web/topic/store/userHooks";
+import { GraphPart, isNode, isNodeType } from "@/web/topic/utils/graph";
+import { nodeDecorations } from "@/web/topic/utils/node";
 
 const formSchema = z.object({
   // same restrictions as edge, so we should be fine reusing node's schema

--- a/src/web/topic/components/TopicPane/QuestionDetails.tsx
+++ b/src/web/topic/components/TopicPane/QuestionDetails.tsx
@@ -1,11 +1,11 @@
 import { PriorityHigh, Schema } from "@mui/icons-material";
 import { ListItem, ListItemIcon, ListItemText, Stack, Typography } from "@mui/material";
 
-import { useQuestionDetails } from "../../store/nodeTypeHooks";
-import { Node, isNode } from "../../utils/graph";
-import { StandaloneEdge } from "../Edge/StandaloneEdge";
-import { AddNodeButton } from "../Node/AddNodeButton";
-import { EditableNode } from "../Node/EditableNode";
+import { StandaloneEdge } from "@/web/topic/components/Edge/StandaloneEdge";
+import { AddNodeButton } from "@/web/topic/components/Node/AddNodeButton";
+import { EditableNode } from "@/web/topic/components/Node/EditableNode";
+import { useQuestionDetails } from "@/web/topic/store/nodeTypeHooks";
+import { Node, isNode } from "@/web/topic/utils/graph";
 
 interface Props {
   questionNode: Node & { type: "question" };

--- a/src/web/topic/components/TopicPane/QuickViewForm.tsx
+++ b/src/web/topic/components/TopicPane/QuickViewForm.tsx
@@ -11,8 +11,8 @@ import { FormEvent } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
-import { quickViewSchema } from "../../../../common/view";
-import { QuickView, setTitle } from "../../../view/quickViewStore/store";
+import { quickViewSchema } from "@/common/view";
+import { QuickView, setTitle } from "@/web/view/quickViewStore/store";
 
 interface Props {
   currentView: QuickView;

--- a/src/web/topic/components/TopicPane/QuickViewSection.tsx
+++ b/src/web/topic/components/TopicPane/QuickViewSection.tsx
@@ -10,7 +10,9 @@ import {
 } from "@mui/material";
 import { useState } from "react";
 
-import { useSessionUser } from "../../../common/hooks";
+import { useSessionUser } from "@/web/common/hooks";
+import { QuickViewForm } from "@/web/topic/components/TopicPane/QuickViewForm";
+import { useUserCanEditTopicData } from "@/web/topic/store/userHooks";
 import {
   QuickView,
   createView,
@@ -22,9 +24,7 @@ import {
   useCanUndoRedo,
   useQuickViews,
   useSelectedViewId,
-} from "../../../view/quickViewStore/store";
-import { useUserCanEditTopicData } from "../../store/userHooks";
-import { QuickViewForm } from "./QuickViewForm";
+} from "@/web/view/quickViewStore/store";
 
 export const QuickViewSection = () => {
   const { sessionUser } = useSessionUser();

--- a/src/web/topic/components/TopicPane/SourceDetails.tsx
+++ b/src/web/topic/components/TopicPane/SourceDetails.tsx
@@ -1,11 +1,11 @@
 import { Info, Schema } from "@mui/icons-material";
 import { ListItem, ListItemIcon, ListItemText, Stack, Typography } from "@mui/material";
 
-import { useSourceDetails } from "../../store/nodeTypeHooks";
-import { Node } from "../../utils/graph";
-import { StandaloneEdge } from "../Edge/StandaloneEdge";
-import { AddNodeButton } from "../Node/AddNodeButton";
-import { EditableNode } from "../Node/EditableNode";
+import { StandaloneEdge } from "@/web/topic/components/Edge/StandaloneEdge";
+import { AddNodeButton } from "@/web/topic/components/Node/AddNodeButton";
+import { EditableNode } from "@/web/topic/components/Node/EditableNode";
+import { useSourceDetails } from "@/web/topic/store/nodeTypeHooks";
+import { Node } from "@/web/topic/utils/graph";
 
 interface Props {
   sourceNode: Node & { type: "source" };

--- a/src/web/topic/components/TopicPane/TopicDetails.tsx
+++ b/src/web/topic/components/TopicPane/TopicDetails.tsx
@@ -14,13 +14,13 @@ import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
-import { topicSchema } from "../../../../common/topic";
-import { Link } from "../../../common/components/Link";
-import { useSessionUser } from "../../../common/hooks";
-import { setTopicDetails } from "../../store/topicActions";
-import { useTopic } from "../../store/topicHooks";
-import { useUserCanEditTopicData, useUserIsCreator } from "../../store/userHooks";
-import { CommentSection } from "./CommentSection";
+import { topicSchema } from "@/common/topic";
+import { Link } from "@/web/common/components/Link";
+import { useSessionUser } from "@/web/common/hooks";
+import { CommentSection } from "@/web/topic/components/TopicPane/CommentSection";
+import { setTopicDetails } from "@/web/topic/store/topicActions";
+import { useTopic } from "@/web/topic/store/topicHooks";
+import { useUserCanEditTopicData, useUserIsCreator } from "@/web/topic/store/userHooks";
 
 const formSchema = () => {
   return z.object({

--- a/src/web/topic/components/TopicPane/TopicPane.styles.tsx
+++ b/src/web/topic/components/TopicPane/TopicPane.styles.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { Drawer, IconButton, css } from "@mui/material";
 
-import { nodeWidthRem } from "../Node/EditableNode.styles";
+import { nodeWidthRem } from "@/web/topic/components/Node/EditableNode.styles";
 
 export const PositionedDiv = styled.div`
   display: flex;

--- a/src/web/topic/components/TopicPane/TopicPane.tsx
+++ b/src/web/topic/components/TopicPane/TopicPane.tsx
@@ -2,12 +2,20 @@ import { AutoStories, ChevronLeft, KeyboardArrowDown } from "@mui/icons-material
 import { TabContext, TabList, TabPanel } from "@mui/lab";
 import { Tab } from "@mui/material";
 
-import { useSelectedGraphPart } from "../../../view/currentViewStore/store";
-import { GraphPartDetails } from "./GraphPartDetails";
-import { TopicDetails } from "./TopicDetails";
-import { PositionedDiv, StyledDrawer, TogglePaneButton } from "./TopicPane.styles";
-import { TopicViews } from "./TopicViews";
-import { setIsTopicPaneOpen, setSelectedTab, usePaneStore } from "./paneStore";
+import { GraphPartDetails } from "@/web/topic/components/TopicPane/GraphPartDetails";
+import { TopicDetails } from "@/web/topic/components/TopicPane/TopicDetails";
+import {
+  PositionedDiv,
+  StyledDrawer,
+  TogglePaneButton,
+} from "@/web/topic/components/TopicPane/TopicPane.styles";
+import { TopicViews } from "@/web/topic/components/TopicPane/TopicViews";
+import {
+  setIsTopicPaneOpen,
+  setSelectedTab,
+  usePaneStore,
+} from "@/web/topic/components/TopicPane/paneStore";
+import { useSelectedGraphPart } from "@/web/view/currentViewStore/store";
 
 interface Props {
   isLandscape: boolean;

--- a/src/web/topic/components/TopicPane/TopicViews.tsx
+++ b/src/web/topic/components/TopicPane/TopicViews.tsx
@@ -10,11 +10,11 @@ import {
 } from "@mui/material";
 import { useState } from "react";
 
-import { GeneralFilters } from "../../../view/components/Filter/GeneralFilters";
-import { InformationFilters } from "../../../view/components/Filter/InformationFilters";
-import { TableFilters } from "../../../view/components/Filter/TableFilters";
-import { setFormat, useFormat } from "../../../view/currentViewStore/store";
-import { QuickViewSection } from "./QuickViewSection";
+import { QuickViewSection } from "@/web/topic/components/TopicPane/QuickViewSection";
+import { GeneralFilters } from "@/web/view/components/Filter/GeneralFilters";
+import { InformationFilters } from "@/web/view/components/Filter/InformationFilters";
+import { TableFilters } from "@/web/view/components/Filter/TableFilters";
+import { setFormat, useFormat } from "@/web/view/currentViewStore/store";
 
 export const TopicViews = () => {
   const [isFormatSectionOpen, setIsFormatSectionOpen] = useState(true);

--- a/src/web/topic/components/TopicWorkspace/TopicWorkspace.tsx
+++ b/src/web/topic/components/TopicWorkspace/TopicWorkspace.tsx
@@ -1,12 +1,12 @@
 import { Global } from "@emotion/react";
 import { Box, useMediaQuery } from "@mui/material";
 
-import { ContextMenu } from "../../../common/components/ContextMenu/ContextMenu";
-import { useFormat } from "../../../view/currentViewStore/store";
-import { CriteriaTable } from "../CriteriaTable/CriteriaTable";
-import { Diagram } from "../Diagram/Diagram";
-import { TopicToolbar } from "../Surface/TopicToolbar";
-import { TopicPane } from "../TopicPane/TopicPane";
+import { ContextMenu } from "@/web/common/components/ContextMenu/ContextMenu";
+import { CriteriaTable } from "@/web/topic/components/CriteriaTable/CriteriaTable";
+import { Diagram } from "@/web/topic/components/Diagram/Diagram";
+import { TopicToolbar } from "@/web/topic/components/Surface/TopicToolbar";
+import { TopicPane } from "@/web/topic/components/TopicPane/TopicPane";
+import { useFormat } from "@/web/view/currentViewStore/store";
 
 export const TopicWorkspace = () => {
   const isLandscape = useMediaQuery("(orientation: landscape)");

--- a/src/web/topic/hooks/diagramHooks.ts
+++ b/src/web/topic/hooks/diagramHooks.ts
@@ -1,9 +1,9 @@
 import { useState } from "react";
 
-import { useForceNodesIntoLayers, useLayoutThoroughness } from "../../view/currentViewStore/layout";
-import { useSelectedGraphPart } from "../../view/currentViewStore/store";
-import { Diagram, PositionedDiagram, PositionedNode } from "../utils/diagram";
-import { NodePosition, layout } from "../utils/layout";
+import { Diagram, PositionedDiagram, PositionedNode } from "@/web/topic/utils/diagram";
+import { NodePosition, layout } from "@/web/topic/utils/layout";
+import { useForceNodesIntoLayers, useLayoutThoroughness } from "@/web/view/currentViewStore/layout";
+import { useSelectedGraphPart } from "@/web/view/currentViewStore/store";
 
 // re-renders when diagram changes, but only re-layouts if graph parts are added or removed
 export const useLayoutedDiagram = (diagram: Diagram) => {

--- a/src/web/topic/hooks/flowHooks.ts
+++ b/src/web/topic/hooks/flowHooks.ts
@@ -8,9 +8,9 @@ import {
 } from "reactflow";
 import { shallow } from "zustand/shallow";
 
-import { nodeHeightPx, nodeWidthPx } from "../components/Node/EditableNode.styles";
-import { PositionedNode } from "../utils/diagram";
-import { Node } from "../utils/graph";
+import { nodeHeightPx, nodeWidthPx } from "@/web/topic/components/Node/EditableNode.styles";
+import { PositionedNode } from "@/web/topic/utils/diagram";
+import { Node } from "@/web/topic/utils/graph";
 
 const getViewportToIncludeNode = (
   node: PositionedNode,

--- a/src/web/topic/loadStores.ts
+++ b/src/web/topic/loadStores.ts
@@ -12,18 +12,18 @@ import { v4 as uuid } from "uuid";
 import { z } from "zod";
 import { StorageValue } from "zustand/middleware";
 
-import { errorWithData } from "../../common/errorHandling";
+import { errorWithData } from "@/common/errorHandling";
+import { migrate } from "@/web/topic/store/migrate";
+import { TopicStoreState } from "@/web/topic/store/store";
+import { getPersistState, setTopicData } from "@/web/topic/store/utilActions";
+import { getTopicTitle } from "@/web/topic/store/utils";
 import {
   QuickViewStoreState,
   currentVersion as currentViewsVersion,
   getPersistState as getViewsPersistState,
   initialStateWithBasicViews,
   loadQuickViewsFromDownloaded,
-} from "../view/quickViewStore/store";
-import { migrate } from "./store/migrate";
-import { TopicStoreState } from "./store/store";
-import { getPersistState, setTopicData } from "./store/utilActions";
-import { getTopicTitle } from "./store/utils";
+} from "@/web/view/quickViewStore/store";
 
 const oldDownloadSchema1 = z.object({
   state: z.record(z.any()),

--- a/src/web/topic/store/actions.ts
+++ b/src/web/topic/store/actions.ts
@@ -1,9 +1,10 @@
 import { createDraft, finishDraft } from "immer";
 import set from "lodash/set";
 
-import { RelationName, edgeSchema } from "../../../common/edge";
-import { errorWithData } from "../../../common/errorHandling";
-import { NodeType, nodeSchema } from "../../../common/node";
+import { RelationName, edgeSchema } from "@/common/edge";
+import { errorWithData } from "@/common/errorHandling";
+import { NodeType, nodeSchema } from "@/common/node";
+import { useTopicStore } from "@/web/topic/store/store";
 import {
   Edge,
   GraphPart,
@@ -12,8 +13,7 @@ import {
   findEdgeOrThrow,
   findGraphPartOrThrow,
   findNodeOrThrow,
-} from "../utils/graph";
-import { useTopicStore } from "./store";
+} from "@/web/topic/utils/graph";
 
 // score setting is way more work than it needs to be because one score can live in multiple places:
 // - on the graphPart

--- a/src/web/topic/store/apiSyncerMiddleware.ts
+++ b/src/web/topic/store/apiSyncerMiddleware.ts
@@ -1,11 +1,11 @@
 import diff from "microdiff";
 import { StateCreator, StoreMutatorIdentifier } from "zustand";
 
-import { trpcClient } from "../../../pages/_app.page";
-import { emitter } from "../../common/event";
-import { convertToApi } from "../utils/apiConversion";
-import { TopicStoreState } from "./store";
-import { isPlaygroundTopic } from "./utils";
+import { trpcClient } from "@/pages/_app.page";
+import { emitter } from "@/web/common/event";
+import { TopicStoreState } from "@/web/topic/store/store";
+import { isPlaygroundTopic } from "@/web/topic/store/utils";
+import { convertToApi } from "@/web/topic/utils/apiConversion";
 
 const getCrudDiffs = <T>(
   before: T[],

--- a/src/web/topic/store/createDeleteActions.ts
+++ b/src/web/topic/store/createDeleteActions.ts
@@ -1,12 +1,12 @@
 import { createDraft, finishDraft } from "immer";
 
-import { errorWithData } from "../../../common/errorHandling";
-import { justificationNodeTypes, structureNodeTypes } from "../../../common/node";
-import { emitter } from "../../common/event";
-import { getUnrestrictedEditing } from "../../view/actionConfigStore";
-import { setSelected } from "../../view/currentViewStore/store";
-import { getImplicitLabel } from "../utils/claim";
-import { Relation, canCreateEdge, getRelation } from "../utils/edge";
+import { errorWithData } from "@/common/errorHandling";
+import { justificationNodeTypes, structureNodeTypes } from "@/common/node";
+import { emitter } from "@/web/common/event";
+import { getExplicitClaimCount } from "@/web/topic/store/graphPartHooks";
+import { TopicStoreState, useTopicStore } from "@/web/topic/store/store";
+import { getImplicitLabel } from "@/web/topic/utils/claim";
+import { Relation, canCreateEdge, getRelation } from "@/web/topic/utils/edge";
 import {
   Graph,
   type GraphPart,
@@ -18,10 +18,10 @@ import {
   findNodeOrThrow,
   getNodesComposedBy,
   isNode,
-} from "../utils/graph";
-import { FlowNodeType, edges } from "../utils/node";
-import { getExplicitClaimCount } from "./graphPartHooks";
-import { TopicStoreState, useTopicStore } from "./store";
+} from "@/web/topic/utils/graph";
+import { FlowNodeType, edges } from "@/web/topic/utils/node";
+import { getUnrestrictedEditing } from "@/web/view/actionConfigStore";
+import { setSelected } from "@/web/view/currentViewStore/store";
 
 const createNode = (
   state: TopicStoreState,

--- a/src/web/topic/store/edgeHooks.ts
+++ b/src/web/topic/store/edgeHooks.ts
@@ -1,9 +1,9 @@
 import { shallow } from "zustand/shallow";
 
-import { useIsAnyGraphPartSelected } from "../../view/currentViewStore/store";
-import { nodes } from "../utils/edge";
-import { findEdgeOrThrow } from "../utils/graph";
-import { useTopicStore } from "./store";
+import { useTopicStore } from "@/web/topic/store/store";
+import { nodes } from "@/web/topic/utils/edge";
+import { findEdgeOrThrow } from "@/web/topic/utils/graph";
+import { useIsAnyGraphPartSelected } from "@/web/view/currentViewStore/store";
 
 export const useIsNodeSelected = (edgeId: string) => {
   const neighborNodes = useTopicStore((state) => {

--- a/src/web/topic/store/graphPartHooks.ts
+++ b/src/web/topic/store/graphPartHooks.ts
@@ -1,11 +1,11 @@
 import { shallow } from "zustand/shallow";
 
-import { justificationRelationNames } from "../../../common/edge";
-import { NodeType, justificationNodeTypes, researchNodeTypes } from "../../../common/node";
-import { deepIsEqual } from "../../../common/utils";
-import { isClaimEdge } from "../utils/claim";
-import { Node } from "../utils/graph";
-import { TopicStoreState, useTopicStore } from "./store";
+import { justificationRelationNames } from "@/common/edge";
+import { NodeType, justificationNodeTypes, researchNodeTypes } from "@/common/node";
+import { deepIsEqual } from "@/common/utils";
+import { TopicStoreState, useTopicStore } from "@/web/topic/store/store";
+import { isClaimEdge } from "@/web/topic/utils/claim";
+import { Node } from "@/web/topic/utils/graph";
 
 export const useRootClaim = (graphPartId: string) => {
   return useTopicStore((state) => {

--- a/src/web/topic/store/loadActions.ts
+++ b/src/web/topic/store/loadActions.ts
@@ -1,10 +1,10 @@
+import { initialState, topicStorePlaygroundName, useTopicStore } from "@/web/topic/store/store";
 import {
   type TopicData,
   convertToStoreEdge,
   convertToStoreNode,
   convertToStoreScores,
-} from "../utils/apiConversion";
-import { initialState, topicStorePlaygroundName, useTopicStore } from "./store";
+} from "@/web/topic/utils/apiConversion";
 
 export const populateDiagramFromApi = (topicData: TopicData) => {
   // Ensure we use distinct persistence for topic page compared to playground.

--- a/src/web/topic/store/nodeGetters.ts
+++ b/src/web/topic/store/nodeGetters.ts
@@ -1,5 +1,5 @@
-import { NodeType } from "../../../common/node";
-import { useTopicStore } from "./store";
+import { NodeType } from "@/common/node";
+import { useTopicStore } from "@/web/topic/store/store";
 
 export const getDefaultNode = (nodeType: NodeType) => {
   const state = useTopicStore.getState();

--- a/src/web/topic/store/nodeHooks.ts
+++ b/src/web/topic/store/nodeHooks.ts
@@ -1,12 +1,12 @@
 import { shallow } from "zustand/shallow";
 
-import { errorWithData } from "../../../common/errorHandling";
-import { NodeType } from "../../../common/node";
-import { useIsAnyGraphPartSelected } from "../../view/currentViewStore/store";
-import { RelationDirection, findNodeOrThrow } from "../utils/graph";
-import { children, edges, neighbors, parents } from "../utils/node";
-import { getDefaultNode } from "./nodeGetters";
-import { useTopicStore } from "./store";
+import { errorWithData } from "@/common/errorHandling";
+import { NodeType } from "@/common/node";
+import { getDefaultNode } from "@/web/topic/store/nodeGetters";
+import { useTopicStore } from "@/web/topic/store/store";
+import { RelationDirection, findNodeOrThrow } from "@/web/topic/utils/graph";
+import { children, edges, neighbors, parents } from "@/web/topic/utils/node";
+import { useIsAnyGraphPartSelected } from "@/web/view/currentViewStore/store";
 
 export const useNode = (nodeId: string | null) => {
   return useTopicStore((state) => {

--- a/src/web/topic/store/nodeTypeHooks.ts
+++ b/src/web/topic/store/nodeTypeHooks.ts
@@ -1,5 +1,5 @@
-import { findGraphPartOrThrow, findNodeOrThrow } from "../utils/graph";
-import { useTopicStore } from "./store";
+import { useTopicStore } from "@/web/topic/store/store";
+import { findGraphPartOrThrow, findNodeOrThrow } from "@/web/topic/utils/graph";
 
 export const useQuestionDetails = (questionNodeId: string) => {
   return useTopicStore((state) => {

--- a/src/web/topic/store/scoreGetters.ts
+++ b/src/web/topic/store/scoreGetters.ts
@@ -1,8 +1,8 @@
 import get from "lodash/get";
 
-import { Score } from "../utils/graph";
-import { getAverageScore } from "../utils/score";
-import { UserScores } from "./store";
+import { UserScores } from "@/web/topic/store/store";
+import { Score } from "@/web/topic/utils/graph";
+import { getAverageScore } from "@/web/topic/utils/score";
 
 export const getDisplayScoresByGraphPartId = (
   graphPartIds: string[],

--- a/src/web/topic/store/scoreHooks.ts
+++ b/src/web/topic/store/scoreHooks.ts
@@ -3,13 +3,13 @@ import get from "lodash/get";
 import sum from "lodash/sum";
 import { shallow } from "zustand/shallow";
 
-import { throwError } from "../../../common/errorHandling";
-import { usePerspectives } from "../../view/perspectiveStore";
-import { Node, Score } from "../utils/graph";
-import { children, edges } from "../utils/node";
-import { getNumericScore } from "../utils/score";
-import { getDisplayScoresByGraphPartId } from "./scoreGetters";
-import { useTopicStore } from "./store";
+import { throwError } from "@/common/errorHandling";
+import { getDisplayScoresByGraphPartId } from "@/web/topic/store/scoreGetters";
+import { useTopicStore } from "@/web/topic/store/store";
+import { Node, Score } from "@/web/topic/utils/graph";
+import { children, edges } from "@/web/topic/utils/node";
+import { getNumericScore } from "@/web/topic/utils/score";
+import { usePerspectives } from "@/web/view/perspectiveStore";
 
 export const useDisplayScores = (graphPartIds: string[]): Record<string, Score> => {
   const perspectives = usePerspectives();

--- a/src/web/topic/store/store.ts
+++ b/src/web/topic/store/store.ts
@@ -3,16 +3,11 @@ import { temporal } from "zundo";
 import { devtools, persist } from "zustand/middleware";
 import { createWithEqualityFn } from "zustand/traditional";
 
-import {
-  useDiagramFilter,
-  useGeneralFilter,
-  useShowImpliedEdges,
-} from "../../view/currentViewStore/filter";
-import { usePerspectives } from "../../view/perspectiveStore";
-import { applyDiagramFilter } from "../../view/utils/diagramFilter";
-import { applyNodeTypeFilter, applyScoreFilter } from "../../view/utils/generalFilter";
-import { Diagram } from "../utils/diagram";
-import { hideImpliedEdges } from "../utils/edge";
+import { apiSyncer } from "@/web/topic/store/apiSyncerMiddleware";
+import { migrate } from "@/web/topic/store/migrate";
+import { getDisplayScoresByGraphPartId } from "@/web/topic/store/scoreGetters";
+import { Diagram } from "@/web/topic/utils/diagram";
+import { hideImpliedEdges } from "@/web/topic/utils/edge";
 import {
   Edge,
   Node,
@@ -20,10 +15,15 @@ import {
   buildNode,
   getRelevantEdges,
   getSecondaryNeighbors,
-} from "../utils/graph";
-import { apiSyncer } from "./apiSyncerMiddleware";
-import { migrate } from "./migrate";
-import { getDisplayScoresByGraphPartId } from "./scoreGetters";
+} from "@/web/topic/utils/graph";
+import {
+  useDiagramFilter,
+  useGeneralFilter,
+  useShowImpliedEdges,
+} from "@/web/view/currentViewStore/filter";
+import { usePerspectives } from "@/web/view/perspectiveStore";
+import { applyDiagramFilter } from "@/web/view/utils/diagramFilter";
+import { applyNodeTypeFilter, applyScoreFilter } from "@/web/view/utils/generalFilter";
 
 export interface PlaygroundTopic {
   id: undefined; // so we can check this to see if the store topic is a playground topic

--- a/src/web/topic/store/topicActions.ts
+++ b/src/web/topic/store/topicActions.ts
@@ -1,6 +1,6 @@
 import { createDraft, finishDraft } from "immer";
 
-import { useTopicStore } from "./store";
+import { useTopicStore } from "@/web/topic/store/store";
 
 export const setTopicDetails = (description: string) => {
   const state = createDraft(useTopicStore.getState());

--- a/src/web/topic/store/topicHooks.ts
+++ b/src/web/topic/store/topicHooks.ts
@@ -1,7 +1,7 @@
 import { shallow } from "zustand/shallow";
 
-import { useTopicStore } from "./store";
-import { isPlaygroundTopic } from "./utils";
+import { useTopicStore } from "@/web/topic/store/store";
+import { isPlaygroundTopic } from "@/web/topic/store/utils";
 
 export const useOnPlayground = () => {
   return useTopicStore((state) => isPlaygroundTopic(state.topic));

--- a/src/web/topic/store/userHooks.ts
+++ b/src/web/topic/store/userHooks.ts
@@ -1,8 +1,8 @@
 import { shallow } from "zustand/shallow";
 
-import { trpc } from "../../common/trpc";
-import { UserTopic, useTopicStore } from "./store";
-import { isPlaygroundTopic } from "./utils";
+import { trpc } from "@/web/common/trpc";
+import { UserTopic, useTopicStore } from "@/web/topic/store/store";
+import { isPlaygroundTopic } from "@/web/topic/store/utils";
 
 // TODO: for security, this should probably get the session user rather than assume the username is from the session user
 export const useUserCanEditTopicData = (username?: string) => {

--- a/src/web/topic/store/utilActions.ts
+++ b/src/web/topic/store/utilActions.ts
@@ -1,9 +1,14 @@
 import { StorageValue } from "zustand/middleware";
 
-import { errorWithData } from "../../../common/errorHandling";
-import { emitter } from "../../common/event";
-import { TopicStoreState, initialState, playgroundUsername, useTopicStore } from "./store";
-import { isPlaygroundTopic } from "./utils";
+import { errorWithData } from "@/common/errorHandling";
+import { emitter } from "@/web/common/event";
+import {
+  TopicStoreState,
+  initialState,
+  playgroundUsername,
+  useTopicStore,
+} from "@/web/topic/store/store";
+import { isPlaygroundTopic } from "@/web/topic/store/utils";
 
 export const getPersistState = () => {
   const persistOptions = useTopicStore.persist.getOptions();

--- a/src/web/topic/store/utilHooks.ts
+++ b/src/web/topic/store/utilHooks.ts
@@ -1,6 +1,6 @@
 import { useStore } from "zustand";
 
-import { useTopicStore } from "./store";
+import { useTopicStore } from "@/web/topic/store/store";
 
 // temporal store is a vanilla store, we need to wrap it to use it as a hook and be able to react to changes
 const useTopicTemporalStore = () => useStore(useTopicStore.temporal);

--- a/src/web/topic/store/utils.ts
+++ b/src/web/topic/store/utils.ts
@@ -1,5 +1,5 @@
-import { errorWithData } from "../../../common/errorHandling";
-import { PlaygroundTopic, StoreTopic, TopicStoreState } from "./store";
+import { errorWithData } from "@/common/errorHandling";
+import { PlaygroundTopic, StoreTopic, TopicStoreState } from "@/web/topic/store/store";
 
 export const getTopicTitle = (state: TopicStoreState) => {
   const rootNode = state.nodes[0];

--- a/src/web/topic/utils/apiConversion.ts
+++ b/src/web/topic/utils/apiConversion.ts
@@ -2,13 +2,19 @@ import { inferRouterOutputs } from "@trpc/server";
 import compact from "lodash/compact";
 import set from "lodash/set";
 
-import { AppRouter } from "../../../api/routers/_app";
-import { Edge as ApiEdge, Edge } from "../../../common/edge";
-import { Node as ApiNode, Node } from "../../../common/node";
-import { UserScore as ApiScore } from "../../../common/userScore";
-import { UserScores as StoreScores, TopicStoreState } from "../store/store";
-import { isPlaygroundTopic } from "../store/utils";
-import { Score, Edge as StoreEdge, Node as StoreNode, buildEdge, buildNode } from "./graph";
+import { AppRouter } from "@/api/routers/_app";
+import { Edge as ApiEdge, Edge } from "@/common/edge";
+import { Node as ApiNode, Node } from "@/common/node";
+import { UserScore as ApiScore } from "@/common/userScore";
+import { UserScores as StoreScores, TopicStoreState } from "@/web/topic/store/store";
+import { isPlaygroundTopic } from "@/web/topic/store/utils";
+import {
+  Score,
+  Edge as StoreEdge,
+  Node as StoreNode,
+  buildEdge,
+  buildNode,
+} from "@/web/topic/utils/graph";
 
 export const convertToStoreNode = (apiNode: TopicNode) => {
   return buildNode({

--- a/src/web/topic/utils/claim.ts
+++ b/src/web/topic/utils/claim.ts
@@ -1,8 +1,8 @@
 import lowerCase from "lodash/lowerCase";
 
-import { justificationRelationNames } from "../../../common/edge";
-import { errorWithData } from "../../../common/errorHandling";
-import { Edge, Graph, GraphPart, findGraphPartOrThrow, isNode } from "./graph";
+import { justificationRelationNames } from "@/common/edge";
+import { errorWithData } from "@/common/errorHandling";
+import { Edge, Graph, GraphPart, findGraphPartOrThrow, isNode } from "@/web/topic/utils/graph";
 
 // Using claimEdges instead of claimNodes because eventually we'll probably replace Root Claim nodes
 // with direct edges from a claim to diagram part.

--- a/src/web/topic/utils/diagram.ts
+++ b/src/web/topic/utils/diagram.ts
@@ -1,4 +1,4 @@
-import { Edge, Node } from "./graph";
+import { Edge, Node } from "@/web/topic/utils/graph";
 
 export interface Diagram {
   nodes: Node[];

--- a/src/web/topic/utils/edge.ts
+++ b/src/web/topic/utils/edge.ts
@@ -1,13 +1,8 @@
-import { RelationName, justificationRelationNames } from "../../../common/edge";
-import {
-  NodeType,
-  justificationNodeTypes,
-  nodeTypes,
-  researchNodeTypes,
-} from "../../../common/node";
-import { hasClaims } from "./claim";
-import { Edge, Graph, Node, RelationDirection, findNodeOrThrow } from "./graph";
-import { children, components, parents } from "./node";
+import { RelationName, justificationRelationNames } from "@/common/edge";
+import { NodeType, justificationNodeTypes, nodeTypes, researchNodeTypes } from "@/common/node";
+import { hasClaims } from "@/web/topic/utils/claim";
+import { Edge, Graph, Node, RelationDirection, findNodeOrThrow } from "@/web/topic/utils/graph";
+import { children, components, parents } from "@/web/topic/utils/node";
 
 const questionRelations: AddableRelation[] = nodeTypes.map((nodeType) => ({
   child: "question",

--- a/src/web/topic/utils/graph.ts
+++ b/src/web/topic/utils/graph.ts
@@ -1,12 +1,12 @@
 import uniqBy from "lodash/uniqBy";
 import { v4 as uuid } from "uuid";
 
-import { RelationName, justificationRelationNames } from "../../../common/edge";
-import { errorWithData } from "../../../common/errorHandling";
-import { NodeType, infoNodeTypes, justificationNodeTypes } from "../../../common/node";
-import { GeneralFilter } from "../../view/utils/generalFilter";
-import { composedRelations } from "./edge";
-import { FlowNodeType } from "./node";
+import { RelationName, justificationRelationNames } from "@/common/edge";
+import { errorWithData } from "@/common/errorHandling";
+import { NodeType, infoNodeTypes, justificationNodeTypes } from "@/common/node";
+import { composedRelations } from "@/web/topic/utils/edge";
+import { FlowNodeType } from "@/web/topic/utils/node";
+import { GeneralFilter } from "@/web/view/utils/generalFilter";
 
 export interface Graph {
   nodes: Node[];

--- a/src/web/topic/utils/layout.ts
+++ b/src/web/topic/utils/layout.ts
@@ -1,9 +1,9 @@
 import ELK, { ElkNode, LayoutOptions } from "elkjs";
 
-import { NodeType, nodeTypes } from "../../../common/node";
-import { nodeHeightPx, nodeWidthPx } from "../components/Node/EditableNode.styles";
-import { Diagram } from "./diagram";
-import { type Edge, type Node, ancestors, descendants } from "./graph";
+import { NodeType, nodeTypes } from "@/common/node";
+import { nodeHeightPx, nodeWidthPx } from "@/web/topic/components/Node/EditableNode.styles";
+import { Diagram } from "@/web/topic/utils/diagram";
+import { type Edge, type Node, ancestors, descendants } from "@/web/topic/utils/graph";
 
 export type Orientation = "DOWN" | "UP" | "RIGHT" | "LEFT";
 export const orientation: Orientation = "DOWN" as Orientation; // not constant to allow potential other orientations in the future, and keeping code that currently exists for handling "LEFT" orientation

--- a/src/web/topic/utils/node.ts
+++ b/src/web/topic/utils/node.ts
@@ -18,10 +18,10 @@ import {
   Widgets,
 } from "@mui/icons-material";
 
-import { errorWithData } from "../../../common/errorHandling";
-import { NodeType, areSameCategoryNodes } from "../../../common/node";
-import { componentTypes } from "./edge";
-import { Edge, Graph, Node } from "./graph";
+import { errorWithData } from "@/common/errorHandling";
+import { NodeType, areSameCategoryNodes } from "@/common/node";
+import { componentTypes } from "@/web/topic/utils/edge";
+import { Edge, Graph, Node } from "@/web/topic/utils/graph";
 
 export const indicatorLengthRem = 1.25; // rem
 

--- a/src/web/topic/utils/score.ts
+++ b/src/web/topic/utils/score.ts
@@ -2,7 +2,7 @@ import { type Palette } from "@mui/material";
 import meanBy from "lodash/meanBy";
 import round from "lodash/round";
 
-import { Score } from "../utils/graph";
+import { Score } from "@/web/topic/utils/graph";
 
 export const scoreColors: Record<Score, keyof Palette> = {
   "-": "neutral",

--- a/src/web/view/actionConfigStore.ts
+++ b/src/web/view/actionConfigStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
-import { withDefaults } from "../../common/object";
+import { withDefaults } from "@/common/object";
 
 interface ActionConfigStoreState {
   unrestrictedEditing: boolean;

--- a/src/web/view/components/Filter/GeneralFilters.tsx
+++ b/src/web/view/components/Filter/GeneralFilters.tsx
@@ -3,18 +3,22 @@ import { Stack } from "@mui/material";
 import { useCallback, useEffect } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 
-import { nodeTypes } from "../../../../common/node";
-import { deepIsEqual } from "../../../../common/utils";
-import { FormContext } from "../../../common/components/Form/FormContext";
-import { NodeSelect } from "../../../common/components/Form/NodeSelect";
-import { Select } from "../../../common/components/Form/Select";
-import { Switch } from "../../../common/components/Form/Switch";
-import { useAllNodes } from "../../../topic/store/nodeHooks";
-import { possibleScores } from "../../../topic/utils/graph";
-import { setGeneralFilter, useGeneralFilter } from "../../currentViewStore/filter";
-import { useFormat } from "../../currentViewStore/store";
-import { GeneralFilter, generalFilterSchema, scoredComparers } from "../../utils/generalFilter";
-import { ShowSecondaryNeighborsLabel } from "./ShowSecondaryNeighborsLabel";
+import { nodeTypes } from "@/common/node";
+import { deepIsEqual } from "@/common/utils";
+import { FormContext } from "@/web/common/components/Form/FormContext";
+import { NodeSelect } from "@/web/common/components/Form/NodeSelect";
+import { Select } from "@/web/common/components/Form/Select";
+import { Switch } from "@/web/common/components/Form/Switch";
+import { useAllNodes } from "@/web/topic/store/nodeHooks";
+import { possibleScores } from "@/web/topic/utils/graph";
+import { ShowSecondaryNeighborsLabel } from "@/web/view/components/Filter/ShowSecondaryNeighborsLabel";
+import { setGeneralFilter, useGeneralFilter } from "@/web/view/currentViewStore/filter";
+import { useFormat } from "@/web/view/currentViewStore/store";
+import {
+  GeneralFilter,
+  generalFilterSchema,
+  scoredComparers,
+} from "@/web/view/utils/generalFilter";
 
 export const GeneralFilters = () => {
   const generalFilter = useGeneralFilter();

--- a/src/web/view/components/Filter/InformationFilters.tsx
+++ b/src/web/view/components/Filter/InformationFilters.tsx
@@ -1,8 +1,8 @@
 import { AutoStories, School, ThumbsUpDown } from "@mui/icons-material";
 import { FormControlLabel, Switch as MuiSwitch, Stack, Typography } from "@mui/material";
 
-import { setShowInformation, useDiagramFilter } from "../../currentViewStore/filter";
-import { StandardFilter } from "./StandardFilter";
+import { StandardFilter } from "@/web/view/components/Filter/StandardFilter";
+import { setShowInformation, useDiagramFilter } from "@/web/view/currentViewStore/filter";
 
 export const InformationFilters = () => {
   const diagramFilter = useDiagramFilter();

--- a/src/web/view/components/Filter/ShowSecondaryNeighborsLabel.tsx
+++ b/src/web/view/components/Filter/ShowSecondaryNeighborsLabel.tsx
@@ -1,7 +1,7 @@
 import { Stack, Tooltip } from "@mui/material";
 import startCase from "lodash/startCase";
 
-import { InfoCategory } from "../../../../common/infoCategory";
+import { InfoCategory } from "@/common/infoCategory";
 
 interface Props {
   secondaryInfoCategory: InfoCategory;

--- a/src/web/view/components/Filter/StandardFilter.tsx
+++ b/src/web/view/components/Filter/StandardFilter.tsx
@@ -3,20 +3,23 @@ import { Stack } from "@mui/material";
 import { useCallback, useEffect } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 
-import { InfoCategory } from "../../../../common/infoCategory";
-import { deepIsEqual } from "../../../../common/utils";
-import { FormContext } from "../../../common/components/Form/FormContext";
-import { NodeSelect } from "../../../common/components/Form/NodeSelect";
-import { Select } from "../../../common/components/Form/Select";
-import { useCriteria, useNodesOfType, useSolutions } from "../../../topic/store/nodeHooks";
-import { getStandardFilterWithFallbacks, setStandardFilter } from "../../currentViewStore/filter";
+import { InfoCategory } from "@/common/infoCategory";
+import { deepIsEqual } from "@/common/utils";
+import { FormContext } from "@/web/common/components/Form/FormContext";
+import { NodeSelect } from "@/web/common/components/Form/NodeSelect";
+import { Select } from "@/web/common/components/Form/Select";
+import { useCriteria, useNodesOfType, useSolutions } from "@/web/topic/store/nodeHooks";
+import {
+  getStandardFilterWithFallbacks,
+  setStandardFilter,
+} from "@/web/view/currentViewStore/filter";
 import {
   StandardFilter as StandardFilterData,
   infoStandardFilterTypes,
   problemDetails,
   standardFilterSchema,
   standardFilterSchemasByType,
-} from "../../utils/diagramFilter";
+} from "@/web/view/utils/diagramFilter";
 
 interface Props {
   infoCategory: InfoCategory;

--- a/src/web/view/components/Filter/TableFilters.tsx
+++ b/src/web/view/components/Filter/TableFilters.tsx
@@ -3,12 +3,12 @@ import { Stack } from "@mui/material";
 import { useCallback, useEffect } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 
-import { deepIsEqual } from "../../../../common/utils";
-import { FormContext } from "../../../common/components/Form/FormContext";
-import { NodeSelect } from "../../../common/components/Form/NodeSelect";
-import { useCriteria, useNodesOfType, useSolutions } from "../../../topic/store/nodeHooks";
-import { setTableFilter, useTableFilterWithFallbacks } from "../../currentViewStore/filter";
-import { TableFilter, tableFilterSchema } from "../../utils/tableFilter";
+import { deepIsEqual } from "@/common/utils";
+import { FormContext } from "@/web/common/components/Form/FormContext";
+import { NodeSelect } from "@/web/common/components/Form/NodeSelect";
+import { useCriteria, useNodesOfType, useSolutions } from "@/web/topic/store/nodeHooks";
+import { setTableFilter, useTableFilterWithFallbacks } from "@/web/view/currentViewStore/filter";
+import { TableFilter, tableFilterSchema } from "@/web/view/utils/tableFilter";
 
 export const TableFilters = () => {
   const tableFilter = useTableFilterWithFallbacks();

--- a/src/web/view/components/Perspectives/Perspectives.tsx
+++ b/src/web/view/components/Perspectives/Perspectives.tsx
@@ -1,8 +1,8 @@
 import { Autocomplete, TextField } from "@mui/material";
 
-import { useSessionUser } from "../../../common/hooks";
-import { useScoringUsernames } from "../../../topic/store/scoreHooks";
-import { setPerspectives, usePerspectives } from "../../perspectiveStore";
+import { useSessionUser } from "@/web/common/hooks";
+import { useScoringUsernames } from "@/web/topic/store/scoreHooks";
+import { setPerspectives, usePerspectives } from "@/web/view/perspectiveStore";
 
 export const Perspectives = () => {
   const { sessionUser } = useSessionUser();

--- a/src/web/view/currentViewStore/filter.ts
+++ b/src/web/view/currentViewStore/filter.ts
@@ -2,17 +2,21 @@ import union from "lodash/union";
 import without from "lodash/without";
 import { shallow } from "zustand/shallow";
 
-import { InfoCategory } from "../../../common/infoCategory";
-import { infoNodeTypes } from "../../../common/node";
-import { emitter } from "../../common/event";
-import { getDefaultNode } from "../../topic/store/nodeGetters";
-import { useTopicStore } from "../../topic/store/store";
-import { findNodeOrThrow } from "../../topic/utils/graph";
-import { neighbors } from "../../topic/utils/node";
-import { DiagramFilter, StandardFilter, StandardFilterWithFallbacks } from "../utils/diagramFilter";
-import { GeneralFilter } from "../utils/generalFilter";
-import { TableFilter } from "../utils/tableFilter";
-import { useCurrentViewStore } from "./store";
+import { InfoCategory } from "@/common/infoCategory";
+import { infoNodeTypes } from "@/common/node";
+import { emitter } from "@/web/common/event";
+import { getDefaultNode } from "@/web/topic/store/nodeGetters";
+import { useTopicStore } from "@/web/topic/store/store";
+import { findNodeOrThrow } from "@/web/topic/utils/graph";
+import { neighbors } from "@/web/topic/utils/node";
+import { useCurrentViewStore } from "@/web/view/currentViewStore/store";
+import {
+  DiagramFilter,
+  StandardFilter,
+  StandardFilterWithFallbacks,
+} from "@/web/view/utils/diagramFilter";
+import { GeneralFilter } from "@/web/view/utils/generalFilter";
+import { TableFilter } from "@/web/view/utils/tableFilter";
 
 // hooks
 const useCategoriesToShow = () => {

--- a/src/web/view/currentViewStore/layout.ts
+++ b/src/web/view/currentViewStore/layout.ts
@@ -1,4 +1,4 @@
-import { useCurrentViewStore } from "./store";
+import { useCurrentViewStore } from "@/web/view/currentViewStore/store";
 
 // hooks
 export const useForceNodesIntoLayers = () => {

--- a/src/web/view/currentViewStore/store.ts
+++ b/src/web/view/currentViewStore/store.ts
@@ -4,19 +4,19 @@ import { useStore } from "zustand";
 import { devtools, persist } from "zustand/middleware";
 import { createWithEqualityFn } from "zustand/traditional";
 
-import { Format, InfoCategory } from "../../../common/infoCategory";
-import { withDefaults } from "../../../common/object";
-import { emitter } from "../../common/event";
-import { useGraphPart } from "../../topic/store/graphPartHooks";
+import { Format, InfoCategory } from "@/common/infoCategory";
+import { withDefaults } from "@/common/object";
+import { emitter } from "@/web/common/event";
+import { useGraphPart } from "@/web/topic/store/graphPartHooks";
+import { triggerEvent } from "@/web/view/currentViewStore/triggerEventMiddleware";
 import {
   getDefaultQuickView,
   getQuickViewByTitle,
   selectViewFromState,
-} from "../quickViewStore/store";
-import { StandardFilter } from "../utils/diagramFilter";
-import { GeneralFilter } from "../utils/generalFilter";
-import { TableFilter } from "../utils/tableFilter";
-import { triggerEvent } from "./triggerEventMiddleware";
+} from "@/web/view/quickViewStore/store";
+import { StandardFilter } from "@/web/view/utils/diagramFilter";
+import { GeneralFilter } from "@/web/view/utils/generalFilter";
+import { TableFilter } from "@/web/view/utils/tableFilter";
 
 export interface ViewState {
   selectedGraphPartId: string | null;

--- a/src/web/view/currentViewStore/triggerEventMiddleware.ts
+++ b/src/web/view/currentViewStore/triggerEventMiddleware.ts
@@ -1,7 +1,7 @@
 import { StateCreator, StoreMutatorIdentifier } from "zustand";
 
-import { emitter } from "../../common/event";
-import { ViewState } from "./store";
+import { emitter } from "@/web/common/event";
+import { ViewState } from "@/web/view/currentViewStore/store";
 
 type TriggerEvent = <
   Mps extends [StoreMutatorIdentifier, unknown][] = [],

--- a/src/web/view/miscTopicConfigStore.ts
+++ b/src/web/view/miscTopicConfigStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
-import { withDefaults } from "../../common/object";
+import { withDefaults } from "@/common/object";
 
 interface MiscTopicConfigStoreState {
   showResolvedComments: boolean;

--- a/src/web/view/perspectiveStore.ts
+++ b/src/web/view/perspectiveStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
-import { getScoringUsernames } from "../topic/store/utilActions";
+import { getScoringUsernames } from "@/web/topic/store/utilActions";
 
 interface PerspectiveStoreState {
   myPerspective: string;

--- a/src/web/view/quickViewStore/apiSyncerMiddleware.ts
+++ b/src/web/view/quickViewStore/apiSyncerMiddleware.ts
@@ -1,11 +1,11 @@
 import diff from "microdiff";
 import { StateCreator, StoreMutatorIdentifier } from "zustand";
 
-import { QuickView } from "../../../common/view";
-import { trpcClient } from "../../../pages/_app.page";
-import { emitter } from "../../common/event";
-import { isPlaygroundTopic } from "../../topic/store/utils";
-import { QuickViewStoreState } from "./store";
+import { QuickView } from "@/common/view";
+import { trpcClient } from "@/pages/_app.page";
+import { emitter } from "@/web/common/event";
+import { isPlaygroundTopic } from "@/web/topic/store/utils";
+import { QuickViewStoreState } from "@/web/view/quickViewStore/store";
 
 const getCrudDiffs = <T extends object>(
   before: T[],

--- a/src/web/view/quickViewStore/store.ts
+++ b/src/web/view/quickViewStore/store.ts
@@ -5,13 +5,13 @@ import { useStore } from "zustand";
 import { StorageValue, devtools, persist } from "zustand/middleware";
 import { createWithEqualityFn } from "zustand/traditional";
 
-import { errorWithData } from "../../../common/errorHandling";
-import { withDefaults } from "../../../common/object";
-import { deepIsEqual } from "../../../common/utils";
-import { emitter } from "../../common/event";
-import { StoreTopic, UserTopic } from "../../topic/store/store";
-import { ViewState, getView, initialViewState, setView } from "../currentViewStore/store";
-import { apiSyncer } from "./apiSyncerMiddleware";
+import { errorWithData } from "@/common/errorHandling";
+import { withDefaults } from "@/common/object";
+import { deepIsEqual } from "@/common/utils";
+import { emitter } from "@/web/common/event";
+import { StoreTopic, UserTopic } from "@/web/topic/store/store";
+import { ViewState, getView, initialViewState, setView } from "@/web/view/currentViewStore/store";
+import { apiSyncer } from "@/web/view/quickViewStore/apiSyncerMiddleware";
 
 type QuickViewType = "quick"; // eventually maybe separate "recommended" vs "personal"
 

--- a/src/web/view/utils/diagramFilter.ts
+++ b/src/web/view/utils/diagramFilter.ts
@@ -1,11 +1,11 @@
 import uniqBy from "lodash/uniqBy";
 import { z } from "zod";
 
-import { RelationName, researchRelationNames } from "../../../common/edge";
-import { InfoCategory } from "../../../common/infoCategory";
-import { infoNodeTypes, nodeSchema } from "../../../common/node";
-import { Graph, Node, ancestors, descendants, getRelevantEdges } from "../../topic/utils/graph";
-import { children, parents } from "../../topic/utils/node";
+import { RelationName, researchRelationNames } from "@/common/edge";
+import { InfoCategory } from "@/common/infoCategory";
+import { infoNodeTypes, nodeSchema } from "@/common/node";
+import { Graph, Node, ancestors, descendants, getRelevantEdges } from "@/web/topic/utils/graph";
+import { children, parents } from "@/web/topic/utils/node";
 
 // cross-standard-filter options
 const detailTypes = ["all", "connectedToCriteria", "none"] as const;

--- a/src/web/view/utils/generalFilter.ts
+++ b/src/web/view/utils/generalFilter.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 
-import { NodeType, zNodeTypes } from "../../../common/node";
-import { GraphPart, Node, Score, possibleScores } from "../../topic/utils/graph";
-import { getNumericScore } from "../../topic/utils/score";
+import { NodeType, zNodeTypes } from "@/common/node";
+import { GraphPart, Node, Score, possibleScores } from "@/web/topic/utils/graph";
+import { getNumericScore } from "@/web/topic/utils/score";
 
 export const scoredComparers = ["≥", ">", "≤", "<", "="] as const;
 const zScoredComparers = z.enum(scoredComparers);

--- a/src/web/view/utils/tableFilter.ts
+++ b/src/web/view/utils/tableFilter.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { nodeSchema } from "../../../common/node";
+import { nodeSchema } from "@/common/node";
 
 export const tableFilterSchema = z.object({
   centralProblemId: nodeSchema.shape.id.optional(), // there could be no problems to choose from

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,9 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    },
     "plugins": [
       {
         "name": "next"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,10 @@
+import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  plugins: [tsconfigPaths()],
   test: {
+    include: ["./src/**/*.{test,spec}.?(c|m)[jt]s?(x)"], // default from https://vitest.dev/config/#include but looking only at src/
     setupFiles: ["./scripts/setupTests.ts"],
   },
 });


### PR DESCRIPTION
Closes #183 

### Description of changes

-

### Additional context

- should make it easier to see where imports are coming from, and easier to update file paths when moving files across directories
- if for some reason this has detriments and this seems bad, the eslint plugin (with autofix rule) should allow us to easily swap back (autofix made all the changes in this PR ✨)
