### PR TITLE
fix: don't partition effects with no created links

### DIFF
--- a/src/web/topic/utils/layout.ts
+++ b/src/web/topic/utils/layout.ts
@@ -69,7 +69,8 @@ const calculatePartition = (node: Node, edges: Edge[]) => {
 
     if (shouldBeAboveCriteria && shouldBeBelowCriteria) return "null";
     else if (shouldBeAboveCriteria) return "0";
-    else return "2";
+    else if (shouldBeBelowCriteria) return "2";
+    else return "null";
   } else {
     return partitionOrders[node.type];
   }


### PR DESCRIPTION
e.g. criterion context with parent effects will just have "relates to" edges without "created by" problem edges being shown. these should not be partitioned, so they can be above the criterion.

### Description of changes

-

### Additional context

-
