### PR TITLE
feat: reorder quickviews

### DIFF
--- a/src/web/topic/components/TopicPane/QuickViewSection.tsx
+++ b/src/web/topic/components/TopicPane/QuickViewSection.tsx
@@ -1,4 +1,4 @@
-import { Add, Delete, Edit, Redo, Save, Undo, Visibility } from "@mui/icons-material";
+import { Add, Delete, Edit, Redo, Save, SwapVert, Undo, Visibility } from "@mui/icons-material";
 import {
   Divider,
   IconButton,
@@ -7,9 +7,11 @@ import {
   ListItemButton,
   ListItemIcon,
   ListItemText,
+  Menu,
 } from "@mui/material";
 import { useState } from "react";
 
+import { CloseOnClickMenuItem } from "@/web/common/components/ContextMenu/CloseOnClickMenuItem";
 import { useSessionUser } from "@/web/common/hooks";
 import { QuickViewForm } from "@/web/topic/components/TopicPane/QuickViewForm";
 import { useUserCanEditTopicData } from "@/web/topic/store/userHooks";
@@ -17,6 +19,7 @@ import {
   QuickView,
   createView,
   deleteView,
+  moveView,
   redo,
   saveView,
   selectView,
@@ -25,6 +28,114 @@ import {
   useQuickViews,
   useSelectedViewId,
 } from "@/web/view/quickViewStore/store";
+
+interface RowProps {
+  view: QuickView;
+  selected: boolean;
+  editable: boolean;
+  onEdit: () => void;
+}
+
+const QuickViewRow = ({ view, selected, editable, onEdit }: RowProps) => {
+  const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLElement | null>(null);
+
+  return (
+    <ListItem key={view.id}>
+      <ListItemButton
+        selected={selected}
+        onClick={() => selectView(view.id)}
+        sx={{ paddingY: 0, height: "40px" }} // icon buttons have padding, so this extra padding isn't necessary, and use a consistent height whether or not icon buttons are showing
+      >
+        <ListItemIcon>
+          {editable ? (
+            <>
+              <IconButton
+                color="inherit"
+                title="Reorder View"
+                aria-label="Reorder View"
+                onClick={(e) => {
+                  setMenuAnchorEl(e.currentTarget);
+                  e.stopPropagation(); // don't also trigger row select
+                }}
+              >
+                <SwapVert />
+              </IconButton>
+              <Menu
+                anchorEl={menuAnchorEl}
+                open={Boolean(menuAnchorEl)}
+                onClose={() => setMenuAnchorEl(null)}
+              >
+                <CloseOnClickMenuItem
+                  onClick={(e) => {
+                    moveView(view.id, "up");
+                    e.stopPropagation(); // don't also trigger row select
+                  }}
+                  closeMenu={() => setMenuAnchorEl(null)}
+                >
+                  Move up
+                </CloseOnClickMenuItem>
+                <CloseOnClickMenuItem
+                  onClick={(e) => {
+                    moveView(view.id, "down");
+                    e.stopPropagation(); // don't also trigger row select
+                  }}
+                  closeMenu={() => setMenuAnchorEl(null)}
+                >
+                  Move down
+                </CloseOnClickMenuItem>
+              </Menu>
+            </>
+          ) : (
+            <Visibility />
+          )}
+        </ListItemIcon>
+
+        <ListItemText primary={view.title} />
+
+        {editable && (
+          <>
+            <IconButton
+              color="inherit"
+              title="Edit View"
+              aria-label="Edit View"
+              onClick={(e) => {
+                onEdit();
+                e.stopPropagation(); // don't also trigger row select
+              }}
+            >
+              <Edit />
+            </IconButton>
+            <IconButton
+              color="inherit"
+              title="Overwrite View"
+              aria-label="Overwrite View"
+              // Assumes that the selected view is being displayed, so saving wouldn't do anything.
+              // Could be more accurate by checking if this index's view state deep equals the current view state... but that seems overkill performance-wise.
+              disabled={selected}
+              onClick={(e) => {
+                saveView(view.id);
+                e.stopPropagation(); // don't also trigger row select
+              }}
+            >
+              <Save />
+            </IconButton>
+            <IconButton
+              color="inherit"
+              title="Delete View"
+              aria-label="Delete View"
+              onClick={(e) => {
+                deleteView(view.id);
+                e.stopPropagation(); // don't also trigger row select
+              }}
+            >
+              <Delete />
+            </IconButton>
+          </>
+        )}
+      </ListItemButton>
+    </ListItem>
+  );
+};
 
 export const QuickViewSection = () => {
   const { sessionUser } = useSessionUser();
@@ -93,60 +204,13 @@ export const QuickViewSection = () => {
           </ListItem>
         )}
         {quickViews.map((view) => (
-          <ListItem key={view.id}>
-            <ListItemButton
-              selected={selectedViewId === view.id}
-              onClick={() => selectView(view.id)}
-              sx={{ paddingY: 0, height: "40px" }} // icon buttons have padding, so this extra padding isn't necessary, and use a consistent height whether or not icon buttons are showing
-            >
-              <ListItemIcon>
-                <Visibility />
-              </ListItemIcon>
-
-              <ListItemText primary={view.title} />
-
-              {userCanEditTopicData && (
-                <>
-                  <IconButton
-                    color="inherit"
-                    title="Edit View"
-                    aria-label="Edit View"
-                    onClick={(e) => {
-                      setEditingView(view);
-                      e.stopPropagation(); // don't also trigger row select
-                    }}
-                  >
-                    <Edit />
-                  </IconButton>
-                  <IconButton
-                    color="inherit"
-                    title="Overwrite View"
-                    aria-label="Overwrite View"
-                    // Assumes that the selected view is being displayed, so saving wouldn't do anything.
-                    // Could be more accurate by checking if this index's view state deep equals the current view state... but that seems overkill performance-wise.
-                    disabled={selectedViewId === view.id}
-                    onClick={(e) => {
-                      saveView(view.id);
-                      e.stopPropagation(); // don't also trigger row select
-                    }}
-                  >
-                    <Save />
-                  </IconButton>
-                  <IconButton
-                    color="inherit"
-                    title="Delete View"
-                    aria-label="Delete View"
-                    onClick={(e) => {
-                      deleteView(view.id);
-                      e.stopPropagation(); // don't also trigger row select
-                    }}
-                  >
-                    <Delete />
-                  </IconButton>
-                </>
-              )}
-            </ListItemButton>
-          </ListItem>
+          <QuickViewRow
+            key={view.id}
+            view={view}
+            selected={selectedViewId === view.id}
+            editable={userCanEditTopicData}
+            onEdit={() => setEditingView(view)}
+          />
         ))}
       </List>
 

--- a/src/web/view/quickViewStore/store.ts
+++ b/src/web/view/quickViewStore/store.ts
@@ -206,6 +206,33 @@ export const deleteView = (viewId: string) => {
   );
 };
 
+export const moveView = (viewId: string, direction: "up" | "down") => {
+  const views = useQuickViewStore
+    .getState()
+    .views.toSorted((view1, view2) => view1.order - view2.order);
+
+  const indexFrom = views.findIndex((view) => view.id === viewId);
+  if (indexFrom === -1) throw new Error(`No view with id ${viewId}`);
+  if (indexFrom === 0 && direction === "up") return;
+  if (indexFrom === views.length - 1 && direction === "down") return;
+
+  const viewsWithoutMoved = views.toSpliced(indexFrom, 1);
+  const reorderedViews = viewsWithoutMoved.toSpliced(
+    direction === "up" ? indexFrom - 1 : indexFrom + 1,
+    0,
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we found the index from `views`, we know it exists
+    views[indexFrom]!,
+  );
+
+  useQuickViewStore.setState(
+    {
+      views: reorderedViews.map((view, index) => ({ ...view, order: index })),
+    },
+    false,
+    "moveView",
+  );
+};
+
 /**
  * if deselecting, remove the view param, else set the view param to the view's title
  */


### PR DESCRIPTION
ideally would use something like pragmatic-drag-and-drop, but there's so much code for that, seemed not worth right now.

also considered dnd-kit, but that also seems like it isn't super well-maintained, and there was no example for dragging with keyboard.

Closes #422

### Description of changes

-

### Additional context

-
