### PR TITLE
Added hotkey for deleting nodes

### DIFF
--- a/src/web/common/components/ContextMenu/DeleteNodeMenuItem.tsx
+++ b/src/web/common/components/ContextMenu/DeleteNodeMenuItem.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+
 import { ContextMenuItem } from "@/web/common/components/ContextMenu/CloseOnClickMenuItem";
 import { useSessionUser } from "@/web/common/hooks";
 import { deleteNode } from "@/web/topic/store/createDeleteActions";
@@ -7,6 +9,20 @@ import { Node } from "@/web/topic/utils/graph";
 export const DeleteNodeMenuItem = ({ node }: { node: Node }) => {
   const { sessionUser } = useSessionUser();
   const userCanEditTopicData = useUserCanEditTopicData(sessionUser?.username);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Delete" && userCanEditTopicData) {
+        deleteNode(node.id);
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [node, userCanEditTopicData]);
 
   if (!userCanEditTopicData) return <></>;
 

--- a/src/web/common/components/ContextMenu/DeleteNodeMenuItem.tsx
+++ b/src/web/common/components/ContextMenu/DeleteNodeMenuItem.tsx
@@ -11,20 +11,20 @@ export const DeleteNodeMenuItem = ({ node }: { node: Node }) => {
   const userCanEditTopicData = useUserCanEditTopicData(sessionUser?.username);
 
   useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
+    const handleGlobalDelete = (event: KeyboardEvent) => {
       if (event.key === "Delete" && userCanEditTopicData) {
         deleteNode(node.id);
       }
     };
 
-    document.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keydown", handleGlobalDelete);
 
     return () => {
-      document.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keydown", handleGlobalDelete);
     };
-  }, [node, userCanEditTopicData]);
+  }, [node.id, userCanEditTopicData]);
 
-  if (!userCanEditTopicData) return <></>;
+  if (!userCanEditTopicData) return null;
 
-  return <ContextMenuItem onClick={() => deleteNode(node.id)}>Delete node</ContextMenuItem>;
+  return <ContextMenuItem onClick={() => deleteNode(node.id)}>Delete Node</ContextMenuItem>;
 };

--- a/src/web/topic/components/TopicWorkspace/TopicWorkspace.tsx
+++ b/src/web/topic/components/TopicWorkspace/TopicWorkspace.tsx
@@ -15,8 +15,7 @@ import { TourSetter } from "@/web/topic/components/TopicWorkspace/TourSetter";
 import { TutorialAnchor } from "@/web/topic/components/TopicWorkspace/TutorialAnchor";
 import { TutorialController } from "@/web/topic/components/TopicWorkspace/TutorialController";
 import { WorkspaceContext } from "@/web/topic/components/TopicWorkspace/WorkspaceContext";
-import { setScore } from "@/web/topic/store/actions";
-import { deleteNode } from "@/web/topic/store/createDeleteActions";
+import { deleteGraphPart, setScore } from "@/web/topic/store/actions";
 import { playgroundUsername } from "@/web/topic/store/store";
 import { isOnPlayground } from "@/web/topic/store/utilActions";
 import { Score, possibleScores } from "@/web/topic/utils/graph";
@@ -26,16 +25,6 @@ import { getReadonlyMode, toggleReadonlyMode } from "@/web/view/actionConfigStor
 import { getSelectedGraphPart, setSelected, useFormat } from "@/web/view/currentViewStore/store";
 import { getPerspectives } from "@/web/view/perspectiveStore";
 import { toggleShowIndicators } from "@/web/view/userConfigStore";
-
-const getSelectedNodeId = (): string | null => {
-  const selectedPart = getSelectedGraphPart();
-  return selectedPart ? selectedPart.id : null;
-};
-
-const nodeExists = (nodeId: string): boolean => {
-  const selectedPart = getSelectedGraphPart();
-  return selectedPart ? selectedPart.id === nodeId : false;
-};
 
 const useWorkspaceHotkeys = (user: { username: string } | null | undefined) => {
   useHotkeys([hotkeys.deselectPart], () => setSelected(null));
@@ -53,12 +42,10 @@ const useWorkspaceHotkeys = (user: { username: string } | null | undefined) => {
     setScore(myUsername, selectedPart.id, score as Score);
   });
 
