### PR TITLE
touchup: improve node label-icon alignment

### DIFF
--- a/src/web/topic/components/Node/EditableNode.tsx
+++ b/src/web/topic/components/Node/EditableNode.tsx
@@ -118,7 +118,8 @@ const EditableNodeBase = ({ node, className = "" }: Props) => {
       sx={nodeStyles}
     >
       <TopDiv className="flex h-6 items-center justify-between">
-        <NodeTypeDiv className="flex h-6 items-center rounded-br rounded-tl">
+        {/* pb/pr-0.5 to have 2px of space below/right, to match the 2px border of the node that's above/left of this node type div */}
+        <NodeTypeDiv className="flex h-6 items-center rounded-br rounded-tl pb-0.5 pr-0.5">
           <NodeIcon className="mx-1 size-3.5" />
           <NodeTypeSpan
             contentEditable={customizable}

--- a/src/web/topic/components/Node/EditableNode.tsx
+++ b/src/web/topic/components/Node/EditableNode.tsx
@@ -128,7 +128,7 @@ const EditableNodeBase = ({ node, className = "" }: Props) => {
               if (text && text !== nodeDecoration.title && text !== node.data.customType)
                 setCustomNodeType(node, text);
             }}
-            className="nopan pr-1 text-sm leading-none"
+            className="nopan pr-1 text-sm leading-normal"
           >
             {typeText}
           </NodeTypeSpan>

--- a/src/web/topic/components/Node/EditableNode.tsx
+++ b/src/web/topic/components/Node/EditableNode.tsx
@@ -91,15 +91,19 @@ const EditableNodeBase = ({ node, className = "" }: Props) => {
           [NodeTypeDiv.toString()]: {
             backgroundColor: color,
             // anti-aliasing between white node background and colored border/icon background creates a gray line - add colored shadow to hide this https://stackoverflow.com/a/40100710/8409296
-            boxShadow: `-1px -1px 0px 1px ${color}`,
+            // 0.5px spread instead of 1px because 1px creates a really thin shadow on the bottom/right, which can be seen
+            // more clearly e.g. when selecting a benefit node (black shadow against bright background)
+            boxShadow: `-1px -1px 0px 0.5px ${color}`,
           },
 
           [`&.selected ${NodeTypeDiv.toString()}`]: {
-            boxShadow: "-1px -1px 0px 1px black",
+            // Match the shadow size of not-selected nodes
+            boxShadow: `-1px -1px 0px 0.5px black`,
           },
 
           [`&.spotlight-secondary ${NodeTypeDiv.toString()}`]: {
-            boxShadow: `-1px -1px 0px 1px ${theme.palette.info.main}`,
+            // Match the shadow size of not-selected nodes
+            boxShadow: `-1px -1px 0px 0.5px ${theme.palette.info.main}`,
           },
         };
 


### PR DESCRIPTION
### Description of changes

- see commit messages

### Additional context

first commit attempts to better center-align the node label and node icon (note that FF already looked good and still seems to):

![image](https://github.com/user-attachments/assets/c3e720fc-2784-4d60-9e3d-e006c1ae1f81)

second commit attempts to make spacing more consistent around the node label and icon:

![image](https://github.com/user-attachments/assets/d7b8e394-a5a1-4558-8b89-9f28a01981df)

third commit removes the very thin shadow that sometimes would render on the bottom/right of node label:

![image](https://github.com/user-attachments/assets/fdd9bbb3-d720-4afb-89b8-2f084f6c6f79)
