### PR TITLE
fix: mobile headline is indented awkwardly

### DIFF
--- a/src/web/home/Headline.tsx
+++ b/src/web/home/Headline.tsx
@@ -7,20 +7,19 @@ const RotatingDescriptors = () => {
   return (
     <>
       {/* use `hideThird` with a delay to show only one of the 3 texts for each 3s interval of the 9s */}
-      <span className="invisible absolute animate-[slideInOut_3s_infinite,_hideThird_9s_0s_infinite] text-primary-main">
+      {/* use `left-0` and `w-full` for mobile because text-align center doesn't otherwise work with absolute positioning https://stackoverflow.com/a/18148018 */}
+      <span className="invisible absolute left-0 w-full animate-[slideInOut_3s_infinite,_hideThird_9s_0s_infinite] text-primary-main sm:left-auto">
         effectively
       </span>
-      <span className="invisible absolute animate-[slideInOut_3s_infinite,_hideThird_9s_3s_infinite] text-primary-main">
+      <span className="invisible absolute left-0 w-full animate-[slideInOut_3s_infinite,_hideThird_9s_3s_infinite] text-primary-main sm:left-auto">
         collaboratively
       </span>
-      <span className="invisible absolute animate-[slideInOut_3s_infinite,_hideThird_9s_6s_infinite] text-primary-main">
+      <span className="invisible absolute left-0 w-full animate-[slideInOut_3s_infinite,_hideThird_9s_6s_infinite] text-primary-main sm:left-auto">
         with an open mind
       </span>
 
-      {/* size the text space correctly, while allowing the rotating words to be absolute and appear in the same spot as each other */}
-      <span aria-hidden="true" className="invisible">
-        size
-      </span>
+      {/* size the text space to a line's worth, while allowing the rotating words to be absolute and appear in the same spot as each other */}
+      <br />
     </>
   );
 };


### PR DESCRIPTION
### Description of changes

-

### Additional context

-