-  useHotkeys("delete", () => {
-    const selectedNodeId = getSelectedNodeId();
-    if (selectedNodeId && nodeExists(selectedNodeId)) {
-      deleteNode(selectedNodeId);
-    } else {
-      console.error("Node not found:", selectedNodeId);
+  useHotkeys([hotkeys.delete || "del"], () => {
+    const selectedPart = getSelectedGraphPart();
+    if (selectedPart?.id) {
+      deleteGraphPart(selectedPart.id);
     }
   });
 };

--- a/src/web/topic/components/TopicWorkspace/TopicWorkspace.tsx
+++ b/src/web/topic/components/TopicWorkspace/TopicWorkspace.tsx
@@ -16,6 +16,7 @@ import { TutorialAnchor } from "@/web/topic/components/TopicWorkspace/TutorialAn
 import { TutorialController } from "@/web/topic/components/TopicWorkspace/TutorialController";
 import { WorkspaceContext } from "@/web/topic/components/TopicWorkspace/WorkspaceContext";
 import { setScore } from "@/web/topic/store/actions";
+import { deleteNode } from "@/web/topic/store/createDeleteActions";
 import { playgroundUsername } from "@/web/topic/store/store";
 import { isOnPlayground } from "@/web/topic/store/utilActions";
 import { Score, possibleScores } from "@/web/topic/utils/graph";
@@ -25,6 +26,16 @@ import { getReadonlyMode, toggleReadonlyMode } from "@/web/view/actionConfigStor
 import { getSelectedGraphPart, setSelected, useFormat } from "@/web/view/currentViewStore/store";
 import { getPerspectives } from "@/web/view/perspectiveStore";
 import { toggleShowIndicators } from "@/web/view/userConfigStore";
+
+const getSelectedNodeId = (): string | null => {
+  const selectedPart = getSelectedGraphPart();
+  return selectedPart ? selectedPart.id : null;
+};
+
+const nodeExists = (nodeId: string): boolean => {
+  const selectedPart = getSelectedGraphPart();
+  return selectedPart ? selectedPart.id === nodeId : false;
+};
 
 const useWorkspaceHotkeys = (user: { username: string } | null | undefined) => {
   useHotkeys([hotkeys.deselectPart], () => setSelected(null));
@@ -37,10 +48,18 @@ const useWorkspaceHotkeys = (user: { username: string } | null | undefined) => {
     const [score] = hotkeysEvent.keys;
     if (!score || !possibleScores.some((s) => score === s)) return;
 
-    // seems slightly awkward that there's logic here not reused with the Score component, but hard to reuse that in a clean way
     const myUsername = isOnPlayground() ? playgroundUsername : user?.username;
     if (!userCanEditScores(myUsername, getPerspectives(), getReadonlyMode())) return;
     setScore(myUsername, selectedPart.id, score as Score);
+  });
+
+  useHotkeys("delete", () => {
+    const selectedNodeId = getSelectedNodeId();
+    if (selectedNodeId && nodeExists(selectedNodeId)) {
+      deleteNode(selectedNodeId);
+    } else {
+      console.error("Node not found:", selectedNodeId);
+    }
   });
 };
 
@@ -56,7 +75,6 @@ export const TopicWorkspace = () => {
   const useSplitPanes = isLandscape && usingBigScreen;
 
   return (
-    // h-svh to force workspace to take up full height of screen
     <div className="relative flex h-svh flex-col">
       <AppHeader />
 
@@ -94,7 +112,6 @@ export const TopicWorkspace = () => {
           </WorkspaceContext.Provider>
         )}
 
-        {/* prevents body scrolling when workspace is rendered*/}
         <Global styles={{ body: { overflow: "hidden" } }} />
       </div>
 

--- a/src/web/topic/store/actions.ts
+++ b/src/web/topic/store/actions.ts
@@ -131,3 +131,17 @@ export const setGraphPartNotes = (graphPart: GraphPart, value: string) => {
 
   useTopicStore.setState(finishDraft(state), false, "setGraphPartNotes");
 };
+
+export const deleteGraphPart = (graphPartId: string) => {
+  const state = createDraft(useTopicStore.getState());
+
+  const foundGraphPart = findGraphPartOrThrow(graphPartId, state.nodes, state.edges);
+
+  // Видалення графічної частини
+  // eslint-disable-next-line functional/immutable-data
+  state.nodes = state.nodes.filter((node) => node.id !== foundGraphPart.id);
+  // eslint-disable-next-line functional/immutable-data
+  state.edges = state.edges.filter((edge) => edge.source !== foundGraphPart.id && edge.target !== foundGraphPart.id);
+
+  useTopicStore.setState(finishDraft(state), false, "deleteGraphPart");
+};

--- a/src/web/topic/store/actions.ts
+++ b/src/web/topic/store/actions.ts
@@ -134,14 +134,20 @@ export const setGraphPartNotes = (graphPart: GraphPart, value: string) => {
 
 export const deleteGraphPart = (graphPartId: string) => {
   const state = createDraft(useTopicStore.getState());
-
   const foundGraphPart = findGraphPartOrThrow(graphPartId, state.nodes, state.edges);
 
-  // Видалення графічної частини
-  // eslint-disable-next-line functional/immutable-data
-  state.nodes = state.nodes.filter((node) => node.id !== foundGraphPart.id);
-  // eslint-disable-next-line functional/immutable-data
-  state.edges = state.edges.filter((edge) => edge.source !== foundGraphPart.id && edge.target !== foundGraphPart.id);
+  const updatedNodes = state.nodes.filter((node) => node.id !== foundGraphPart.id);
+  const updatedEdges = state.edges.filter((edge) => 
+      edge.source !== foundGraphPart.id && edge.target !== foundGraphPart.id
+  );
 
-  useTopicStore.setState(finishDraft(state), false, "deleteGraphPart");
+  useTopicStore.setState(
+      finishDraft({
+          ...state,
+          nodes: updatedNodes,
+          edges: updatedEdges
+      }),
+      false,
+      "deleteGraphPart"
+  );
 };

--- a/src/web/topic/utils/hotkeys.ts
+++ b/src/web/topic/utils/hotkeys.ts
@@ -13,4 +13,5 @@ export const hotkeys = {
   showIndicators: "Alt + i",
   zoomIn: "Ctrl + =",
   zoomOut: "Ctrl + -",
+   delete: "del",
 };


### PR DESCRIPTION
Closes #[520]

### Description of changes
Added a keyboard shortcut (Delete) for deleting nodes in the graph editor.
Implemented useEffect with an event listener for keydown in DeleteNodeMenuItem.tsx.
-

### Additional context
Verified that nodes can be deleted using both the context menu and the Delete key.
-
