### PR TITLE
touchup: clean up topic details pane a bit

### DIFF
--- a/src/web/topic/components/TopicPane/GraphPartDetails.tsx
+++ b/src/web/topic/components/TopicPane/GraphPartDetails.tsx
@@ -53,7 +53,8 @@ export const GraphPartDetails = ({ graphPart, selectedTab, setSelectedTab }: Pro
 
   // Ideally we could exactly reuse the indicator logic here, rather than duplicating, but not sure
   // a good way to do that, so we're just duplicating the logic for now.
-  // Don't want to use the exact indicators, because in the pane, it seems worse to show partial icons e.g. ThumbsUp vs ThumbsDown.
+  // Don't want to use the exact indicators, because pane indication seems to look better with Icon
+  // vs IconOutlined as opposed to background color.
   // Maybe could extract logic from the specific indicators, but that seems also like a decent amount of extra abstraction.
   const { supports, critiques } = useTopLevelJustification(graphPart.id);
   const { questions, facts, sources } = useResearchNodes(graphPart.id);
@@ -162,6 +163,7 @@ export const GraphPartDetails = ({ graphPart, selectedTab, setSelectedTab }: Pro
           <DetailsBasicsSection graphPart={graphPart} />
 
           <Divider className="my-1" />
+
           <ListItem disablePadding={false}>
             <ListItemIcon>
               <ThumbsUpDown />
@@ -174,6 +176,7 @@ export const GraphPartDetails = ({ graphPart, selectedTab, setSelectedTab }: Pro
           {partIsNode && (
             <>
               <Divider className="my-1" />
+
               <ListItem disablePadding={false}>
                 <ListItemIcon>
                   <School />
@@ -185,6 +188,7 @@ export const GraphPartDetails = ({ graphPart, selectedTab, setSelectedTab }: Pro
           )}
 
           <Divider className="my-1" />
+
           <ListItem disablePadding={false}>
             <ListItemIcon>
               <ChatBubble />

--- a/src/web/topic/components/TopicPane/TopicPane.tsx
+++ b/src/web/topic/components/TopicPane/TopicPane.tsx
@@ -11,8 +11,14 @@ import { memo, useEffect, useState } from "react";
 
 import { deepIsEqual } from "@/common/utils";
 import { emitter } from "@/web/common/event";
-import { DetailsTab, GraphPartDetails } from "@/web/topic/components/TopicPane/GraphPartDetails";
-import { TopicDetails } from "@/web/topic/components/TopicPane/TopicDetails";
+import {
+  GraphPartDetails,
+  DetailsTab as PartDetailsTab,
+} from "@/web/topic/components/TopicPane/GraphPartDetails";
+import {
+  TopicDetails,
+  DetailsTab as TopicDetailsTab,
+} from "@/web/topic/components/TopicPane/TopicDetails";
 import {
   Anchor,
   PositionedDiv,
@@ -39,7 +45,8 @@ const TopicPaneBase = ({ anchor, tabs }: Props) => {
   const [isOpen, setIsOpen] = useState(true);
   const [selectedTab, setSelectedTab] = useState(tabs[0]);
 
-  const [selectedPartDetailsTab, setSelectedPartDetailsTab] = useState<DetailsTab>("Basics");
+  const [selectedTopicDetailsTab, setSelectedTopicDetailsTab] = useState<TopicDetailsTab>("Basics");
+  const [selectedPartDetailsTab, setSelectedPartDetailsTab] = useState<PartDetailsTab>("Basics");
 
   const selectedGraphPart = useSelectedGraphPart();
 
@@ -104,7 +111,10 @@ const TopicPaneBase = ({ anchor, tabs }: Props) => {
           key={selectedGraphPart.id}
         />
       ) : (
-        <TopicDetails />
+        <TopicDetails
+          selectedTab={selectedTopicDetailsTab}
+          setSelectedTab={setSelectedTopicDetailsTab}
+        />
       ),
     Views: <TopicViews />,
   };


### PR DESCRIPTION
a bunch of little things:
- use topic title for the heading
- move settings button into the heading
- create section for the Watch
- create Basics section for topic description
- put Basics and Comments sections behind tabs (based on expandDetailsTabs)

### Description of changes

-

### Additional context

-
