### PR TITLE
style: upgrade prettier to 3.3.2

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,6 @@ node_modules
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+
+# misc
+.all-contributorsrc

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,7 +94,7 @@
         "husky": "8.0.3",
         "lint-staged": "13.2.3",
         "postcss": "8.4.38",
-        "prettier": "2.7.1",
+        "prettier": "3.3.2",
         "prisma": "5.1.0",
         "prismock": "1.31.1",
         "storybook": "8.1.8",
@@ -10004,21 +10004,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@storybook/cli/node_modules/prettier": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
-      "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
-      "dev": true,
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "node_modules/@storybook/cli/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -10413,21 +10398,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@storybook/codemod/node_modules/prettier": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
-      "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
-      "dev": true,
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@storybook/codemod/node_modules/semver": {
@@ -24858,15 +24828,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
+      "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -35981,12 +35951,6 @@
           "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
           "dev": true
         },
-        "prettier": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
-          "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
-          "dev": true
-        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -36265,12 +36229,6 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
           "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
-          "dev": true
-        },
-        "prettier": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
-          "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
           "dev": true
         },
         "semver": {
@@ -46760,9 +46718,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
+      "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
       "dev": true
     },
     "prettier-fallback": {

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "husky": "8.0.3",
     "lint-staged": "13.2.3",
     "postcss": "8.4.38",
-    "prettier": "2.7.1",
+    "prettier": "3.3.2",
     "prisma": "5.1.0",
     "prismock": "1.31.1",
     "storybook": "8.1.8",

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -49,7 +49,7 @@ const seed = async () => {
   const nodeCarsGoingTooFastRootClaim = await createNode(
     "rootClaim",
     '"cars going too fast in neighborhood" is important',
-    nodeCarsGoingTooFast
+    nodeCarsGoingTooFast,
   );
   const nodeInexpensive = await createNode("criterion", "inexpensive");
   const nodeConveysReasoning = await createNode("criterion", "conveys reasoning to slow down");
@@ -60,33 +60,33 @@ const seed = async () => {
   const nodeSpeedBumpRootClaim = await createNode(
     "rootClaim",
     '"speed bump" is important',
-    nodeSpeedBump
+    nodeSpeedBump,
   );
   const nodeKidsAtPlaySign = await createNode("solution", "kids at play sign");
   const nodeLittleKidsLive = await createNode(
     "support",
     "little kids live here and can be hit",
-    nodeCarsGoingTooFast
+    nodeCarsGoingTooFast,
   );
   const nodeMeasuredTraffic = await createNode(
     "critique",
     "we measured traffic years ago, and it wasn't a problem",
-    nodeCarsGoingTooFast
+    nodeCarsGoingTooFast,
   );
   const nodeGentrification = await createNode(
     "critique",
     "recent gentrification beyond bottom of hill giving reason to zoom",
-    nodeCarsGoingTooFast
+    nodeCarsGoingTooFast,
   );
   const nodeCarsZipping = await createNode(
     "support",
     "visually see cars zipping by all the time",
-    nodeCarsGoingTooFast
+    nodeCarsGoingTooFast,
   );
   const nodeThoroughfare = await createNode(
     "critique",
     "thoroughfare for emergency vehicles",
-    nodeSpeedBump
+    nodeSpeedBump,
   );
 
   // edges
@@ -108,12 +108,12 @@ const seed = async () => {
   const edgeFastInexpensive = await createEdge(
     "criterionFor",
     nodeCarsGoingTooFast,
-    nodeInexpensive
+    nodeInexpensive,
   );
   const edgeFastConveys = await createEdge(
     "criterionFor",
     nodeCarsGoingTooFast,
-    nodeConveysReasoning
+    nodeConveysReasoning,
   );
   const edgeFastSlow = await createEdge("criterionFor", nodeCarsGoingTooFast, nodeGetsCarsToSlow);
   const edgeFastStoplight = await createEdge("addresses", nodeCarsGoingTooFast, nodeStoplight);
@@ -135,43 +135,43 @@ const seed = async () => {
   const edgeFastRootClaimLittle = await createEdge(
     "supports",
     nodeCarsGoingTooFastRootClaim,
-    nodeLittleKidsLive
+    nodeLittleKidsLive,
   );
   const edgeFastImportantMeasured = await createEdge(
     "critiques",
     nodeCarsGoingTooFastRootClaim,
-    nodeMeasuredTraffic
+    nodeMeasuredTraffic,
   );
   const edgeMeasuredGentrification = await createEdge(
     "critiques",
     nodeMeasuredTraffic,
-    nodeGentrification
+    nodeGentrification,
   );
   const edgeFastImportantZipping = await createEdge(
     "supports",
     nodeCarsGoingTooFastRootClaim,
-    nodeCarsZipping
+    nodeCarsZipping,
   );
   const edgeBumpRootClaimThoroughfare = await createEdge(
     "critiques",
     nodeSpeedBumpRootClaim,
-    nodeThoroughfare
+    nodeThoroughfare,
   );
 
   const nodeInexpensiveLightRootClaim = await createNode(
     "rootClaim",
     '"stoplight" embodies "inexpensive"',
-    edgeInexpensiveLight
+    edgeInexpensiveLight,
   );
   const nodeInexpensiveLightWeek = await createNode(
     "critique",
     "one week of construction costs",
-    edgeInexpensiveLight
+    edgeInexpensiveLight,
   );
   const edgeInexpensiveLightWeek = await createEdge(
     "critiques",
     nodeInexpensiveLightRootClaim,
-    nodeInexpensiveLightWeek
+    nodeInexpensiveLightWeek,
   );
 
   // user scores

--- a/src/api/notifications/commentCreated.test.ts
+++ b/src/api/notifications/commentCreated.test.ts
@@ -31,7 +31,7 @@ const generateComment = (
   topic: Topic,
   parent: CommentParent,
   parentType: CommentParentType,
-  content?: string
+  content?: string,
 ): Comment => {
   const time = new Date();
   const isChildComment = parent !== null;
@@ -161,7 +161,7 @@ beforeEach(async () => {
       authorWatcherSubscriber,
       topicWithoutAllowAnyEdit,
       commentWithTopicParent,
-      "comment"
+      "comment",
     ),
   });
 });
@@ -175,7 +175,7 @@ describe("getInAppNotificationMessage", () => {
           topicWithoutAllowAnyEdit,
           commentWithTopicParent,
           "comment",
-          "hey blah there!"
+          "hey blah there!",
         ),
       });
 
@@ -193,7 +193,7 @@ describe("getInAppNotificationMessage", () => {
           topicWithoutAllowAnyEdit,
           null,
           "topic",
-          "hey blah there!"
+          "hey blah there!",
         ),
       });
 
@@ -211,14 +211,14 @@ describe("getInAppNotificationMessage", () => {
           topicWithoutAllowAnyEdit,
           null,
           "topic",
-          "This sentence is 100 characters loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong.This sentence is 100 characters loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong.This sentence is 100 characters loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong.This sentence is 100 characters loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong.This sentence is 100 characters loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong."
+          "This sentence is 100 characters loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong.This sentence is 100 characters loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong.This sentence is 100 characters loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong.This sentence is 100 characters loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong.This sentence is 100 characters loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong.",
         ),
       });
 
       const message = getInAppNotificationMessage(comment);
 
       expect(message).toBe(
-        'authorWatcherSubscriber commented: "This sentence is 100 characters loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong.This sentence is 100 characters loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong.This sentence is 100 characters loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong.This sentence is 100 characters loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong.This sentence is 100 characters looooooooooooooooooooooooooo..."'
+        'authorWatcherSubscriber commented: "This sentence is 100 characters loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong.This sentence is 100 characters loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong.This sentence is 100 characters loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong.This sentence is 100 characters loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong.This sentence is 100 characters looooooooooooooooooooooooooo..."',
       );
     });
   });
@@ -229,7 +229,7 @@ const expectNotification = (
   receiver: User,
   comment: Comment,
   reason: ReasonType,
-  message?: string
+  message?: string,
 ) => {
   if (received.length > 1) throw new Error("received more than one notification");
   const oneReceived = received[0];
@@ -283,7 +283,7 @@ describe("handleCommentCreated", () => {
           ignorerNotSubscriber,
           topicWithoutAllowAnyEdit,
           null,
-          "topic"
+          "topic",
         );
         await xprisma.comment.create({ data: comment });
 
@@ -302,7 +302,7 @@ describe("handleCommentCreated", () => {
           notWatcherNotSubscriber,
           topicWithoutAllowAnyEdit,
           null,
-          "topic"
+          "topic",
         );
         await xprisma.comment.create({ data: comment });
 
@@ -376,13 +376,13 @@ describe("handleCommentCreated", () => {
         watcherSubNotifications,
         watcherSubscriber,
         commentWithCommentParent,
-        "subscribed"
+        "subscribed",
       );
       expectNotification(
         notWatcherSubNotifications,
         notWatcherIsSubscriber,
         commentWithCommentParent,
-        "subscribed"
+        "subscribed",
       );
     });
 
@@ -397,7 +397,7 @@ describe("handleCommentCreated", () => {
         watcherNotSubNotifications,
         watcherNotSubscriber,
         commentWithCommentParent,
-        "watching"
+        "watching",
       );
     });
   });

--- a/src/api/notifications/commentCreated.ts
+++ b/src/api/notifications/commentCreated.ts
@@ -38,7 +38,7 @@ const getUsersToNotify = async (comment: Comment, threadStarterCommentId: string
   });
   const subscribersToNotify = subscribers.map((subscriber) => {
     const subscription = subscriber.subscriptions.find(
-      (subscription) => subscription.sourceId === threadStarterCommentId
+      (subscription) => subscription.sourceId === threadStarterCommentId,
     );
     if (!subscription) throw errorWithData("couldn't find subscription", { subscriber, comment });
     const user: UserToNotify = {
@@ -95,7 +95,7 @@ export const getInAppNotificationMessage = (comment: Comment) => {
 const createInAppNotifications = async (
   comment: Comment,
   commentTopic: Topic,
-  usersToNotify: UserToNotify[]
+  usersToNotify: UserToNotify[],
 ) => {
   const sourceUrl = new URL(`/${commentTopic.creatorName}/${commentTopic.title}/`, getBaseUrl());
   sourceUrl.searchParams.set("comment", comment.id);
@@ -127,11 +127,11 @@ const subscribeAuthor = async (comment: Comment, threadStarterCommentId: string)
   });
 
   const authorIsIgnoringTopic = author.watches.some(
-    (watch) => watch.topicId === comment.topicId && watch.type === "ignore"
+    (watch) => watch.topicId === comment.topicId && watch.type === "ignore",
   );
 
   const authorAlreadyHasSubscription = author.subscriptions.some(
-    (subscription) => subscription.sourceId === threadStarterCommentId
+    (subscription) => subscription.sourceId === threadStarterCommentId,
   );
 
   if (authorIsIgnoringTopic || authorAlreadyHasSubscription) return;

--- a/src/api/routers/comment.test.ts
+++ b/src/api/routers/comment.test.ts
@@ -153,7 +153,7 @@ describe("handleChangesets", () => {
             commentsToCreate: [newComment, newOtherComment],
             commentsToUpdate: [],
             commentsToDelete: [],
-          })
+          }),
       ).rejects.toThrow();
     });
   });
@@ -217,7 +217,7 @@ describe("handleChangesets", () => {
               commentsToCreate: [newComment],
               commentsToUpdate: [],
               commentsToDelete: [],
-            })
+            }),
         ).rejects.toThrow();
 
         await expect(
@@ -227,7 +227,7 @@ describe("handleChangesets", () => {
               commentsToCreate: [],
               commentsToUpdate: [updatedComment],
               commentsToDelete: [],
-            })
+            }),
         ).rejects.toThrow();
       });
     });
@@ -252,7 +252,7 @@ describe("handleChangesets", () => {
               commentsToCreate: [newComment],
               commentsToUpdate: [],
               commentsToDelete: [],
-            })
+            }),
         ).rejects.toThrow();
 
         await expect(
@@ -262,7 +262,7 @@ describe("handleChangesets", () => {
               commentsToCreate: [],
               commentsToUpdate: [updatedComment],
               commentsToDelete: [],
-            })
+            }),
         ).rejects.toThrow();
 
         await expect(
@@ -272,7 +272,7 @@ describe("handleChangesets", () => {
               commentsToCreate: [],
               commentsToUpdate: [resolvedComment],
               commentsToDelete: [],
-            })
+            }),
         ).rejects.toThrow();
 
         await expect(
@@ -282,7 +282,7 @@ describe("handleChangesets", () => {
               commentsToCreate: [],
               commentsToUpdate: [],
               commentsToDelete: [deletedComment],
-            })
+            }),
         ).rejects.toThrow();
       });
     });

