### PR TITLE
fix: smoke test not selecting right element

### DIFF
--- a/e2e/.eslintrc.json
+++ b/e2e/.eslintrc.json
@@ -1,0 +1,103 @@
+{
+  // lean strict on linting, can reduce strictness if/when things get annoying
+  "extends": [
+    "next/core-web-vitals",
+    "eslint:recommended",
+    "plugin:import/recommended",
+    "prettier"
+  ],
+  "plugins": ["functional", "import"],
+  "overrides": [
+    // don't use ts checking for js files https://stackoverflow.com/a/64488475
+    {
+      "files": ["*.ts", "*.tsx"],
+      "extends": [
+        "plugin:@typescript-eslint/eslint-recommended",
+        "plugin:@typescript-eslint/strict-type-checked",
+        "plugin:@typescript-eslint/stylistic-type-checked"
+      ],
+      "plugins": ["@typescript-eslint"],
+      "parser": "@typescript-eslint/parser",
+      "parserOptions": {
+        "project": true
+      },
+      "rules": {
+        "@typescript-eslint/member-ordering": "error",
+        "@typescript-eslint/switch-exhaustiveness-check": "error",
+        "@typescript-eslint/no-confusing-void-expression": [
+          "error",
+          { "ignoreArrowShorthand": true }
+        ],
+        // annoying when wanting to overspecify different types that happen to be the same but could become different
+        "@typescript-eslint/no-duplicate-type-constituents": "off",
+        // annoying to have to dupe this with the js version
+        "@typescript-eslint/no-unused-vars": [
+          "error",
+          {
+            "args": "all",
+            "argsIgnorePattern": "^_",
+            "varsIgnorePattern": "^_"
+          }
+        ]
+      }
+    }
+  ],
+  "rules": {
+    "functional/functional-parameters": [
+      "error",
+      {
+        "enforceParameterCount": false
+      }
+    ],
+    "functional/immutable-data": ["error", { "ignoreIdentifierPattern": ["router"] }],
+    "functional/no-classes": "error",
+    "functional/no-let": "error",
+    "functional/no-loop-statements": "error",
+    "functional/no-this-expressions": "error",
+    // huh, this seems needed for resolving paths? https://stackoverflow.com/a/55280867/8409296
+    "import/resolver": {
+      "node": {
+        "extensions": [".js", ".jsx", ".ts", ".tsx"]
+      }
+    },
+    "import/order": [
+      "error",
+      {
+        "groups": [
+          "builtin", // Built-in imports (come from NodeJS native) go first
+          "external",
+          "internal",
+          ["sibling", "parent"], // <- Relative imports, the sibling and parent types they can be mingled together
+          "index",
+          "unknown"
+        ],
+        "newlines-between": "always",
+        "alphabetize": {
+          "order": "asc"
+        }
+      }
+    ],
+    "no-param-reassign": [
+      "error",
+      {
+        "props": true
+      }
+    ],
+    "no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_"
+      }
+    ],
+    "react/no-unescaped-entities": "off",
+    "sort-imports": [
+      "error",
+      {
+        "ignoreDeclarationSort": true, // don"t want to sort import lines, use eslint-plugin-import instead
+        "allowSeparatedGroups": true // separating imports by group seems more readable
+      }
+    ]
+  },
+  "root": true // use this eslint config instead of parents
+}

--- a/e2e/tests/regression.spec.ts
+++ b/e2e/tests/regression.spec.ts
@@ -6,6 +6,7 @@
  * noise on PRs, since that noise can be auto-committed without much issue.
  */
 
+import { getNode } from "@/tests/utils";
 import { expect, test } from "@playwright/test";
 
 test("can play around", async ({ page }) => {
@@ -27,7 +28,7 @@ test("can play around", async ({ page }) => {
   // confirm playground looks normal with some nodes, laid out, persisted after refresh
   await page.getByRole("link", { name: "Play Around" }).first().click();
   await page.getByLabel("Close Tour").click();
-  await page.getByRole("button", { name: "Problem new node" }).click();
+  await getNode(page, "Problem").click();
   await page.getByRole("button", { name: "Add new Solution" }).click();
   await page.reload();
   await page.getByLabel("Close Tour").click(); // make sure page is done reloading, and get the tour out of the screenshot so we can see the diagram

--- a/e2e/tests/smoke.spec.ts
+++ b/e2e/tests/smoke.spec.ts
@@ -9,6 +9,8 @@
 
 import { expect, test } from "@playwright/test";
 
+import { getNode } from "@/tests/utils";
+
 test("can play around", async ({ page }) => {
   // confirm can go to playground from home page
   await page.goto("/");
@@ -19,10 +21,10 @@ test("can play around", async ({ page }) => {
 
   // confirm nodes/edges can be added and persist after refresh
   await page.getByLabel("Close Tour").click();
-  await page.getByRole("button", { name: "Problem new node" }).click();
+  await getNode(page, "Problem").click();
   await page.getByRole("button", { name: "Add new Solution" }).click();
   await page.reload();
   await page.getByLabel("Close Tour").click(); // make sure page is done reloading, and get the tour out of the screenshot so we can see the diagram
-  await expect(page.getByRole("button", { name: "Problem new node" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "Solution new node" })).toHaveCount(2); // there'll be one solution node in the details pane, one in the diagram
+  await expect(getNode(page, "Problem")).toBeVisible();
+  await expect(getNode(page, "Solution")).toHaveCount(2); // there'll be one solution node in the details pane, one in the diagram
 });

--- a/e2e/tests/utils.ts
+++ b/e2e/tests/utils.ts
@@ -1,0 +1,10 @@
+import { Page } from "@playwright/test";
+
+export const getNode = (page: Page, nodeType: string) => {
+  return (
+    page
+      .getByRole("button", { name: nodeType })
+      // distinguish from Add Node buttons
+      .and(page.getByRole("button", { name: "new node" }))
+  );
+};

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -17,6 +17,9 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "paths": {
+      "@/*": ["./*"]
+    },
     "plugins": [
       {
         "name": "next"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,5 +26,5 @@
     ]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules", "docs-site", "mock-auth"]
+  "exclude": ["node_modules", "docs-site", "e2e", "mock-auth"]
 }


### PR DESCRIPTION
buttons now displaying on node caused "solution new node" not to find the node in the details pane.

added tsconfig and eslintrc so that absolute paths can work in e2e/.
