### PR TITLE
touchup: highlight only edge cell on hover

### DIFF
--- a/src/web/topic/components/CriteriaTable/CriteriaTable.tsx
+++ b/src/web/topic/components/CriteriaTable/CriteriaTable.tsx
@@ -286,12 +286,13 @@ export const CriteriaTable = () => {
         enableStickyHeader={true}
         // not very well documented in the library, but this drop zone takes up space for unknown reasons.
         positionToolbarDropZone="none"
-        muiTablePaperProps={{
-          className: "criteria-table-paper",
-        }}
         muiTableProps={{
           className: tableZoomClasses,
         }}
+        muiTablePaperProps={{
+          className: "criteria-table-paper",
+        }}
+        muiTableBodyRowProps={{ hover: false }}
         state={{
           // have to set columnOrder because otherwise new columns are appended to the end, instead of before the last cell in the case of Solution Totals when table is transposed
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- all columns should have an id or accessorKey set

--- a/src/web/topic/components/CriteriaTable/EdgeCell.tsx
+++ b/src/web/topic/components/CriteriaTable/EdgeCell.tsx
@@ -2,12 +2,18 @@ import { openContextMenu } from "@/web/common/store/contextMenuActions";
 import { CommonIndicators } from "@/web/topic/components/Indicator/CommonIndicators";
 import { ContentIndicators } from "@/web/topic/components/Indicator/ContentIndicators";
 import { Edge } from "@/web/topic/utils/graph";
-import { setSelected } from "@/web/view/currentViewStore/store";
+import { setSelected, useIsGraphPartSelected } from "@/web/view/currentViewStore/store";
 
 export const EdgeCell = ({ edge }: { edge: Edge }) => {
+  const selected = useIsGraphPartSelected(edge.id);
+
   return (
     <div
-      className="flex h-full flex-col items-center justify-center"
+      className={
+        "flex h-full flex-col items-center justify-center" +
+        // bg-neutral-50 instead of bg-neutral-main because we specifically want to contrast with indicator backgrounds
+        ` hover:bg-neutral-50${selected ? " bg-neutral-50" : ""}`
+      }
       onClick={() => setSelected(edge.id)}
       onContextMenu={(event) => openContextMenu(event, { edge })}
       role="button"


### PR DESCRIPTION
previously highlighted the whole row, which wasn't super helpful.

also lightened the highlight color to contrast better with indicators.

### Description of changes

-

### Additional context

-