--- a/src/api/routers/comment.ts
+++ b/src/api/routers/comment.ts
@@ -25,7 +25,7 @@ export const commentRouter = router({
         commentsToCreate: commentSchema.array(),
         commentsToUpdate: commentSchema.array(),
         commentsToDelete: commentSchema.array(),
-      })
+      }),
     )
     .mutation(async (opts) => {
       const { commentsToCreate, commentsToUpdate, commentsToDelete } = opts.input;
@@ -42,7 +42,7 @@ export const commentRouter = router({
         return isOnlyModifyingResolved(comment, foundComment);
       });
       const commentsToModifyOtherThanResolved = commentsToUpdate.filter(
-        (comment) => !commentsToOnlyModifyResolved.some((c) => c.id === comment.id)
+        (comment) => !commentsToOnlyModifyResolved.some((c) => c.id === comment.id),
       );
 
       // ensure has permissions
@@ -61,10 +61,10 @@ export const commentRouter = router({
       ].every((comment) => comment.authorName === opts.ctx.user.username);
 
       const userCanResolveTheComments = commentsToOnlyModifyResolved.every(
-        (comment) => userCanEditTopic || comment.authorName === opts.ctx.user.username
+        (comment) => userCanEditTopic || comment.authorName === opts.ctx.user.username,
       );
       const userCanDeleteTheComments = commentsToDelete.every((comment) =>
-        userCanDeleteComment(opts.ctx.user.username, userCanEditTopic, comment, commentsToDelete)
+        userCanDeleteComment(opts.ctx.user.username, userCanEditTopic, comment, commentsToDelete),
       );
 
       if (

--- a/src/api/routers/topic.test.ts
+++ b/src/api/routers/topic.test.ts
@@ -181,7 +181,7 @@ describe("setData", () => {
             userEmailVerified: true,
             user: loggedInUser,
           }
-        : {}
+        : {},
     );
 
     await trpc.topic.setData({

--- a/src/api/routers/topic.ts
+++ b/src/api/routers/topic.ts
@@ -18,7 +18,7 @@ export const topicRouter = router({
       z.object({
         username: userSchema.shape.username,
         title: topicSchema.shape.title,
-      })
+      }),
     )
     .query(async (opts) => {
       const isCreator = opts.input.username === opts.ctx.user?.username;
@@ -42,7 +42,7 @@ export const topicRouter = router({
       z.object({
         username: userSchema.shape.username,
         title: topicSchema.shape.title,
-      })
+      }),
     )
     .query(async (opts) => {
       const isCreator = opts.input.username === opts.ctx.user?.username;
@@ -97,9 +97,9 @@ export const topicRouter = router({
         scoresToCreate: z.array(userScoreSchema),
         scoresToUpdate: z.array(userScoreSchema),
         scoresToDelete: z.array(
-          userScoreSchema.pick({ username: true, graphPartId: true, topicId: true })
+          userScoreSchema.pick({ username: true, graphPartId: true, topicId: true }),
         ),
-      })
+      }),
     )
     .mutation(async (opts) => {
       // authorize
@@ -132,7 +132,7 @@ export const topicRouter = router({
 
       // ensure requests don't try changing nodes/edges/scores from other topics
       const onlyChangingObjectsFromThisTopic = topicObjectLists.every((topicObjects) =>
-        topicObjects.every((topicObject) => topicObject.topicId === topic.id)
+        topicObjects.every((topicObject) => topicObject.topicId === topic.id),
       );
 
       if (nonCreatorMadeRestrictedChanges || !onlyChangingObjectsFromThisTopic) {
@@ -237,7 +237,7 @@ export const topicRouter = router({
         }),
         // TODO: create basic views without passing over API when default view state is decoupled from web types
         quickViews: quickViewSchema.omit({ topicId: true }).array(), // omit topic because we'll set it on creation here
-      })
+      }),
     )
     .mutation(async (opts) => {
       const newTopic = await xprisma.topic.create({
@@ -283,7 +283,7 @@ export const topicRouter = router({
         description: true,
         visibility: true,
         allowAnyoneToEdit: true,
-      })
+      }),
     )
     .mutation(async (opts) => {
       const topic = await xprisma.topic.findUniqueOrThrow({ where: { id: opts.input.id } });

--- a/src/api/routers/view.test.ts
+++ b/src/api/routers/view.test.ts
@@ -140,7 +140,7 @@ describe("handleChangesets", () => {
             viewsToCreate: [newView1, newView2],
             viewsToUpdate: [],
             viewsToDelete: [],
-          })
+          }),
       ).rejects.toThrow();
     });
   });
@@ -164,7 +164,7 @@ describe("handleChangesets", () => {
             viewsToCreate: [newView],
             viewsToUpdate: [],
             viewsToDelete: [],
-          })
+          }),
       ).rejects.toThrow();
 
       await expect(
@@ -174,7 +174,7 @@ describe("handleChangesets", () => {
             viewsToCreate: [],
             viewsToUpdate: [updatedView],
             viewsToDelete: [],
-          })
+          }),
       ).rejects.toThrow();
 
       await expect(
@@ -184,7 +184,7 @@ describe("handleChangesets", () => {
             viewsToCreate: [],
             viewsToUpdate: [],
             viewsToDelete: [deletedView],
-          })
+          }),
       ).rejects.toThrow();
     });
   });

