### PR TITLE
fix: banner's "read more" leads to error page

### DIFF
--- a/src/web/common/components/SiteBanner/SiteBanner.tsx
+++ b/src/web/common/components/SiteBanner/SiteBanner.tsx
@@ -26,7 +26,9 @@ export const SiteBanner = () => {
       onClose={() => hideBanner()}
     >
       🚀 Looking for an easy way to help out? Pilot test Ameliorate!{" "}
-      <Link href="https://ameliorate.app/docs/pilot-testing">Read more</Link>
+      <Link href="https://ameliorate.app/docs/pilot-testing" target="_blank">
+        Read more
+      </Link>
     </Alert>
   );
 };


### PR DESCRIPTION
### Description of changes

-

### Additional context

-
