### PR TITLE
refactor: default reactquery staletime to infinity

### DIFF
--- a/src/pages/[username].page.tsx
+++ b/src/pages/[username].page.tsx
@@ -32,7 +32,7 @@ const User: NextPage = () => {
   const findUser = trpc.user.findByUsername.useQuery(
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- `enabled` guarantees non-null before query is run
     { username: username! },
-    { enabled: !!username, staleTime: Infinity } // seems fine to have to refresh page to get data that's updated by other users
+    { enabled: !!username }
   );
 
   // TODO: use suspense to better handle loading & error

--- a/src/pages/notifications.page.tsx
+++ b/src/pages/notifications.page.tsx
@@ -17,10 +17,7 @@ type RowData = InAppNotification & { topic: Topic };
 const Notifications: NextPage = () => {
   const utils = trpc.useContext();
 
-  const findNotifications = trpc.notification.findAll.useQuery(
-    undefined,
-    { staleTime: Infinity } // no need to make this update without a page refresh
-  );
+  const findNotifications = trpc.notification.findAll.useQuery(undefined);
 
   const deleteNotification = trpc.notification.delete.useMutation({
     onMutate: (variables) => {

--- a/src/web/comment/components/Comment.tsx
+++ b/src/web/comment/components/Comment.tsx
@@ -39,7 +39,7 @@ export const Comment = ({ comment }: Props) => {
 
   const findSubscription = trpc.subscriptions.find.useQuery(
     { sourceId: threadStarterCommentId },
-    { enabled: willShowSubscribeBell, staleTime: Infinity } // don't requery if we've already pulled the subscription, until we invalidate
+    { enabled: willShowSubscribeBell }
   );
   const subscribe = trpc.subscriptions.create.useMutation({
     onSuccess: () => findSubscription.refetch(),

--- a/src/web/common/trpc.ts
+++ b/src/web/common/trpc.ts
@@ -10,6 +10,7 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       refetchOnWindowFocus: false,
+      staleTime: Infinity,
     },
   },
 });

--- a/src/web/topic/components/TopicPane/TopicDetails.tsx
+++ b/src/web/topic/components/TopicPane/TopicDetails.tsx
@@ -46,7 +46,7 @@ export const TopicDetails = () => {
   const findWatch = trpc.watch.find.useQuery(
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- non-playground topics will have an id
     { topicId: topic.id! },
-    { enabled: willShowWatch, staleTime: Infinity }
+    { enabled: willShowWatch }
   );
   const setWatch = trpc.watch.setWatch.useMutation({
     onSuccess: () => findWatch.refetch(),

--- a/src/web/topic/store/userHooks.ts
+++ b/src/web/topic/store/userHooks.ts
@@ -11,7 +11,7 @@ export const useUserCanEditTopicData = (username?: string) => {
   const findTopic = trpc.topic.findByUsernameAndTitle.useQuery(
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- `enabled` guarantees non-null id, and if there's an id, it's a UserTopic
     { username: (storeTopic as UserTopic).creatorName, title: (storeTopic as UserTopic).title },
-    { enabled: storeTopic.id !== undefined, staleTime: Infinity }
+    { enabled: storeTopic.id !== undefined }
   );
 
   if (isPlaygroundTopic(storeTopic)) return true;


### PR DESCRIPTION
so far, no query needs to automatically refetch after some stale time. seems better to explicitly specify a stale time when we care to.

### Description of changes

-

### Additional context

-