--- a/src/api/routers/view.ts
+++ b/src/api/routers/view.ts
@@ -16,7 +16,7 @@ export const viewRouter = router({
         viewsToCreate: quickViewSchema.array(),
         viewsToUpdate: quickViewSchema.array(),
         viewsToDelete: quickViewSchema.array(),
-      })
+      }),
     )
     .mutation(async (opts) => {
       const { viewsToCreate, viewsToUpdate, viewsToDelete } = opts.input;
@@ -25,7 +25,7 @@ export const viewRouter = router({
       const userIsCreator = opts.ctx.user.username === topic.creatorName;
       const userCanEditTopic = userIsCreator || topic.allowAnyoneToEdit;
       const viewsAllForSameTopic = [...viewsToCreate, ...viewsToUpdate, ...viewsToDelete].every(
-        (view) => view.topicId === opts.input.topicId
+        (view) => view.topicId === opts.input.topicId,
       );
 
       if (!userCanEditTopic || !viewsAllForSameTopic) throw new TRPCError({ code: "FORBIDDEN" });

--- a/src/common/comment.ts
+++ b/src/common/comment.ts
@@ -43,7 +43,7 @@ export const userCanDeleteComment = (
   username: string,
   userCanEditTopic: boolean,
   commentToDelete: Comment,
-  otherCommentsBeingDeleted: Comment[]
+  otherCommentsBeingDeleted: Comment[],
 ) => {
   if (commentToDelete.authorName === username || userCanEditTopic) return true;
 
@@ -51,7 +51,7 @@ export const userCanDeleteComment = (
     commentToDelete.parentType === "comment" &&
     otherCommentsBeingDeleted.some(
       (otherComment) =>
-        otherComment.id === commentToDelete.parentId && otherComment.authorName === username
+        otherComment.id === commentToDelete.parentId && otherComment.authorName === username,
     );
 
   return deletingAsResultOfPermittedThreadDeletion;

--- a/src/common/errorHandling.ts
+++ b/src/common/errorHandling.ts
@@ -6,7 +6,7 @@
 // eslint-disable-next-line functional/functional-parameters, @typescript-eslint/no-explicit-any
 export const errorWithData = (message: string, ...data: any[]) => {
   return new Error(
-    data.length > 0 ? message + "\n\nrelated data:\n" + JSON.stringify(data) : message
+    data.length > 0 ? message + "\n\nrelated data:\n" + JSON.stringify(data) : message,
   );
 };
 

--- a/src/common/topic.ts
+++ b/src/common/topic.ts
@@ -18,11 +18,11 @@ export const topicSchema = z.object({
     .max(100)
     .regex(
       /^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,99}$/i, // match github username rules but with repo name length, thanks https://github.com/shinnn/github-username-regex/blob/master/index.js
-      "Title may only contain alphanumeric characters or single hyphens, and cannot begin or end with a hyphen."
+      "Title may only contain alphanumeric characters or single hyphens, and cannot begin or end with a hyphen.",
     )
     .refine(
       (topic) => !reservedSecondLevelEndpointNames.includes(topic.toLocaleLowerCase()),
-      (topic) => ({ message: `${topic} is a reserved title.` })
+      (topic) => ({ message: `${topic} is a reserved title.` }),
     ),
   creatorName: userSchema.shape.username,
   description: z.string().max(10000),

--- a/src/common/user.ts
+++ b/src/common/user.ts
@@ -10,11 +10,11 @@ export const userSchema = z.object({
     .max(39)
     .regex(
       /^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i, // match github rules, thanks https://github.com/shinnn/github-username-regex/blob/master/index.js
-      "Username may only contain alphanumeric characters or single hyphens, and cannot begin or end with a hyphen."
+      "Username may only contain alphanumeric characters or single hyphens, and cannot begin or end with a hyphen.",
     )
     .refine(
       (username) => !reservedFirstLevelEndpointNames.includes(username.toLocaleLowerCase()),
-      (username) => ({ message: `${username} is a reserved username.` })
+      (username) => ({ message: `${username} is a reserved username.` }),
     ),
   authId: z.string(),
   receiveEmailNotifications: z.boolean(),

--- a/src/common/view.ts
+++ b/src/common/view.ts
@@ -16,7 +16,7 @@ export const savedViewSchema = z.object({
     .max(100)
     .regex(
       /^(?! )(?!.* $)[a-zA-Z0-9 ]+$/,
-      "Title may only contain alphanumeric characters or spaces, and cannot begin or end with a space."
+      "Title may only contain alphanumeric characters or spaces, and cannot begin or end with a space.",
     )
     .optional(),
   order: z.number().optional(),

--- a/src/pages/[username].page.tsx
+++ b/src/pages/[username].page.tsx
@@ -32,7 +32,7 @@ const User: NextPage = () => {
   const findUser = trpc.user.findByUsername.useQuery(
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- `enabled` guarantees non-null before query is run
     { username: username! },
-    { enabled: !!username }
+    { enabled: !!username },
   );
 
   // TODO: use suspense to better handle loading & error

--- a/src/pages/[username]/[topicTitle].page.tsx
+++ b/src/pages/[username]/[topicTitle].page.tsx
@@ -20,12 +20,12 @@ import { setInitialPerspective } from "@/web/view/perspectiveStore";
 const DynamicTopicWorkspace = dynamic<Record<string, never>>(
   () =>
     import("../../web/topic/components/TopicWorkspace/TopicWorkspace").then(
-      (module) => module.TopicWorkspace
+      (module) => module.TopicWorkspace,
     ),
   {
     ssr: false,
     loading: () => <Loading />,
-  }
+  },
 );
 
 const Topic: NextPage = () => {
@@ -41,7 +41,7 @@ const Topic: NextPage = () => {
     // Not using stale time because client-side navigation back to this page fires the useEffect again,
     // repopulating the store with old data (if the client changed data before navigating away & back).
     // So we'll just re-fire on page mount, should be fine.
-    { enabled: !!username && !!topicTitle }
+    { enabled: !!username && !!topicTitle },
   );
 
   const { sessionUser } = useSessionUser();

--- a/src/pages/[username]/[topicTitle]/settings.page.tsx
+++ b/src/pages/[username]/[topicTitle]/settings.page.tsx
@@ -19,7 +19,7 @@ const TopicSettings: NextPage = () => {
   const findTopic = trpc.topic.findByUsernameAndTitle.useQuery(
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- `enabled` guarantees non-null before query is run
     { username: username!, title: topicTitle! },
-    { enabled: !!username && !!topicTitle }
+    { enabled: !!username && !!topicTitle },
   );
 
   // TODO: use suspense to better handle loading & error

--- a/src/pages/api/panel.page.ts
+++ b/src/pages/api/panel.page.ts
@@ -9,6 +9,6 @@ export default function handler(_: NextApiRequest, res: NextApiResponse) {
     renderTrpcPanel(appRouter, {
       url: `${getBaseUrl()}/api/trpc`,
       transformer: "superjson",
-    })
+    }),
   );
 }

--- a/src/pages/choose-username.page.tsx
+++ b/src/pages/choose-username.page.tsx
@@ -40,7 +40,7 @@ const formSchema = (utils: ReturnType<typeof trpc.useContext>) => {
         const user = await utils.user.findByUsername.fetch({ username });
         return !user;
       },
-      (username) => ({ message: `Username ${username} is not available.` })
+      (username) => ({ message: `Username ${username} is not available.` }),
     ),
   });
 };

--- a/src/pages/playground.page.tsx
+++ b/src/pages/playground.page.tsx
@@ -18,12 +18,12 @@ const DynamicTopicWorkspace = dynamic<Record<string, never>>(
   // const DynamicTopicWorkspace = dynamic(
   () =>
     import("../web/topic/components/TopicWorkspace/TopicWorkspace").then(
-      (module) => module.TopicWorkspace
+      (module) => module.TopicWorkspace,
     ),
   {
     ssr: false,
     loading: () => <Loading />,
-  }
+  },
 );
 
 const Playground: NextPage = () => {

--- a/src/web/comment/components/Comment.tsx
+++ b/src/web/comment/components/Comment.tsx
@@ -39,7 +39,7 @@ export const Comment = ({ comment }: Props) => {
 
   const findSubscription = trpc.subscriptions.find.useQuery(
     { sourceId: threadStarterCommentId },
-    { enabled: willShowSubscribeBell }
+    { enabled: willShowSubscribeBell },
   );
   const subscribe = trpc.subscriptions.create.useMutation({
     onSuccess: () => findSubscription.refetch(),

--- a/src/web/comment/store/apiSyncerMiddleware.ts
+++ b/src/web/comment/store/apiSyncerMiddleware.ts
@@ -10,7 +10,7 @@ import { isPlaygroundTopic } from "@/web/topic/store/utils";
 const getCrudDiffs = <T extends object>(
   before: T[],
   after: T[],
-  identifierFn: (element: T) => string
+  identifierFn: (element: T) => string,
 ): [T[], T[], T[]] => {
   // use keyed objects instead of array of objects because array diffs vary based on element ordering
   const keyedBefore = Object.fromEntries(before.map((item) => [identifierFn(item), item]));
@@ -23,13 +23,13 @@ const getCrudDiffs = <T extends object>(
     Object.entries(keyedBefore).map(([key, value]) => [
       key,
       Object.fromEntries(Object.entries(value).map(([k, v]) => [k, JSON.stringify(v)])),
-    ])
+    ]),
   );
   const stringifiedAfter = Object.fromEntries(
     Object.entries(keyedAfter).map(([key, value]) => [
       key,
       Object.fromEntries(Object.entries(value).map(([k, v]) => [k, JSON.stringify(v)])),
-    ])
+    ]),
   );
 
   const diffs = diff(stringifiedBefore, stringifiedAfter);
@@ -63,7 +63,7 @@ const getApiComments = (topicId: number, store: CommentStoreState): Comment[] =>
 const saveDiffs = (
   topicId: number,
   storeBefore: CommentStoreState,
-  storeAfter: CommentStoreState
+  storeAfter: CommentStoreState,
 ) => {
   const apiBefore = getApiComments(topicId, storeBefore);
   const apiAfter = getApiComments(topicId, storeAfter);
@@ -71,11 +71,11 @@ const saveDiffs = (
   const [commentsToCreate, commentsToUpdate, commentsToDelete] = getCrudDiffs(
     apiBefore,
     apiAfter,
-    (comment) => comment.id
+    (comment) => comment.id,
   );
 
   const anyChanges = [commentsToCreate, commentsToUpdate, commentsToDelete].some(
-    (changes) => changes.length > 0
+    (changes) => changes.length > 0,
   );
   if (!anyChanges) return;
 
@@ -89,9 +89,9 @@ const saveDiffs = (
 
 type ApiSyncer = <
   Mps extends [StoreMutatorIdentifier, unknown][] = [],
-  Mcs extends [StoreMutatorIdentifier, unknown][] = []
+  Mcs extends [StoreMutatorIdentifier, unknown][] = [],
 >(
-  create: StateCreator<CommentStoreState, Mps, Mcs>
+  create: StateCreator<CommentStoreState, Mps, Mcs>,
 ) => StateCreator<CommentStoreState, Mps, Mcs>;
 
 type ApiSyncerImpl = (f: StateCreator<CommentStoreState>) => StateCreator<CommentStoreState>;

--- a/src/web/comment/store/commentStore.ts
+++ b/src/web/comment/store/commentStore.ts
@@ -42,20 +42,20 @@ const useCommentStore = createWithEqualityFn<CommentStoreState>()(
         merge: (persistedState, _currentState) =>
           withDefaults(persistedState as Partial<CommentStoreState>, initialState),
         storage: storageWithDates,
-      }
-    )
+      },
+    ),
   ),
 
   // Using `createWithEqualityFn` so that we can do a diff in hooks that return new arrays/objects
   // so that we can avoid extra renders
-  Object.is
+  Object.is,
 );
 
 // hooks
 export const useThreadStarterComments = (
   parentId: string | null,
   parentType: CommentParentType,
-  showResolved: boolean
+  showResolved: boolean,
 ) => {
   return useCommentStore((state) =>
     state.comments
@@ -63,9 +63,9 @@ export const useThreadStarterComments = (
         (comment) =>
           comment.parentId === parentId &&
           comment.parentType === parentType &&
-          (showResolved || !comment.resolved)
+          (showResolved || !comment.resolved),
       )
-      .toSorted((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
+      .toSorted((a, b) => a.createdAt.getTime() - b.createdAt.getTime()),
   );
 };
 
@@ -73,14 +73,14 @@ export const useThreadChildrenComments = (commentId: string) => {
   return useCommentStore((state) =>
     state.comments
       .filter((comment) => comment.parentId === commentId && comment.parentType === "comment")
-      .toSorted((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
+      .toSorted((a, b) => a.createdAt.getTime() - b.createdAt.getTime()),
   );
 };
 
 export const useCommentCount = (
   parentId: string | null,
   parentType: CommentParentType,
-  showResolved: boolean
+  showResolved: boolean,
 ) => {
   return useCommentStore(
     (state) =>
@@ -88,8 +88,8 @@ export const useCommentCount = (
         (comment) =>
           comment.parentId === parentId &&
           comment.parentType === parentType &&
-          (showResolved || !comment.resolved)
-      ).length
+          (showResolved || !comment.resolved),
+      ).length,
   );
 };
 
@@ -99,7 +99,7 @@ export const upsertComment = (
   parentId: string | null,
   parentType: CommentParentType,
   content: string,
-  commentId?: string
+  commentId?: string,
 ) => {
   const state = useCommentStore.getState();
 
@@ -139,11 +139,11 @@ export const deleteComment = (commentId: string) => {
         (comment) =>
           comment.id !== commentId &&
           // delete children, if this is a thread-starter comment
-          !(comment.parentId === commentId && comment.parentType === "comment")
+          !(comment.parentId === commentId && comment.parentType === "comment"),
       ),
     }),
     false,
-    "deleteComment"
+    "deleteComment",
   );
 };
 
@@ -151,11 +151,11 @@ export const resolveComment = (commentId: string, resolved: boolean) => {
   useCommentStore.setState(
     (state) => ({
       comments: state.comments.map((comment) =>
-        comment.id === commentId ? { ...comment, resolved } : comment
+        comment.id === commentId ? { ...comment, resolved } : comment,
       ),
     }),
     false,
-    "resolveComment"
+    "resolveComment",
   );
 };
 
@@ -186,7 +186,7 @@ export const loadCommentsFromApi = (topic: UserTopic, comments: StoreComment[]) 
       })),
     },
     true,
-    "loadCommentsFromApi"
+    "loadCommentsFromApi",
   );
 };
 

--- a/src/web/comment/store/draftStore.ts
+++ b/src/web/comment/store/draftStore.ts
@@ -39,27 +39,27 @@ const useDraftStore = createWithEqualityFn<DraftStoreState>()(
       merge: (persistedState, _currentState) =>
         withDefaults(persistedState as Partial<DraftStoreState>, initialState),
       storage: storageWithDates,
-    }
+    },
   ),
 
   // Using `createWithEqualityFn` so that we can do a diff in hooks that return new arrays/objects
   // so that we can avoid extra renders
-  Object.is
+  Object.is,
 );
 
 // hooks
 export const useDraft = (
   parentId: string | null,
   parentType: CommentParentType,
-  commentId?: string
+  commentId?: string,
 ) => {
   return useDraftStore((state) =>
     state.drafts.find(
       (draft) =>
         draft.parentId === parentId &&
         draft.parentType === parentType &&
-        draft.commentId === commentId
-    )
+        draft.commentId === commentId,
+    ),
   );
 };
 
@@ -68,7 +68,7 @@ export const setDraft = (
   parentId: string | null,
   parentType: CommentParentType,
   content: string,
-  commentId?: string
+  commentId?: string,
 ) => {
   useDraftStore.setState(
     (state) => ({
@@ -79,19 +79,19 @@ export const setDraft = (
               draft.parentId === parentId &&
               draft.parentType === parentType &&
               draft.commentId === commentId
-            )
+            ),
         )
         .concat({ parentId, parentType, content, commentId }),
     }),
     true,
-    "setDraft"
+    "setDraft",
   );
 };
 
 export const deleteDraft = (
   parentId: string | null,
   parentType: CommentParentType,
-  commentId?: string
+  commentId?: string,
 ) => {
   useDraftStore.setState(
     (state) => ({
@@ -101,11 +101,11 @@ export const deleteDraft = (
             draft.parentId === parentId &&
             draft.parentType === parentType &&
             draft.commentId === commentId
-          )
+          ),
       ),
     }),
     true,
-    "deleteDraft"
+    "deleteDraft",
   );
 };
 

