### PR TITLE
touchup: position tutorial at bottom-right

### DIFF
--- a/src/web/topic/components/TopicWorkspace/TourHelper.tsx
+++ b/src/web/topic/components/TopicWorkspace/TourHelper.tsx
@@ -28,10 +28,7 @@ export const TourHelper = () => {
     if (!hasSeenAnyTour) startFirstTour(userCanEditTopicData);
   }, [hasSeenAnyTour, memoTourProps, userCanEditTopicData]);
 
-  // Default anchor for tour popover - ideally want this closer to bottom so that it doesn't stand
-  // on top of details pane for big screens (-bottom-2 seems right), but popover currently is
-  // positioned incorrectly when steps change popover size. Hoping to have this resolved with [ticket].
-  // return <div className={`${tourDefaultAnchorClass} invisible absolute -bottom-2 right-0`} />;
-  // return <div className={`${tourDefaultAnchorClass} invisible absolute bottom-8 right-0`} />;
-  return <div className={`${tourDefaultAnchorClass} invisible absolute -right-2 top-20`} />;
+  // Seems like there's no way to position the tour without an anchor, so here's one for when we
+  // don't have a particular element we care to point out.
+  return <div className={`${tourDefaultAnchorClass} invisible absolute -bottom-2 right-0`} />;
 };

--- a/src/web/tour/steps/diagramBasics.tsx
+++ b/src/web/tour/steps/diagramBasics.tsx
@@ -20,6 +20,7 @@ Below is a problem node, which suggests that "cars going too fast in my neighbor
             alt="problem node - cars going too fast"
             width={305}
             height={159}
+            key="https://github.com/user-attachments/assets/989d5310-6193-421c-9dac-aaaa55ba7ef6"
           />
         }
       />
@@ -39,6 +40,7 @@ Note that editing is only possible if you created the topic or if you were given
             alt="editing node text"
             width={322}
             height={205}
+            key="https://github.com/user-attachments/assets/ca5049a6-cb74-479a-a386-0fe22d2034e1"
           />
         }
       />
@@ -56,6 +58,7 @@ Note that editing is only possible if you created the topic or if you were given
             alt="adding a node"
             width={527}
             height={387}
+            key="https://github.com/user-attachments/assets/380f2603-33c9-46d7-997f-532831196ff4"
           />
         }
       />
@@ -75,6 +78,7 @@ Advanced actions and configuration can be found by clicking on the More Actions 
             alt="Other actions"
             width={413}
             height={476}
+            key="https://github.com/user-attachments/assets/61b07a44-bd48-49ef-b9ee-780b4c2a676c"
           />
         }
       />
@@ -92,6 +96,7 @@ Advanced actions and configuration can be found by clicking on the More Actions 
             alt="Edges"
             width={273}
             height={324}
+            key="https://github.com/user-attachments/assets/14892d89-d970-407d-bb41-64dd6ae4ac6b"
           />
         }
       />
@@ -104,7 +109,13 @@ Advanced actions and configuration can be found by clicking on the More Actions 
         stepTitle='Completed "Diagram Basics"! 🎉'
         text="Yay! Now you're ready to build your own diagrams."
         imageSlot={
-          <Image src={celebrateGif} alt="Celebrate completed tutorial!" width={256} height={143} />
+          <Image
+            src={celebrateGif}
+            alt="Celebrate completed tutorial!"
+            width={256}
+            height={143}
+            key={celebrateGif}
+          />
         }
       />
     ),

--- a/src/web/tour/tour.ts
+++ b/src/web/tour/tour.ts
@@ -23,7 +23,13 @@ export const startTour = (tour: Tour) => {
   }
 
   reactour.setCurrentStep(0);
-  reactour.setIsOpen(true);
+
+  // Previously had issue where the first step of the new tour was being sized the same as the
+  // previously-seen tour step, causing it to be positioned incorrectly.
+  // Closing and reopening after timeout (presumably to ensure there's a render with the false
+  // value?) seems to fix this.
+  reactour.setIsOpen(false);
+  setTimeout(() => reactour?.setIsOpen(true), 0);
 };
 
 export const tourIsOpen = () => {


### PR DESCRIPTION
figured out the positioning issues:

1. images were initially rendering as the size of the previously- loaded image. needed to set keys to ensure each image was getting its own size on initial render

2. `setSteps` without closing the tutorial was using the same popover size as the previously-seen step. needed to temporarily close the tutorial when switching steps.

### Description of changes

-

### Additional context

-
