### PR TITLE
fix: changes lost on navigate back

### DIFF
--- a/src/pages/[username]/[topicTitle].page.tsx
+++ b/src/pages/[username]/[topicTitle].page.tsx
@@ -38,10 +38,10 @@ const Topic: NextPage = () => {
   const getDiagram = trpc.topic.getData.useQuery(
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- `enabled` guarantees non-null before query is run
     { username: username!, title: topicTitle! },
-    // Not using stale time because client-side navigation back to this page fires the useEffect again,
+    // Zero stale time because client-side navigation back to this page fires the useEffect again,
     // repopulating the store with old data (if the client changed data before navigating away & back).
     // So we'll just re-fire on page mount, should be fine.
-    { enabled: !!username && !!topicTitle },
+    { enabled: !!username && !!topicTitle, staleTime: 0 },
   );
 
   const { sessionUser } = useSessionUser();


### PR DESCRIPTION
to reproduce:
1. create or open a topic you can edit
2. make some edits (add/remove nodes)
3. go to settings page
4. use back button to go back to your topic
5. observe your edits have been undone

this happened because the API request to load data for a topic was being kept fresh forever, so it would never re-request without a page refresh. once loaded with old data, the old data was saved, because all state changes are saved.

in this case, navigating using the back button would perform an SPA page navigation, reusing the data it was previously loaded with.

this bug was introduced by #441

### Description of changes

-

### Additional context

-