--- a/src/web/common/components/Form/Select.tsx
+++ b/src/web/common/components/Form/Select.tsx
@@ -35,7 +35,7 @@ export const Select = ({
       options.map((option) => {
         return typeof option === "object" ? option : { id: option, label: option };
       }),
-    [options]
+    [options],
   );
 
   // Use object for the value so that a label can differ from the value (particularly if the value is an id),

--- a/src/web/common/components/Layout.tsx
+++ b/src/web/common/components/Layout.tsx
@@ -139,8 +139,8 @@ const Layout: NextPage<LayoutProps> = ({ children }) => {
                     isAuthed
                       ? "/choose-username"
                       : isInitialRender // server-client mismatch if we use `returnTo` on initial render because server doesn't have access to asPath
-                      ? "/api/auth/login"
-                      : `/api/auth/login?returnTo=${encodeURIComponent(asPath)}`
+                        ? "/api/auth/login"
+                        : `/api/auth/login?returnTo=${encodeURIComponent(asPath)}`
                   }
                 >
                   {isAuthed ? "Username" : "Log in"}

--- a/src/web/common/components/NumberInput/NumberInput.tsx
+++ b/src/web/common/components/NumberInput/NumberInput.tsx
@@ -15,7 +15,7 @@ import * as React from "react";
  */
 export const NumberInput = React.forwardRef(function NumberInput(
   props: NumberInputProps,
-  ref: React.ForwardedRef<HTMLDivElement>
+  ref: React.ForwardedRef<HTMLDivElement>,
 ) {
   return (
     <BaseNumberInput
@@ -92,7 +92,7 @@ const StyledInputRoot = styled("div")(
   &:focus-visible {
     outline: 0;
   }
-`
+`,
 );
 
 const StyledInputElement = styled("input")(
@@ -110,7 +110,7 @@ const StyledInputElement = styled("input")(
   padding: 8px 12px;
   outline: 0;
   width: 50px;
-`
+`,
 );
 
 const StyledButton = styled("button")(
@@ -184,5 +184,5 @@ const StyledButton = styled("button")(
   & .arrow {
     transform: translateY(-1px);
   }
-`
+`,
 );

--- a/src/web/common/hooks.ts
+++ b/src/web/common/hooks.ts
@@ -39,7 +39,7 @@ export const useContextMenu = () => {
     event.preventDefault(); // prevent opening default context menu
 
     setAnchorPosition(
-      anchorPosition === undefined ? { top: event.clientY, left: event.clientX } : undefined
+      anchorPosition === undefined ? { top: event.clientY, left: event.clientX } : undefined,
     );
   };
 
@@ -54,7 +54,7 @@ export const useSessionUser = () => {
   const findUserByAuthId = trpc.user.findByAuthId.useQuery(
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-non-null-asserted-optional-chain -- enabled will ensure it only runs when not null
     { authId: authUser?.sub! },
-    { enabled: !!authUser?.sub, staleTime: Infinity }
+    { enabled: !!authUser?.sub, staleTime: Infinity },
   );
 
   // ensure we return null if the user is not authenticated (i.e. after logout, don't continue using the cached user)

--- a/src/web/topic/components/CriteriaTable/CriteriaTable.styles.tsx
+++ b/src/web/topic/components/CriteriaTable/CriteriaTable.styles.tsx
@@ -18,7 +18,9 @@ export const tableStyles = css`
       );
       /* MUI-Paper is not sized dynamically with the total table. 
         Because of this; directly applying the box shadow from MUI-paper onto table */
-      box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14),
+      box-shadow:
+        0px 3px 1px -2px rgba(0, 0, 0, 0.2),
+        0px 2px 2px 0px rgba(0, 0, 0, 0.14),
         0px 1px 5px 0px rgba(0, 0, 0, 0.12);
     }
 

--- a/src/web/topic/components/CriteriaTable/CriteriaTable.tsx
+++ b/src/web/topic/components/CriteriaTable/CriteriaTable.tsx
@@ -90,11 +90,11 @@ const buildTableCells = (
   problemNode: Node,
   solutions: Node[],
   criteria: Node[],
-  edges: Edge[]
+  edges: Edge[],
 ): [[HeaderCell, ...HeaderCell[]], ...[HeaderCell, ...Cell[]][]] => {
   const headerRow = [problemNode, ...solutions].map((node) => buildNodeHeader(node)) as [
     HeaderCell,
-    ...HeaderCell[]
+    ...HeaderCell[],
   ];
 
   const bodyRows = criteria.map(
@@ -109,7 +109,7 @@ const buildTableCells = (
 
           return buildEdgeCell(edge);
         }),
-      ] as [HeaderCell, ...Cell[]]
+      ] as [HeaderCell, ...Cell[]],
   );
 
   const totalsRow = [
@@ -124,7 +124,7 @@ const buildTableCells = (
 
 const buildTableDefs = (
   tableData: [[HeaderCell, ...HeaderCell[]], ...[HeaderCell, ...Cell[]][]],
-  useSolutionsForColumns: boolean
+  useSolutionsForColumns: boolean,
 ): { rowData: RowData[]; columnData: MRT_ColumnDef<RowData>[] } => {
   const [headerRow, ...bodyRows] = tableData;
 
@@ -209,7 +209,7 @@ export const CriteriaTable = () => {
   const { selectedSolutions, selectedCriteria } = getSelectedTradeoffNodes(
     solutions,
     criteria,
-    tableFilter
+    tableFilter,
   );
 
   const filteredSolutions = applyScoreFilter(selectedSolutions, generalFilter, scores);
@@ -222,7 +222,7 @@ export const CriteriaTable = () => {
     ? tableData
     : (headerRow.map((_, columnIndex) =>
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- assume that every row has same number of cells as header row
-        tableData.map((row) => row[columnIndex]!)
+        tableData.map((row) => row[columnIndex]!),
       ) as typeof tableData);
 
   const { rowData, columnData } = buildTableDefs(transposedTableData, useSolutionsForColumns);

--- a/src/web/topic/components/Edge/ScoreEdge.tsx
+++ b/src/web/topic/components/Edge/ScoreEdge.tsx
@@ -38,8 +38,8 @@ const svgMarkerDef = (inReactFlow: boolean, spotlight: Spotlight) => {
     spotlight === "primary"
       ? highlightedEdgeColor
       : spotlight === "secondary"
-      ? infoColor
-      : edgeColor;
+        ? infoColor
+        : edgeColor;
 
   return (
     <defs>
@@ -102,8 +102,8 @@ export const ScoreEdge = ({ inReactFlow, ...flowEdge }: EdgeProps & Props) => {
   const spotlight: Spotlight = flowEdge.selected
     ? "primary"
     : isNodeSelected
-    ? "secondary"
-    : "normal";
+      ? "secondary"
+      : "normal";
 
   const [edgePath, labelX, labelY] = getBezierPath({
     sourceX: flowEdge.sourceX,

--- a/src/web/topic/components/Indicator/ClaimTreeIndicator.tsx
+++ b/src/web/topic/components/Indicator/ClaimTreeIndicator.tsx
@@ -26,7 +26,7 @@ export const ClaimTreeIndicator = ({ graphPartId }: Props) => {
       if (!rootClaim) return;
       viewJustification(rootClaim.id);
     },
-    [rootClaim]
+    [rootClaim],
   );
 
   const Icon = explicitClaimCount > 0 ? AccountTree : AccountTreeOutlined;

--- a/src/web/topic/components/Indicator/ForceShownIndicator.tsx
+++ b/src/web/topic/components/Indicator/ForceShownIndicator.tsx
@@ -19,7 +19,7 @@ const ForceShownIndicatorBase = ({ nodeId, partColor }: Props) => {
       stopForcingNodeToShow(nodeId);
       event.stopPropagation(); // prevent selecting the node and awkwardly re-showing if flashlight mode is on
     },
-    [nodeId]
+    [nodeId],
   );
 
   if (!nodeIsForcedToShow) return <></>;

--- a/src/web/topic/components/Node/AddNodeButtonGroup.tsx
+++ b/src/web/topic/components/Node/AddNodeButtonGroup.tsx
@@ -56,7 +56,7 @@ const AddNodeButtonGroup = memo(
         ))}
       </ButtonGroup>
     );
-  }
+  },
 );
 
 // eslint-disable-next-line functional/immutable-data

--- a/src/web/topic/components/Node/FlowNode.styles.tsx
+++ b/src/web/topic/components/Node/FlowNode.styles.tsx
@@ -43,8 +43,8 @@ export const nodeStyles = (node: Node, spotlight: Spotlight) => {
       z-index: ${spotlight === "primary"
         ? zIndex.primary
         : spotlight === "secondary"
-        ? zIndex.secondary
-        : 0} !important; // !important to override because reactflow sets z-index via style attribute
+          ? zIndex.secondary
+          : 0} !important; // !important to override because reactflow sets z-index via style attribute
     }
   `;
 };

--- a/src/web/topic/components/Node/FlowNode.tsx
+++ b/src/web/topic/components/Node/FlowNode.tsx
@@ -44,8 +44,8 @@ export const FlowNode = (flowNode: NodeProps) => {
   const spotlight: Spotlight = flowNode.selected
     ? "primary"
     : isNeighborSelected || isEdgeSelected
-    ? "secondary"
-    : "normal";
+      ? "secondary"
+      : "normal";
 
   useEffect(() => {
     // hack to avoid animation on first render; for some reason nodes were animating from position 0

--- a/src/web/topic/components/Node/NodeHandle.tsx
+++ b/src/web/topic/components/Node/NodeHandle.tsx
@@ -50,8 +50,8 @@ const NodeHandleBase = ({ node, direction, orientation }: Props) => {
         ? Position.Top
         : Position.Left
       : orientation === "DOWN"
-      ? Position.Bottom
-      : Position.Right;
+        ? Position.Bottom
+        : Position.Right;
 
   return (
     <Tooltip

--- a/src/web/topic/components/Score/Score.styles.tsx
+++ b/src/web/topic/components/Score/Score.styles.tsx
@@ -5,10 +5,9 @@ export const ScorePopper = styled(Popper)`
   display: flex;
   position: absolute;
   border-radius: 50%;
-  ${({ theme }) =>
-    css`
-      z-index: ${theme.zIndex.tooltip};
-    `}
+  ${({ theme }) => css`
+    z-index: ${theme.zIndex.tooltip};
+  `}
 `;
 
 interface BackdropProps {

--- a/src/web/topic/components/Score/ScoreCompare.tsx
+++ b/src/web/topic/components/Score/ScoreCompare.tsx
@@ -23,7 +23,7 @@ export const ScoreCompare = ({ userScores, type = "regular" }: Props) => {
       const usernamesForScore = get(result, score, []);
       return set(result, score, [...usernamesForScore, username]);
     },
-    {} as Partial<Record<Score, string[]>>
+    {} as Partial<Record<Score, string[]>>,
   );
 
   const data: Data<CustomDataEntry> = Object.entries(scoreUsers).map(([score, usernames]) => {

--- a/src/web/topic/components/TopicForm/TopicForm.tsx
+++ b/src/web/topic/components/TopicForm/TopicForm.tsx
@@ -34,7 +34,7 @@ export const CreateTopicForm = ({ user }: { user: User }) => {
     onSuccess: async (newTopic, variables) => {
       utils.topic.findByUsernameAndTitle.setData(
         { username: user.username, title: variables.topic.title },
-        newTopic
+        newTopic,
       );
 
       utils.user.findByUsername.setData({ username: user.username }, (oldUser) => {
@@ -87,13 +87,13 @@ export const EditTopicForm = ({ topic, user }: { topic: Topic; user: User }) => 
       // update old title query
       utils.topic.findByUsernameAndTitle.setData(
         { username: user.username, title: topic.title },
-        null
+        null,
       );
 
       // update new title query
       utils.topic.findByUsernameAndTitle.setData(
         { username: user.username, title: updatedTopic.title },
-        updatedTopic
+        updatedTopic,
       );
     },
   });
@@ -115,7 +115,7 @@ export const EditTopicForm = ({ topic, user }: { topic: Topic; user: User }) => 
 
       utils.topic.findByUsernameAndTitle.setData(
         { username: user.username, title: topic.title },
-        null
+        null,
       );
     },
   });
@@ -190,7 +190,7 @@ const formSchema = (utils: ReturnType<typeof trpc.useContext>, user: User, topic
         });
         return !existingTopic;
       },
-      (title) => ({ message: `Title ${title} is not available.` })
+      (title) => ({ message: `Title ${title} is not available.` }),
     ),
     description: topicSchema.shape.description,
     visibility: topicSchema.shape.visibility,

--- a/src/web/topic/components/TopicPane/QuickViewForm.tsx
+++ b/src/web/topic/components/TopicPane/QuickViewForm.tsx
@@ -27,7 +27,7 @@ const formSchema = (currentView: QuickView, quickViews: QuickView[]) => {
         if (title === currentView.title) return true;
         return !quickViews.some((view) => view.title === title);
       },
-      (_title) => ({ message: "Title must be unique." })
+      (_title) => ({ message: "Title must be unique." }),
     ),
   });
 };

--- a/src/web/topic/components/TopicPane/TopicDetails.tsx
+++ b/src/web/topic/components/TopicPane/TopicDetails.tsx
@@ -46,7 +46,7 @@ export const TopicDetails = () => {
   const findWatch = trpc.watch.find.useQuery(
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- non-playground topics will have an id
     { topicId: topic.id! },
-    { enabled: willShowWatch }
+    { enabled: willShowWatch },
   );
   const setWatch = trpc.watch.setWatch.useMutation({
     onSuccess: () => findWatch.refetch(),

--- a/src/web/topic/hooks/flowHooks.ts
+++ b/src/web/topic/hooks/flowHooks.ts
@@ -16,7 +16,7 @@ const getViewportToIncludeNode = (
   node: PositionedNode,
   viewport: Viewport,
   viewportHeight: number,
-  viewportWidth: number
+  viewportWidth: number,
 ): Viewport => {
   const distanceToKeepNodeInViewport = 100; //pixels
 
@@ -34,8 +34,8 @@ const getViewportToIncludeNode = (
     viewport.x < viewportXForNodeWithinLeftBounds
       ? viewportXForNodeWithinLeftBounds
       : viewport.x > viewportXForNodeWithinRightBounds
-      ? viewportXForNodeWithinRightBounds
-      : viewport.x;
+        ? viewportXForNodeWithinRightBounds
+        : viewport.x;
 
   const viewportYForNodeWithinTopBounds = scaledDistanceToKeepNodeInViewport - scaledNodeY;
   const viewportYForNodeWithinBottomBounds =
@@ -45,8 +45,8 @@ const getViewportToIncludeNode = (
     viewport.y < viewportYForNodeWithinTopBounds
       ? viewportYForNodeWithinTopBounds
       : viewport.y > viewportYForNodeWithinBottomBounds
-      ? viewportYForNodeWithinBottomBounds
-      : viewport.y;
+        ? viewportYForNodeWithinBottomBounds
+        : viewport.y;
 
   return { x: newViewportX, y: newViewportY, zoom: viewport.zoom };
 };
@@ -94,7 +94,7 @@ export const useViewportUpdater = () => {
       viewportWidth,
       viewportHeight,
       minZoom,
-      1
+      1,
     );
 
     const viewport = { x: transform[0], y: transform[1], zoom: transform[2] };

--- a/src/web/topic/loadStores.ts
+++ b/src/web/topic/loadStores.ts
@@ -65,7 +65,7 @@ const downloadJsonSchema = z.preprocess(
       state: z.record(z.any()),
       version: z.number(),
     }),
-  })
+  }),
 );
 
 interface DownloadJson {
@@ -96,7 +96,7 @@ export const downloadTopic = () => {
  */
 const ensureUnique = (
   topicStoreState: TopicStoreState,
-  quickViewStoreState: QuickViewStoreState
+  quickViewStoreState: QuickViewStoreState,
 ) => {
   const { nodes, edges } = topicStoreState;
   const { views } = quickViewStoreState;
@@ -129,7 +129,7 @@ const ensureUnique = (
 
 export const uploadTopic = (
   event: React.ChangeEvent<HTMLInputElement>,
-  sessionUsername?: string
+  sessionUsername?: string,
 ) => {
   if (event.target.files === null) return;
 
@@ -146,12 +146,12 @@ export const uploadTopic = (
       if (!topicPersistState.version) {
         throw errorWithData(
           "No version found in file, cannot migrate old state",
-          topicPersistState
+          topicPersistState,
         );
       }
       const migratedTopicState = migrate(
         topicPersistState.state,
-        topicPersistState.version
+        topicPersistState.version,
       ) as TopicStoreState;
 
       const viewsPersistState = downloadJson.views;

--- a/src/web/topic/store/actions.ts
+++ b/src/web/topic/store/actions.ts
@@ -41,7 +41,7 @@ export const setScore = (username: string, graphPartId: string, score: Score) =>
 
   // update implicit child claim's score if it exists
   const implicitRootClaim = state.nodes.find(
-    (node) => node.data.arguedDiagramPartId === graphPartId
+    (node) => node.data.arguedDiagramPartId === graphPartId,
   );
   if (implicitRootClaim) {
     /* eslint-disable functional/immutable-data, no-param-reassign */

--- a/src/web/topic/store/apiSyncerMiddleware.ts
+++ b/src/web/topic/store/apiSyncerMiddleware.ts
@@ -10,7 +10,7 @@ import { convertToApi } from "@/web/topic/utils/apiConversion";
 const getCrudDiffs = <T>(
   before: T[],
   after: T[],
-  identifierFn: (element: T) => string
+  identifierFn: (element: T) => string,
 ): [T[], T[], T[]] => {
   // use keyed objects instead of array of objects because array diffs vary based on element ordering
   const keyedBefore = Object.fromEntries(before.map((item) => [identifierFn(item), item]));
@@ -49,19 +49,19 @@ const saveDiffs = (storeBefore: TopicStoreState, storeAfter: TopicStoreState) =>
   const [nodesToCreate, nodesToUpdate, nodesToDelete] = getCrudDiffs(
     apiBefore.nodes,
     apiAfter.nodes,
-    (node) => node.id
+    (node) => node.id,
   );
 
   const [edgesToCreate, edgesToUpdate, edgesToDelete] = getCrudDiffs(
     apiBefore.edges,
     apiAfter.edges,
-    (edge) => edge.id
+    (edge) => edge.id,
   );
 
   const [scoresToCreate, scoresToUpdate, scoresToDelete] = getCrudDiffs(
     apiBefore.userScores,
     apiAfter.userScores,
-    (score) => score.username.toString() + score.graphPartId
+    (score) => score.username.toString() + score.graphPartId,
   );
 
   const changeLists = {
@@ -92,9 +92,9 @@ const saveDiffs = (storeBefore: TopicStoreState, storeAfter: TopicStoreState) =>
 
 type ApiSyncer = <
   Mps extends [StoreMutatorIdentifier, unknown][] = [],
-  Mcs extends [StoreMutatorIdentifier, unknown][] = []
+  Mcs extends [StoreMutatorIdentifier, unknown][] = [],
 >(
-  create: StateCreator<TopicStoreState, Mps, Mcs>
+  create: StateCreator<TopicStoreState, Mps, Mcs>,
 ) => StateCreator<TopicStoreState, Mps, Mcs>;
 
 type ApiSyncerImpl = (f: StateCreator<TopicStoreState>) => StateCreator<TopicStoreState>;

--- a/src/web/topic/store/createDeleteActions.ts
+++ b/src/web/topic/store/createDeleteActions.ts
@@ -28,7 +28,7 @@ const createNode = (
   state: TopicStoreState,
   toNodeType: FlowNodeType,
   arguedDiagramPartId?: string,
-  selectNewNode = true
+  selectNewNode = true,
 ) => {
   const newNode = buildNode({ type: toNodeType, arguedDiagramPartId });
 
@@ -56,7 +56,7 @@ const connectCriteriaToSolutions = (state: TopicStoreState, newNode: Node, probl
       (edge) =>
         edge.source === problemNode.id &&
         edge.label === targetRelation.name &&
-        findNodeOrThrow(edge.target, state.nodes).type === targetRelation.child
+        findNodeOrThrow(edge.target, state.nodes).type === targetRelation.child,
     )
     .map((edge) => {
       const sourceId = newNode.type === "criterion" ? newNode.id : edge.target;
@@ -108,7 +108,7 @@ export const addNode = ({
     !topicGraph.nodes.find(
       (node) =>
         node.type === "rootClaim" &&
-        (node.data.arguedDiagramPartId === fromPartId || node.id === fromPartId)
+        (node.data.arguedDiagramPartId === fromPartId || node.id === fromPartId),
     )
   ) {
     const label = getImplicitLabel(fromPartId, topicGraph);
@@ -121,7 +121,7 @@ export const addNode = ({
       ? topicGraph.nodes.find(
           (node) =>
             node.type === "rootClaim" &&
-            (node.data.arguedDiagramPartId === fromPartId || node.id === fromPartId)
+            (node.data.arguedDiagramPartId === fromPartId || node.id === fromPartId),
         )
       : undefined;
   const fromPart =
@@ -169,7 +169,7 @@ const createEdgesImpliedByComposition = (
   topicGraph: Graph,
   parent: Node,
   child: Node,
-  relation: Relation
+  relation: Relation,
 ) => {
   const nodesComposedByParent = getNodesComposedBy(parent, topicGraph);
   nodesComposedByParent
@@ -197,7 +197,7 @@ const createEdgeAndImpliedEdges = (
   topicGraph: Graph,
   parent: GraphPart,
   child: GraphPart,
-  relation: Relation
+  relation: Relation,
 ) => {
   // We aren't yet fully supporting edges pointing to other edges.
   // It's not clear at this time whether completely adding or removing support for edges to edges is better,
@@ -259,7 +259,7 @@ export const connectNodes = (parentId: string | null, childId: string | null) =>
 export const reconnectEdge = (
   oldEdge: { id: string; source: string; target: string },
   newParentId: string | null,
-  newChildId: string | null
+  newChildId: string | null,
 ) => {
   if (oldEdge.source === newParentId && oldEdge.target === newChildId) return;
 
@@ -289,10 +289,10 @@ export const deleteNode = (nodeId: string) => {
       /* eslint-disable functional/immutable-data, no-param-reassign */
       // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- consider using a map instead of an object?
       state.nodes = state.nodes.filter(
-        (node) => node.data.arguedDiagramPartId !== deletedNode.data.arguedDiagramPartId
+        (node) => node.data.arguedDiagramPartId !== deletedNode.data.arguedDiagramPartId,
       );
       state.edges = state.edges.filter(
-        (edge) => edge.data.arguedDiagramPartId !== deletedNode.data.arguedDiagramPartId
+        (edge) => edge.data.arguedDiagramPartId !== deletedNode.data.arguedDiagramPartId,
       );
       /* eslint-enable functional/immutable-data, no-param-reassign */
     }
@@ -331,12 +331,12 @@ const deleteInvalidClaims = (state: TopicStoreState) => {
   state.nodes = state.nodes.filter(
     (node) =>
       node.data.arguedDiagramPartId === undefined ||
-      graphPartIds.includes(node.data.arguedDiagramPartId)
+      graphPartIds.includes(node.data.arguedDiagramPartId),
   );
   state.edges = state.edges.filter(
     (edge) =>
       edge.data.arguedDiagramPartId === undefined ||
-      graphPartIds.includes(edge.data.arguedDiagramPartId)
+      graphPartIds.includes(edge.data.arguedDiagramPartId),
   );
   /* eslint-enable functional/immutable-data, no-param-reassign */
 };

--- a/src/web/topic/store/graphPartHooks.ts
+++ b/src/web/topic/store/graphPartHooks.ts
@@ -10,7 +10,7 @@ import { Node } from "@/web/topic/utils/graph";
 export const useRootClaim = (graphPartId: string) => {
   return useTopicStore((state) => {
     return state.nodes.find(
-      (node) => node.type === "rootClaim" && node.data.arguedDiagramPartId === graphPartId
+      (node) => node.type === "rootClaim" && node.data.arguedDiagramPartId === graphPartId,
     );
   }, shallow);
 };
@@ -20,7 +20,7 @@ export const getExplicitClaimCount = (state: TopicStoreState, graphPartId: strin
     (node) =>
       justificationNodeTypes.includes(node.type) &&
       node.type !== "rootClaim" &&
-      node.data.arguedDiagramPartId === graphPartId
+      node.data.arguedDiagramPartId === graphPartId,
   ).length;
 };
 
@@ -37,13 +37,13 @@ export const useTopLevelClaims = (graphPartId: string) => {
     const nodeToCheckForClaims = justificationNodeTypes.includes(graphPart.type as NodeType)
       ? graphPart
       : state.nodes.find(
-          (node) => node.type === "rootClaim" && node.data.arguedDiagramPartId === graphPartId
+          (node) => node.type === "rootClaim" && node.data.arguedDiagramPartId === graphPartId,
         );
     if (!nodeToCheckForClaims) return { supports: [], critiques: [] };
 
     const topLevelClaimEdges = state.edges.filter(
       (edge) =>
-        justificationRelationNames.includes(edge.label) && edge.source === nodeToCheckForClaims.id
+        justificationRelationNames.includes(edge.label) && edge.source === nodeToCheckForClaims.id,
     );
 
     const supports = topLevelClaimEdges
@@ -52,7 +52,7 @@ export const useTopLevelClaims = (graphPartId: string) => {
 
     const critiques = topLevelClaimEdges
       .map((edge) =>
-        state.nodes.find((node) => node.id === edge.target && node.type === "critique")
+        state.nodes.find((node) => node.id === edge.target && node.type === "critique"),
       )
       .filter((node): node is Node => !!node);
 
@@ -63,12 +63,12 @@ export const useTopLevelClaims = (graphPartId: string) => {
 export const useNonTopLevelClaimCount = (graphPartId: string) => {
   return useTopicStore((state) => {
     const rootClaim = state.nodes.find(
-      (node) => node.type === "rootClaim" && node.data.arguedDiagramPartId === graphPartId
+      (node) => node.type === "rootClaim" && node.data.arguedDiagramPartId === graphPartId,
     );
     if (!rootClaim) return 0;
 
     return state.edges.filter(
-      (edge) => edge.data.arguedDiagramPartId === graphPartId && edge.source !== rootClaim.id
+      (edge) => edge.data.arguedDiagramPartId === graphPartId && edge.source !== rootClaim.id,
     ).length;
   });
 };
@@ -78,7 +78,7 @@ export const useResearchNodes = (graphPartId: string) => {
     const researchNodes = state.nodes.filter(
       (node) =>
         researchNodeTypes.includes(node.type) &&
-        state.edges.find((edge) => edge.source === graphPartId && edge.target === node.id)
+        state.edges.find((edge) => edge.source === graphPartId && edge.target === node.id),
     );
 
     return {

--- a/src/web/topic/store/loadActions.ts
+++ b/src/web/topic/store/loadActions.ts
@@ -29,7 +29,7 @@ export const populateDiagramFromApi = (topicData: TopicData) => {
       userScores,
     },
     true,
-    "populateFromApi"
+    "populateFromApi",
   );
 
   // it doesn't make sense to want to undo a page load

--- a/src/web/topic/store/migrate.ts
+++ b/src/web/topic/store/migrate.ts
@@ -71,7 +71,7 @@ const migrate_0_to_1 = (state: any) => {
       const sourceNodeType = diagram.nodes.find((node: any) => node.id === edge.source)?.type;
       const targetNodeType = diagram.nodes.find((node: any) => node.id === edge.target)?.type;
       const relation = relations.find(
-        (relation) => relation.Parent === sourceNodeType && relation.Child === targetNodeType
+        (relation) => relation.Parent === sourceNodeType && relation.Child === targetNodeType,
       );
       edge.label = relation?.name;
     });
@@ -441,11 +441,11 @@ const migrate_17_to_18 = (state: FromState17) => {
   // - delete diagrams
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   (state as unknown as ToState18).nodes = Object.values(state.diagrams!).flatMap(
-    (diagram) => diagram.nodes as GraphPart18[]
+    (diagram) => diagram.nodes as GraphPart18[],
   );
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   (state as unknown as ToState18).edges = Object.values(state.diagrams!).flatMap(
-    (diagram) => diagram.edges as GraphPart18[]
+    (diagram) => diagram.edges as GraphPart18[],
   );
   delete state.diagrams;
 

--- a/src/web/topic/store/nodeHooks.ts
+++ b/src/web/topic/store/nodeHooks.ts
@@ -144,8 +144,8 @@ export const useSolutions = (problemId?: string) => {
     const problemSolutions = solutions.filter((solution) =>
       state.edges.find(
         (edge) =>
-          edge.source === problemId && edge.label === "addresses" && edge.target === solution.id
-      )
+          edge.source === problemId && edge.label === "addresses" && edge.target === solution.id,
+      ),
     );
 
     return problemSolutions;
@@ -160,8 +160,10 @@ export const useCriteria = (problemId?: string) => {
     const problemCriteria = criteria.filter((criterion) =>
       state.edges.find(
         (edge) =>
-          edge.source === problemId && edge.label === "criterionFor" && edge.target === criterion.id
-      )
+          edge.source === problemId &&
+          edge.label === "criterionFor" &&
+          edge.target === criterion.id,
+      ),
     );
 
     return problemCriteria;

--- a/src/web/topic/store/nodeTypeHooks.ts
+++ b/src/web/topic/store/nodeTypeHooks.ts
@@ -5,17 +5,17 @@ export const useQuestionDetails = (questionNodeId: string) => {
   return useTopicStore((state) => {
     try {
       const asksAboutEdge = state.edges.find(
-        (edge) => edge.target === questionNodeId && edge.label === "asksAbout"
+        (edge) => edge.target === questionNodeId && edge.label === "asksAbout",
       );
       const partAskingAbout = asksAboutEdge
         ? findGraphPartOrThrow(asksAboutEdge.source, state.nodes, state.edges)
         : null;
 
       const answerEdges = state.edges.filter(
-        (edge) => edge.source === questionNodeId && edge.label === "potentialAnswerTo"
+        (edge) => edge.source === questionNodeId && edge.label === "potentialAnswerTo",
       );
       const answers = state.nodes.filter((node) =>
-        answerEdges.some((edge) => edge.target === node.id)
+        answerEdges.some((edge) => edge.target === node.id),
       );
 
       return { partAskingAbout, answers };
@@ -29,7 +29,7 @@ export const useAnswerDetails = (answerNodeId: string) => {
   return useTopicStore((state) => {
     try {
       const answerToEdge = state.edges.find(
-        (edge) => edge.target === answerNodeId && edge.label === "potentialAnswerTo"
+        (edge) => edge.target === answerNodeId && edge.label === "potentialAnswerTo",
       );
       const question = answerToEdge ? findNodeOrThrow(answerToEdge.source, state.nodes) : null;
       return { question };
@@ -42,21 +42,21 @@ export const useAnswerDetails = (answerNodeId: string) => {
 export const useFactDetails = (factNodeId: string) => {
   return useTopicStore((state) => {
     const relevantForEdges = state.edges.filter(
-      (edge) => edge.target === factNodeId && edge.label === "relevantFor"
+      (edge) => edge.target === factNodeId && edge.label === "relevantFor",
     );
 
     const nodesRelevantFor = state.nodes.filter((node) =>
-      relevantForEdges.some((relevantForEdge) => relevantForEdge.source === node.id)
+      relevantForEdges.some((relevantForEdge) => relevantForEdge.source === node.id),
     );
     const edgesRelevantFor = state.edges.filter((edge) =>
-      relevantForEdges.some((relevantForEdge) => relevantForEdge.source === edge.id)
+      relevantForEdges.some((relevantForEdge) => relevantForEdge.source === edge.id),
     );
 
     const sourceEdges = state.edges.filter(
-      (edge) => edge.source === factNodeId && edge.label === "sourceOf"
+      (edge) => edge.source === factNodeId && edge.label === "sourceOf",
     );
     const sources = state.nodes.filter((node) =>
-      sourceEdges.some((sourceEdge) => node.id === sourceEdge.target)
+      sourceEdges.some((sourceEdge) => node.id === sourceEdge.target),
     );
 
     return { nodesRelevantFor, edgesRelevantFor, sources };
@@ -66,28 +66,28 @@ export const useFactDetails = (factNodeId: string) => {
 export const useSourceDetails = (sourceNodeId: string) => {
   return useTopicStore((state) => {
     const relevantForEdges = state.edges.filter(
-      (edge) => edge.target === sourceNodeId && edge.label === "relevantFor"
+      (edge) => edge.target === sourceNodeId && edge.label === "relevantFor",
     );
 
     const nodesRelevantFor = state.nodes.filter((node) =>
-      relevantForEdges.some((relevantForEdge) => relevantForEdge.source === node.id)
+      relevantForEdges.some((relevantForEdge) => relevantForEdge.source === node.id),
     );
     const edgesRelevantFor = state.edges.filter((edge) =>
-      relevantForEdges.some((relevantForEdge) => relevantForEdge.source === edge.id)
+      relevantForEdges.some((relevantForEdge) => relevantForEdge.source === edge.id),
     );
 
     const factEdges = state.edges.filter(
-      (edge) => edge.target === sourceNodeId && edge.label === "sourceOf"
+      (edge) => edge.target === sourceNodeId && edge.label === "sourceOf",
     );
     const facts = state.nodes.filter((node) =>
-      factEdges.some((factEdge) => node.id === factEdge.source)
+      factEdges.some((factEdge) => node.id === factEdge.source),
     );
 
     const mentionEdges = state.edges.filter(
-      (edge) => edge.target === sourceNodeId && edge.label === "mentions"
+      (edge) => edge.target === sourceNodeId && edge.label === "mentions",
     );
     const sources = state.nodes.filter((node) =>
-      mentionEdges.some((mentionEdge) => node.id === mentionEdge.source)
+      mentionEdges.some((mentionEdge) => node.id === mentionEdge.source),
     );
 
     return { nodesRelevantFor, edgesRelevantFor, facts, sources };

--- a/src/web/topic/store/scoreGetters.ts
+++ b/src/web/topic/store/scoreGetters.ts
@@ -7,16 +7,16 @@ import { getAverageScore } from "@/web/topic/utils/score";
 export const getDisplayScoresByGraphPartId = (
   graphPartIds: string[],
   perspectives: string[],
-  userScores: UserScores
+  userScores: UserScores,
 ): Record<string, Score> => {
   const perspectiveScoresByGraphPart = getPerspectiveScoresByGraphPart(
     graphPartIds,
     perspectives,
-    userScores
+    userScores,
   );
 
   const averagedScoreWithGraphPart = Object.entries(perspectiveScoresByGraphPart).map(
-    ([graphPartId, scores]) => [graphPartId, getAverageScore(scores)] as [string, Score]
+    ([graphPartId, scores]) => [graphPartId, getAverageScore(scores)] as [string, Score],
   );
   return Object.fromEntries(averagedScoreWithGraphPart);
 };
@@ -24,7 +24,7 @@ export const getDisplayScoresByGraphPartId = (
 const getPerspectiveScoresByGraphPart = (
   graphPartIds: string[],
   perspectives: string[],
-  userScores: UserScores
+  userScores: UserScores,
 ) => {
   const scoresWithGraphPart: [string, Score[]][] = graphPartIds.map((graphPartId) => {
     const perspectiveScores = perspectives.map((perspective) => {

--- a/src/web/topic/store/scoreHooks.ts
+++ b/src/web/topic/store/scoreHooks.ts
@@ -16,7 +16,7 @@ export const useDisplayScores = (graphPartIds: string[]): Record<string, Score> 
 
   return useTopicStore(
     (state) => getDisplayScoresByGraphPartId(graphPartIds, perspectives, state.userScores),
-    shallow
+    shallow,
   );
 };
 
@@ -41,12 +41,12 @@ export const useSolutionTotal = (solution: Node, problem: Node) => {
   const criteriaSolutionEdges = useTopicStore((state) => {
     const topicGraph = { nodes: state.nodes, edges: state.edges };
     const criteriaForProblem = children(problem, topicGraph).filter(
-      (node) => node.type === "criterion"
+      (node) => node.type === "criterion",
     );
     const criteriaSolutionEdges = compact(
       criteriaForProblem.map((criterion) =>
-        edges(criterion, state.edges).find((edge) => edge.target === solution.id)
-      )
+        edges(criterion, state.edges).find((edge) => edge.target === solution.id),
+      ),
     );
 
     return criteriaSolutionEdges;
@@ -64,6 +64,6 @@ export const useSolutionTotal = (solution: Node, problem: Node) => {
       // use a (-4,4) range for the edge because low means doesn't embody, high means does
       // use a (0,8) range for the criterion because it's just importance, and should therefore just increase/decrease emphasis of the edge score
       return (getNumericScore(edgeScore) - 5) * (getNumericScore(criterionScore) - 1);
-    })
+    }),
   );
 };

--- a/src/web/topic/store/store.ts
+++ b/src/web/topic/store/store.ts
@@ -78,9 +78,9 @@ export const useTopicStore = createWithEqualityFn<TopicStoreState>()(
       version: 23,
       migrate: migrate,
       skipHydration: true,
-    })
+    }),
   ),
-  Object.is // using `createWithEqualityFn` so that we can do shallow or deep diffs in hooks that return new arrays/objects so that we can avoid extra renders
+  Object.is, // using `createWithEqualityFn` so that we can do shallow or deep diffs in hooks that return new arrays/objects so that we can avoid extra renders
 );
 
 export const useDiagram = (): Diagram => {
@@ -97,7 +97,7 @@ export const useDiagram = (): Diagram => {
 
     const nodesAfterTypeFilter = applyNodeTypeFilter(
       nodesAfterDiagramFilter,
-      generalFilter.nodeTypes
+      generalFilter.nodeTypes,
     );
 
     // don't filter edges because hard to prevent awkwardness when edge doesn't pass filter and suddenly nodes are scattered
@@ -112,7 +112,7 @@ export const useDiagram = (): Diagram => {
 
     const nodesBeforeHide = nodesAfterToShow.concat(secondaryNeighbors);
     const nodesAfterHide = nodesBeforeHide.filter(
-      (node) => !generalFilter.nodesToHide.includes(node.id)
+      (node) => !generalFilter.nodesToHide.includes(node.id),
     );
 
     const nodes = uniqBy(nodesAfterHide, "id");

--- a/src/web/topic/store/userHooks.ts
+++ b/src/web/topic/store/userHooks.ts
@@ -11,7 +11,7 @@ export const useUserCanEditTopicData = (username?: string) => {
   const findTopic = trpc.topic.findByUsernameAndTitle.useQuery(
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- `enabled` guarantees non-null id, and if there's an id, it's a UserTopic
     { username: (storeTopic as UserTopic).creatorName, title: (storeTopic as UserTopic).title },
-    { enabled: storeTopic.id !== undefined }
+    { enabled: storeTopic.id !== undefined },
   );
 
   if (isPlaygroundTopic(storeTopic)) return true;

--- a/src/web/topic/utils/claim.ts
+++ b/src/web/topic/utils/claim.ts
@@ -14,7 +14,7 @@ export const getImplicitLabel = (arguedDiagramPartId: string, topicGraph: Graph)
   const arguedDiagramPart = findGraphPartOrThrow(
     arguedDiagramPartId,
     topicGraph.nodes,
-    topicGraph.edges
+    topicGraph.edges,
   );
   if (isNode(arguedDiagramPart)) {
     return `"${arguedDiagramPart.data.label}" is important`;

--- a/src/web/topic/utils/edge.ts
+++ b/src/web/topic/utils/edge.ts
@@ -41,7 +41,7 @@ const researchRelations: AddableRelation[] = questionRelations.concat(
     { child: "fact", name: "relatesTo", parent: "fact", addableFrom: "child" }, // allow chaining facts, which feels natural
     { child: "source", name: "sourceOf", parent: "fact", addableFrom: "both" },
     { child: "source", name: "mentions", parent: "source", addableFrom: "child" },
-  ]
+  ],
 );
 
 // Assumes that we're always pointing from child to parent.
@@ -134,12 +134,12 @@ interface AddableRelation extends Relation {
 export const getRelation = (
   parent: NodeType,
   child: NodeType,
-  relationName?: RelationName
+  relationName?: RelationName,
 ): Relation | undefined => {
   const relation = relationName
     ? relations.find(
         (relation) =>
-          relation.parent === parent && relation.child === child && relation.name === relationName
+          relation.parent === parent && relation.child === child && relation.name === relationName,
       )
     : relations.find((relation) => relation.parent === parent && relation.child === child);
 
@@ -184,7 +184,8 @@ export const addableRelationsFrom = (nodeType: NodeType, addingAs: RelationDirec
 
   const addableRelations = relations.filter(
     (relation) =>
-      relation[fromDirection] === nodeType && ["both", fromDirection].includes(relation.addableFrom)
+      relation[fromDirection] === nodeType &&
+      ["both", fromDirection].includes(relation.addableFrom),
   );
 
   const formattedRelations = addableRelations.map((relation) => ({
@@ -247,7 +248,7 @@ export const getConnectingEdge = (graphPartId1: string, graphPartId2: string, ed
   const edge = edges.find(
     (edge) =>
       (edge.source === graphPartId1 && edge.target === graphPartId2) ||
-      (edge.source === graphPartId2 && edge.target === graphPartId1)
+      (edge.source === graphPartId2 && edge.target === graphPartId1),
   );
 
   return edge;
@@ -269,10 +270,10 @@ export const isEdgeAShortcut = (edge: Edge, topicGraph: Graph) => {
     const parentsOfChild = parents(edgeChild, topicGraph);
 
     const detourNodeAsChild = childrenOfParent.find(
-      (child) => child.type === shortcutRelation.detourNodeType
+      (child) => child.type === shortcutRelation.detourNodeType,
     );
     const detourNodeAsParent = parentsOfChild.find(
-      (parent) => parent.type === shortcutRelation.detourNodeType
+      (parent) => parent.type === shortcutRelation.detourNodeType,
     );
 
     // note: does not check if detour node is showing - this is so that hidden shortcut edges
@@ -298,7 +299,7 @@ export const isEdgeImpliedByComposition = (edge: Edge, topicGraph: Graph) => {
       (otherEdge) =>
         otherEdge.source === component.id &&
         otherEdge.label === edge.label &&
-        otherEdge.target === edgeChild.id
+        otherEdge.target === edgeChild.id,
     );
   });
 
@@ -311,7 +312,7 @@ export const isEdgeImpliedByComposition = (edge: Edge, topicGraph: Graph) => {
       (otherEdge) =>
         otherEdge.target === component.id &&
         otherEdge.label === edge.label &&
-        otherEdge.source === edgeParent.id
+        otherEdge.source === edgeParent.id,
     );
   });
 
@@ -335,7 +336,7 @@ const isEdgeImplied = (edge: Edge, graph: Graph, claimEdges: Edge[]) => {
 
 export const hideImpliedEdges = (edges: Edge[], displayGraph: Graph, topicGraph: Graph) => {
   const claimEdges = topicGraph.edges.filter((edge) =>
-    justificationRelationNames.includes(edge.label)
+    justificationRelationNames.includes(edge.label),
   );
 
   return edges.filter((edge) => !isEdgeImplied(edge, displayGraph, claimEdges));

--- a/src/web/topic/utils/graph.ts
+++ b/src/web/topic/utils/graph.ts
@@ -135,7 +135,7 @@ export type GraphPart = Node | Edge;
 export type GraphPartType = "node" | "edge";
 
 export const possibleScores = ["-", "1", "2", "3", "4", "5", "6", "7", "8", "9"] as const;
-export type Score = typeof possibleScores[number];
+export type Score = (typeof possibleScores)[number];
 
 export const findNodeOrThrow = (nodeId: string, nodes: Node[]) => {
   const node = nodes.find((node) => node.id === nodeId);
@@ -165,7 +165,7 @@ export const isNode = (graphPart: GraphPart): graphPart is Node => {
 
 export const isNodeType = <T extends NodeType>(
   graphPart: GraphPart,
-  type: T
+  type: T,
 ): graphPart is Node & { type: T } => {
   return isNode(graphPart) && graphPart.type === type;
 };
@@ -177,7 +177,7 @@ export const getNodesComposedBy = (node: Node, topicGraph: Graph) => {
     });
 
     const potentialComposedNodes = composingEdges.map((edge) =>
-      findNodeOrThrow(edge.target, topicGraph.nodes)
+      findNodeOrThrow(edge.target, topicGraph.nodes),
     );
 
     return potentialComposedNodes
@@ -190,20 +190,20 @@ const findNodesRecursivelyFrom = (
   fromNode: Node,
   toDirection: RelationDirection,
   graph: Graph,
-  labels?: RelationName[]
+  labels?: RelationName[],
 ): Node[] => {
   const from = toDirection === "child" ? "source" : "target";
   const to = toDirection === "child" ? "target" : "source";
 
   const foundEdges = graph.edges.filter(
-    (edge) => edge[from] === fromNode.id && (!labels || labels.includes(edge.label))
+    (edge) => edge[from] === fromNode.id && (!labels || labels.includes(edge.label)),
   );
   const foundNodes = foundEdges.map((edge) => findNodeOrThrow(edge[to], graph.nodes));
 
   if (foundNodes.length === 0) return [];
 
   const furtherNodes = foundNodes.flatMap((node) =>
-    findNodesRecursivelyFrom(node, toDirection, graph, labels)
+    findNodesRecursivelyFrom(node, toDirection, graph, labels),
   );
 
   return uniqBy(foundNodes.concat(furtherNodes), (node) => node.id);
@@ -221,7 +221,7 @@ export const getRelevantEdges = (nodes: Node[], graph: Graph) => {
   const nodeIds = nodes.map((node) => node.id);
 
   return graph.edges.filter(
-    (edge) => nodeIds.includes(edge.target) && nodeIds.includes(edge.source)
+    (edge) => nodeIds.includes(edge.target) && nodeIds.includes(edge.source),
   );
 };
 
@@ -234,7 +234,7 @@ export const getRelevantEdges = (nodes: Node[], graph: Graph) => {
 export const getSecondaryNeighbors = (
   primaryNodes: Node[],
   graph: Graph,
-  generalFilter: GeneralFilter
+  generalFilter: GeneralFilter,
 ) => {
   const primaryNodeIds = primaryNodes.map((node) => node.id);
 
@@ -252,8 +252,8 @@ export const getSecondaryNeighbors = (
         graph.edges.some(
           (edge) =>
             (edge.source === node.id && primaryNonResearchIds.includes(edge.target)) ||
-            (edge.target === node.id && primaryNonResearchIds.includes(edge.source))
-        )
+            (edge.target === node.id && primaryNonResearchIds.includes(edge.source)),
+        ),
     );
 
     // eslint-disable-next-line functional/immutable-data
@@ -272,8 +272,8 @@ export const getSecondaryNeighbors = (
         graph.edges.some(
           (edge) =>
             (edge.source === node.id && primaryNonStructureIds.includes(edge.target)) ||
-            (edge.target === node.id && primaryNonStructureIds.includes(edge.source))
-        )
+            (edge.target === node.id && primaryNonStructureIds.includes(edge.source)),
+        ),
     );
 
     // eslint-disable-next-line functional/immutable-data

--- a/src/web/topic/utils/layout.ts
+++ b/src/web/topic/utils/layout.ts
@@ -63,10 +63,10 @@ const calculatePartition = (node: Node, nodes: Node[], edges: Edge[]) => {
     const hasProblemAncestor = nodeAncestors.some((ancestor) => ancestor.type === "problem");
     const hasCriterionAncestor = nodeAncestors.some((ancestor) => ancestor.type === "criterion");
     const hasSolutionDescendant = nodeDescendants.some(
-      (descendant) => descendant.type === "solution"
+      (descendant) => descendant.type === "solution",
     );
     const hasCriterionDescendant = nodeDescendants.some(
-      (descendant) => descendant.type === "criterion"
+      (descendant) => descendant.type === "criterion",
     );
 
     // this implementation seems solid but if it becomes unperformant, it might be good enough to
@@ -92,7 +92,7 @@ export interface NodePosition {
 export const layout = async (
   diagram: Diagram,
   partition: boolean,
-  thoroughness: number
+  thoroughness: number,
 ): Promise<NodePosition[]> => {
   const { nodes, edges } = diagram;
 

--- a/src/web/topic/utils/score.ts
+++ b/src/web/topic/utils/score.ts
@@ -27,8 +27,8 @@ export const getAverageScore = (userScores: Score[]): Score => {
   const roundedAverage = round(
     meanBy(
       userScores.filter((score) => score !== "-"),
-      (score) => Number(score)
-    )
+      (score) => Number(score),
+    ),
   );
 
   return roundedAverage.toString() as Score; // average should still result in a Score

--- a/src/web/view/actionConfigStore.ts
+++ b/src/web/view/actionConfigStore.ts
@@ -27,7 +27,7 @@ const useActionConfigStore = create<ActionConfigStoreState>()(
     // removing the need to write a migration for every new field
     merge: (persistedState, _currentState) =>
       withDefaults(persistedState as Partial<ActionConfigStoreState>, initialState),
-  })
+  }),
 );
 
 // hooks

--- a/src/web/view/currentViewStore/filter.ts
+++ b/src/web/view/currentViewStore/filter.ts
@@ -43,7 +43,7 @@ export const useDiagramFilter = (): DiagramFilter => {
 export const useTableFilter = (): TableFilter => {
   return useCurrentViewStore(
     (state) => state.tableFilter,
-    (before, after) => JSON.stringify(before) === JSON.stringify(after)
+    (before, after) => JSON.stringify(before) === JSON.stringify(after),
   );
 };
 
@@ -87,14 +87,14 @@ export const setShowInformation = (category: InfoCategory, show: boolean) => {
     show && !oldCategoriesToShow.includes(category)
       ? [...oldCategoriesToShow, category]
       : !show && oldCategoriesToShow.includes(category)
-      ? oldCategoriesToShow.filter((c) => c !== category)
-      : null;
+        ? oldCategoriesToShow.filter((c) => c !== category)
+        : null;
 
   if (newCategoriesToShow) {
     useCurrentViewStore.setState(
       { categoriesToShow: newCategoriesToShow },
       false,
-      "setShowInformation"
+      "setShowInformation",
     );
     emitter.emit("changedDiagramFilter");
   }
@@ -105,8 +105,8 @@ export const setStandardFilter = (category: InfoCategory, filter: StandardFilter
     category === "structure"
       ? { structureFilter: filter }
       : category === "research"
-      ? { researchFilter: filter }
-      : { justificationFilter: filter };
+        ? { researchFilter: filter }
+        : { justificationFilter: filter };
 
   useCurrentViewStore.setState(newFilter, false, "setStandardFilter");
 
@@ -133,7 +133,7 @@ export const viewCriteriaTable = (problemNodeId: string) => {
       },
     },
     false,
-    "viewCriteriaTable"
+    "viewCriteriaTable",
   );
 };
 
@@ -145,7 +145,7 @@ export const viewJustification = (arguedDiagramPartId: string) => {
       justificationFilter: { type: "rootClaim", centralRootClaimId: arguedDiagramPartId },
     },
     false,
-    "viewJustification"
+    "viewJustification",
   );
 };
 

--- a/src/web/view/currentViewStore/store.ts
+++ b/src/web/view/currentViewStore/store.ts
@@ -82,13 +82,13 @@ export const useCurrentViewStore = createWithEqualityFn<ViewState>()(
       // removing the need to write a migration for every new field
       merge: (persistedState, _currentState) =>
         withDefaults(persistedState as Partial<ViewState>, initialViewState),
-    })
+    }),
   ),
 
   // Using `createWithEqualityFn` so that we can do a diff in hooks that return new arrays/objects
   // so that we can avoid extra renders
   // e.g. when we return URLSearchParams
-  Object.is
+  Object.is,
 );
 
 // temporal store is a vanilla store, we need to wrap it to use it as a hook and be able to react to changes

--- a/src/web/view/currentViewStore/triggerEventMiddleware.ts
+++ b/src/web/view/currentViewStore/triggerEventMiddleware.ts
@@ -5,9 +5,9 @@ import { ViewState } from "@/web/view/currentViewStore/store";
 
 type TriggerEvent = <
   Mps extends [StoreMutatorIdentifier, unknown][] = [],
-  Mcs extends [StoreMutatorIdentifier, unknown][] = []
+  Mcs extends [StoreMutatorIdentifier, unknown][] = [],
 >(
-  create: StateCreator<ViewState, Mps, Mcs>
+  create: StateCreator<ViewState, Mps, Mcs>,
 ) => StateCreator<ViewState, Mps, Mcs>;
 
 type TriggerEventImpl = (f: StateCreator<ViewState>) => StateCreator<ViewState>;

--- a/src/web/view/miscTopicConfigStore.ts
+++ b/src/web/view/miscTopicConfigStore.ts
@@ -23,7 +23,7 @@ const useMiscTopicConfigStore = create<MiscTopicConfigStoreState>()(
     // removing the need to write a migration for every new field
     merge: (persistedState, _currentState) =>
       withDefaults(persistedState as Partial<MiscTopicConfigStoreState>, initialState),
-  })
+  }),
 );
 
 // hooks

--- a/src/web/view/quickViewStore/apiSyncerMiddleware.ts
+++ b/src/web/view/quickViewStore/apiSyncerMiddleware.ts
@@ -10,7 +10,7 @@ import { QuickViewStoreState } from "@/web/view/quickViewStore/store";
 const getCrudDiffs = <T extends object>(
   before: T[],
   after: T[],
-  identifierFn: (element: T) => string
+  identifierFn: (element: T) => string,
 ): [T[], T[], T[]] => {
   // use keyed objects instead of array of objects because array diffs vary based on element ordering
   const keyedBefore = Object.fromEntries(before.map((item) => [identifierFn(item), item]));
@@ -23,13 +23,13 @@ const getCrudDiffs = <T extends object>(
     Object.entries(keyedBefore).map(([key, value]) => [
       key,
       Object.fromEntries(Object.entries(value).map(([k, v]) => [k, JSON.stringify(v)])),
-    ])
+    ]),
   );
   const stringifiedAfter = Object.fromEntries(
     Object.entries(keyedAfter).map(([key, value]) => [
       key,
       Object.fromEntries(Object.entries(value).map(([k, v]) => [k, JSON.stringify(v)])),
-    ])
+    ]),
   );
 
   const diffs = diff(stringifiedBefore, stringifiedAfter);
@@ -64,7 +64,7 @@ const getApiViews = (topicId: number, store: QuickViewStoreState): QuickView[] =
 const saveDiffs = (
   topicId: number,
   storeBefore: QuickViewStoreState,
-  storeAfter: QuickViewStoreState
+  storeAfter: QuickViewStoreState,
 ) => {
   const apiBefore = getApiViews(topicId, storeBefore);
   const apiAfter = getApiViews(topicId, storeAfter);
@@ -72,11 +72,11 @@ const saveDiffs = (
   const [viewsToCreate, viewsToUpdate, viewsToDelete] = getCrudDiffs(
     apiBefore,
     apiAfter,
-    (view) => view.id
+    (view) => view.id,
   );
 
   const anyChanges = [viewsToCreate, viewsToUpdate, viewsToDelete].some(
-    (changes) => changes.length > 0
+    (changes) => changes.length > 0,
   );
   if (!anyChanges) return;
 
@@ -90,9 +90,9 @@ const saveDiffs = (
 
 type ApiSyncer = <
   Mps extends [StoreMutatorIdentifier, unknown][] = [],
-  Mcs extends [StoreMutatorIdentifier, unknown][] = []
+  Mcs extends [StoreMutatorIdentifier, unknown][] = [],
 >(
-  create: StateCreator<QuickViewStoreState, Mps, Mcs>
+  create: StateCreator<QuickViewStoreState, Mps, Mcs>,
 ) => StateCreator<QuickViewStoreState, Mps, Mcs>;
 
 type ApiSyncerImpl = (f: StateCreator<QuickViewStoreState>) => StateCreator<QuickViewStoreState>;

--- a/src/web/view/quickViewStore/store.ts
+++ b/src/web/view/quickViewStore/store.ts
@@ -76,12 +76,12 @@ export const useQuickViewStore = createWithEqualityFn<QuickViewStoreState>()(
       // removing the need to write a migration for every new field
       merge: (persistedState, _currentState) =>
         withDefaults(persistedState as Partial<QuickViewStoreState>, initialState),
-    })
+    }),
   ),
 
   // Using `createWithEqualityFn` so that we can do a diff in hooks that return new arrays/objects
   // so that we can avoid extra renders
-  Object.is
+  Object.is,
 );
 
 // temporal store is a vanilla store, we need to wrap it to use it as a hook and be able to react to changes
@@ -90,7 +90,7 @@ const useTemporalStore = () => useStore(useQuickViewStore.temporal);
 // hooks
 export const useQuickViews = () => {
   return useQuickViewStore((state) =>
-    state.views.toSorted((view1, view2) => view1.order - view2.order)
+    state.views.toSorted((view1, view2) => view1.order - view2.order),
   );
 };
 
@@ -137,7 +137,7 @@ export const createView = () => {
       selectedViewId: newViewId,
     }),
     false,
-    "createView"
+    "createView",
   );
 };
 
@@ -150,11 +150,11 @@ export const setTitle = (viewId: string, newTitle: string) => {
   useQuickViewStore.setState(
     {
       views: state.views.map((view) =>
-        view.id === viewToRename.id ? { ...view, title: newTitle } : view
+        view.id === viewToRename.id ? { ...view, title: newTitle } : view,
       ),
     },
     false,
-    "setTitle"
+    "setTitle",
   );
 
   updateURLParams(newTitle);
@@ -170,12 +170,12 @@ export const saveView = (viewId: string) => {
   useQuickViewStore.setState(
     {
       views: state.views.map((view) =>
-        view.id === viewToSave.id ? { ...view, viewState: currentView } : view
+        view.id === viewToSave.id ? { ...view, viewState: currentView } : view,
       ),
       selectedViewId: state.selectedViewId ?? viewId, // after saving, the newly-saved view should match the current view state, so select it if nothing is selected
     },
     false,
-    "saveView"
+    "saveView",
   );
 };
 
@@ -191,7 +191,7 @@ export const deleteView = (viewId: string) => {
       selectedViewId: state.selectedViewId === viewId ? null : state.selectedViewId,
     },
     false,
-    "deleteView"
+    "deleteView",
   );
 };
 
@@ -278,7 +278,7 @@ export const loadQuickViewsFromApi = (topic: UserTopic, views: QuickView[]) => {
       selectedViewId: null, // don't remember from previous topic - this will be set after loading current view if it should be
     },
     true,
-    "loadQuickViewsFromApi"
+    "loadQuickViewsFromApi",
   );
 
   // it doesn't make sense to want to undo a page load

--- a/src/web/view/userConfigStore.ts
+++ b/src/web/view/userConfigStore.ts
@@ -12,7 +12,7 @@ const initialState: UserConfigStoreState = {
 const useUserConfigStore = create<UserConfigStoreState>()(
   persist(() => initialState, {
     name: "user-config-storage",
-  })
+  }),
 );
 
 // hooks

--- a/src/web/view/utils/diagramFilter.ts
+++ b/src/web/view/utils/diagramFilter.ts
@@ -31,8 +31,8 @@ const applyHighLevelFilter = (graph: Graph, _filters: HighLevelOptions) => {
 
   const details = problems.flatMap((problem) =>
     children(problem, graph).filter((child) =>
-      ["cause", "effect", "benefit", "detriment", "solution"].includes(child.type)
-    )
+      ["cause", "effect", "benefit", "detriment", "solution"].includes(child.type),
+    ),
   );
 
   const nodes = [...problems, ...details];
@@ -84,7 +84,7 @@ const applyProblemFilter = (graph: Graph, filters: ProblemOptions) => {
     solutions,
     criteria,
     filters.solutionDetail,
-    graph
+    graph,
   );
 
   const nodes = [centralProblem, ...problemDetails, ...filteredSolutionDetails];
@@ -138,19 +138,19 @@ const applyTradeoffsFilter = (graph: Graph, filters: TradeoffsOptions) => {
   const { selectedSolutions, selectedCriteria } = getSelectedTradeoffNodes(
     solutions,
     criteria,
-    filters
+    filters,
   );
 
   const criteriaParents = selectedCriteria.flatMap((criterion) =>
     // filter problem because we want to separately include the problem regardless of if we're showing criteria, for context
-    parents(criterion, graph).filter((parent) => parent.type !== "problem")
+    parents(criterion, graph).filter((parent) => parent.type !== "problem"),
   );
 
   const filteredSolutionDetails = getSolutionDetails(
     selectedSolutions,
     selectedCriteria,
     filters.solutionDetail,
-    graph
+    graph,
   );
 
   const nodes = uniqBy(
@@ -161,7 +161,7 @@ const applyTradeoffsFilter = (graph: Graph, filters: TradeoffsOptions) => {
       ...criteriaParents,
       ...filteredSolutionDetails,
     ],
-    (node) => node.id
+    (node) => node.id,
   );
   const edges = getRelevantEdges(nodes, graph);
 
@@ -172,16 +172,16 @@ const getSolutionDetails = (
   solutions: Node[],
   criteria: Node[],
   detailType: DetailType,
-  graph: Graph
+  graph: Graph,
 ) => {
   if (detailType === "none") return [];
 
   const solutionComponentsEffects = solutions.flatMap((solution) =>
-    ancestors(solution, graph, ["has", "creates"])
+    ancestors(solution, graph, ["has", "creates"]),
   );
 
   const solutionObstacles = solutions.flatMap((solution) =>
-    descendants(solution, graph, ["obstacleOf", "addresses"])
+    descendants(solution, graph, ["obstacleOf", "addresses"]),
   );
 
   const criteriaIds = criteria.map((criterion) => criterion.id);
@@ -189,7 +189,7 @@ const getSolutionDetails = (
   return detailType === "all"
     ? [...solutionComponentsEffects, ...solutionObstacles]
     : solutionComponentsEffects.filter((detail) =>
-        ancestors(detail, graph).some((ancestor) => criteriaIds.includes(ancestor.id))
+        ancestors(detail, graph).some((ancestor) => criteriaIds.includes(ancestor.id)),
       );
 };
 
@@ -200,13 +200,13 @@ const getSolutionDetails = (
 export const getSelectedTradeoffNodes = (
   problemSolutions: Node[],
   problemCriteria: Node[],
-  filters: { solutions: string[]; criteria: string[] }
+  filters: { solutions: string[]; criteria: string[] },
 ) => {
   const selectedSolutions = problemSolutions.filter((solution) =>
-    filters.solutions.includes(solution.id)
+    filters.solutions.includes(solution.id),
   );
   const selectedCriteria = problemCriteria.filter((criterion) =>
-    filters.criteria.includes(criterion.id)
+    filters.criteria.includes(criterion.id),
   );
 
   return {
@@ -380,7 +380,7 @@ export const applyDiagramFilter = (graph: Graph, diagramFilter: DiagramFilter) =
     .filter(([_, filter]) => filter.show)
     .flatMap(([category, filter]) => {
       const categoryNodes = graph.nodes.filter((node) =>
-        infoNodeTypes[category as InfoCategory].includes(node.type)
+        infoNodeTypes[category as InfoCategory].includes(node.type),
       );
 
       if (filter.type === "none") return categoryNodes;
@@ -392,7 +392,7 @@ export const applyDiagramFilter = (graph: Graph, diagramFilter: DiagramFilter) =
       // return all nodes of the category if no filtered nodes are returned.
       const filteredCategoryNodes = applyStandardFilter(
         { nodes: categoryNodes, edges: categoryEdges },
-        filter
+        filter,
       ).nodes;
 
       return filteredCategoryNodes;

--- a/src/web/view/utils/generalFilter.ts
+++ b/src/web/view/utils/generalFilter.ts
@@ -28,7 +28,7 @@ export const applyNodeTypeFilter = (nodes: Node[], nodeTypes: NodeType[]) => {
 export const applyScoreFilter = <T extends GraphPart>(
   graphParts: T[],
   filter: GeneralFilter,
-  scores: Record<string, Score>
+  scores: Record<string, Score>,
 ) => {
   const { showOnlyScored, scoredComparer, scoreToCompare } = filter;
   if (!showOnlyScored) return graphParts;


### PR DESCRIPTION
storybook was forcing package-lock to use this version anyway (via prettier-fallback?), and it defaults to a nicer ternary and adds trailing commas, which I prefer.

includes adding .all-contributorsrc to prettierignore because that started to get picked up.

### Description of changes

-

### Additional context

-
