### PR TITLE
fix: can save view with no order

### DIFF
--- a/src/common/view.ts
+++ b/src/common/view.ts
@@ -19,7 +19,7 @@ export const savedViewSchema = z.object({
       "Title may only contain alphanumeric characters, spaces, and dashes, and cannot begin or end with a space or dash.",
     )
     .optional(),
-  order: z.number().optional(),
+  order: z.number().safe().optional(),
   viewState: z.object({}).passthrough(), // TODO: extract view options from web/ so we can have type safety here
 });
 

--- a/src/web/view/quickViewStore/store.ts
+++ b/src/web/view/quickViewStore/store.ts
@@ -129,7 +129,8 @@ export const createView = () => {
     id: newViewId,
     type: "quick",
     title: newTitle,
-    order: Math.max(...state.views.map((view) => view.order)) + 1,
+    // provide -1 by default to `Math.max` because otherwise it returns -Infinity with no arguments
+    order: Math.max(-1, ...state.views.map((view) => view.order)) + 1,
     viewState: currentView,
   };
 


### PR DESCRIPTION
`-Infinity` was passed over the API if all views were deleted, and a new one created.

Unfortunately Prisma serializes `-Infinity` as null (https://github.com/prisma/prisma/issues/19966#issuecomment-1658086903), so this API request was able to save as null in the db, rather than erroring as out of integer bounds.

Added `.finite()` to the zod schema to prevent this possibility in the future.

No other `number`s in schema allow null, so this is currently the only field that can have this issue, but we'll need to keep an eye out for it. `int`s that are conditionally `null` are susceptable.

To reproduce:
1. delete all views for a User Topic
2. create a new view (it'll be saved with `null` order in the db)
3. refresh page
4. delete the new view
5. observe error trying to delete the view because the api prevents passing a view with a `null` order