### PR TITLE
docs(discourse): add mention of tutorials

### DIFF
--- a/docs-site/next.config.js
+++ b/docs-site/next.config.js
@@ -19,6 +19,12 @@ module.exports = withNextra({
         port: "",
         pathname: "/amelioro/ameliorate/assets/**",
       },
+      {
+        protocol: "https",
+        hostname: "github.com",
+        port: "",
+        pathname: "/user-attachments/assets/**",
+      },
     ],
   },
 });

--- a/docs-site/pages/discourse-sessions.mdx
+++ b/docs-site/pages/discourse-sessions.mdx
@@ -1,3 +1,5 @@
+import Image from "next/image";
+
 # Discourse Sessions
 
 A discourse session is a session during which a small group discusses a chosen issue, using Ameliorate to reflect the discussion, keep it focused, and get people on the same page.
@@ -38,4 +40,9 @@ When a session is going to happen, an organizer will send an email with a poll f
 - Read through the project's [Code of Conduct](https://github.com/amelioro/ameliorate/blob/main/CODE_OF_CONDUCT.md) - we might be discussing controversial topics, and we all want to enjoy respect
 - Make sure you're able to join the [Ameliorate Discord server](https://discord.gg/3KhdyJkTWT) and are ready to use the "Discourse Session" voice channel
 - [Create](/getting-started/your-first-topic#creating-your-user) an Ameliorate account
-- (Optional but helpful) Read through [Getting Started](/getting-started) so that you're familiar with the app
+- Step through the ~5 minute tutorials for Viewers (open the app to any topic, perhaps [this one](https://ameliorate.app/examples/detailed-cars-going-too-fast?view=All+structure), and click the question mark) or read through [Getting Started](/getting-started)
+  <Image
+    src="https://github.com/user-attachments/assets/35acd6f5-bab1-48a5-a73e-b27b6e78096a"
+    width={374}
+    height={350}
+  />


### PR DESCRIPTION
also added another allowed remote image host for what seems like github's new asset URL

### Description of changes

-

### Additional context

-
