### PR TITLE
chore(sentry): turn off session replays

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -28,17 +28,4 @@ Sentry.init({
     }
     return event;
   },
-
-  // Replays seem like they could be useful, so we'll just keep them enabled until we know that we'll exceed the free tier
-  replaysOnErrorSampleRate: 1.0,
-  // This sets the sample rate to be 10%. You may want this to be 100% while
-  // in development and sample at a lower rate in production
-  replaysSessionSampleRate: 0.1,
-  integrations: [
-    Sentry.replayIntegration({
-      // Additional Replay configuration goes in here, for example:
-      maskAllText: true,
-      blockAllMedia: true,
-    }),
-  ],
 });


### PR DESCRIPTION
annoying to send fetch envelopes every 5 seconds.
tried sampling only errors as well,
but that still sent envelopes every 5s.

don't think replays are really necessary anyway.

### Description of changes

-

### Additional context

-
