### PR TITLE
feat: persist transpose state for CriteriaTable

### DIFF
--- a/src/web/topic/components/CriteriaTable/CriteriaTable.tsx
+++ b/src/web/topic/components/CriteriaTable/CriteriaTable.tsx
@@ -29,10 +29,7 @@ import { useUserCanEditTopicData } from "@/web/topic/store/userHooks";
 import { getConnectingEdge } from "@/web/topic/utils/edge";
 import { Edge, Node } from "@/web/topic/utils/graph";
 import { useGeneralFilter, useTableFilter } from "@/web/view/currentViewStore/filter";
-import {
-  setUseSolutionsForColumns,
-  useUseSolutionsForColumns,
-} from "@/web/view/currentViewStore/store";
+import { setTransposed, useTransposed } from "@/web/view/currentViewStore/store";
 import { applyScoreFilter } from "@/web/view/utils/generalFilter";
 import { getSelectedTradeoffNodes } from "@/web/view/utils/infoFilter";
 
@@ -187,7 +184,7 @@ const buildTableDefs = (
  *   b. subsequent rows turn into row objects (`rowData`) that know their row header details (for filtering)
  */
 export const CriteriaTable = () => {
-  const useSolutionsForColumns = useUseSolutionsForColumns();
+  const transposed = useTransposed();
 
   const { sessionUser } = useSessionUser();
   const userCanEditTopicData = useUserCanEditTopicData(sessionUser?.username);
@@ -227,14 +224,14 @@ export const CriteriaTable = () => {
   const tableData = buildTableCells(problemNode, filteredSolutions, filteredCriteria, edges);
   const [headerRow, ..._bodyRows] = tableData;
 
-  const transposedTableData = useSolutionsForColumns
+  const transposedTableData = transposed
     ? tableData
     : (headerRow.map((_, columnIndex) =>
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- assume that every row has same number of cells as header row
         tableData.map((row) => row[columnIndex]!),
       ) as typeof tableData);
 
-  const { rowData, columnData } = buildTableDefs(transposedTableData, useSolutionsForColumns);
+  const { rowData, columnData } = buildTableDefs(transposedTableData, transposed);
 
   const ToolBarActions = (table: MRT_TableInstance<RowData>) => {
     return (
@@ -264,7 +261,7 @@ export const CriteriaTable = () => {
             size="small"
             variant="contained"
             color="neutral"
-            onClick={() => setUseSolutionsForColumns(!useSolutionsForColumns)}
+            onClick={() => setTransposed(!transposed)}
           >
             <PivotTableChart />
           </Button>

--- a/src/web/topic/components/CriteriaTable/CriteriaTable.tsx
+++ b/src/web/topic/components/CriteriaTable/CriteriaTable.tsx
@@ -8,7 +8,7 @@ import {
   MRT_ToggleGlobalFilterButton,
   MaterialReactTable,
 } from "material-react-table";
-import React, { useState } from "react";
+import React from "react";
 
 import { errorWithData } from "@/common/errorHandling";
 import { useSessionUser } from "@/web/common/hooks";
@@ -29,6 +29,10 @@ import { useUserCanEditTopicData } from "@/web/topic/store/userHooks";
 import { getConnectingEdge } from "@/web/topic/utils/edge";
 import { Edge, Node } from "@/web/topic/utils/graph";
 import { useGeneralFilter, useTableFilter } from "@/web/view/currentViewStore/filter";
+import {
+  setUseSolutionsForColumns,
+  useUseSolutionsForColumns,
+} from "@/web/view/currentViewStore/store";
 import { applyScoreFilter } from "@/web/view/utils/generalFilter";
 import { getSelectedTradeoffNodes } from "@/web/view/utils/infoFilter";
 
@@ -183,7 +187,7 @@ const buildTableDefs = (
  *   b. subsequent rows turn into row objects (`rowData`) that know their row header details (for filtering)
  */
 export const CriteriaTable = () => {
-  const [useSolutionsForColumns, setUseSolutionsForColumns] = useState<boolean>(true);
+  const useSolutionsForColumns = useUseSolutionsForColumns();
 
   const { sessionUser } = useSessionUser();
   const userCanEditTopicData = useUserCanEditTopicData(sessionUser?.username);

--- a/src/web/view/currentViewStore/store.ts
+++ b/src/web/view/currentViewStore/store.ts
@@ -57,8 +57,10 @@ export interface ViewState {
    * unconditionally include edge labels in layout: https://github.com/eclipse/elk/issues/1092
    */
   avoidEdgeLabelOverlap: boolean;
-  useSolutionsForColumns: boolean;
   layoutThoroughness: number;
+
+  //table config
+  transposed: boolean;
 }
 
 export const initialViewState: ViewState = {
@@ -86,13 +88,14 @@ export const initialViewState: ViewState = {
 
   showImpliedEdges: false,
   showProblemCriterionSolutionEdges: true,
-  useSolutionsForColumns: true,
 
   forceNodesIntoLayers: true,
   layerNodeIslandsTogether: false,
   minimizeEdgeCrossings: false,
   avoidEdgeLabelOverlap: false,
   layoutThoroughness: 100, // by default, prefer keeping parents close to children over keeping node types together
+
+  transposed: true,
 };
 
 const persistedNameBase = "navigateStore";
@@ -134,8 +137,8 @@ export const useCanGoBackForward = () => {
   return [canGoBack, canGoForward];
 };
 
-export const useUseSolutionsForColumns = () => {
-  return useCurrentViewStore((state) => state.useSolutionsForColumns);
+export const useTransposed = () => {
+  return useCurrentViewStore((state) => state.transposed);
 };
 
 // actions
@@ -209,12 +212,8 @@ export const getView = () => {
   return useCurrentViewStore.getState();
 };
 
-export const setUseSolutionsForColumns = (value: boolean) => {
-  useCurrentViewStore.setState(
-    { useSolutionsForColumns: value },
-    false,
-    "setUseSolutionsForColumns",
-  );
+export const setTransposed = (value: boolean) => {
+  useCurrentViewStore.setState({ transposed: value }, false, "setUseSolutionsForColumns");
 };
 
 // misc

--- a/src/web/view/currentViewStore/store.ts
+++ b/src/web/view/currentViewStore/store.ts
@@ -57,6 +57,7 @@ export interface ViewState {
    * unconditionally include edge labels in layout: https://github.com/eclipse/elk/issues/1092
    */
   avoidEdgeLabelOverlap: boolean;
+  useSolutionsForColumns: boolean;
   layoutThoroughness: number;
 }
 
@@ -85,6 +86,7 @@ export const initialViewState: ViewState = {
 
   showImpliedEdges: false,
   showProblemCriterionSolutionEdges: true,
+  useSolutionsForColumns: true,
 
   forceNodesIntoLayers: true,
   layerNodeIslandsTogether: false,
@@ -130,6 +132,10 @@ export const useCanGoBackForward = () => {
   const canGoBack = temporalStore.pastStates.length > 0;
   const canGoForward = temporalStore.futureStates.length > 0;
   return [canGoBack, canGoForward];
+};
+
+export const useUseSolutionsForColumns = () => {
+  return useCurrentViewStore((state) => state.useSolutionsForColumns);
 };
 
 // actions
@@ -201,6 +207,14 @@ export const loadView = async (persistId: string) => {
 // util actions
 export const getView = () => {
   return useCurrentViewStore.getState();
+};
+
+export const setUseSolutionsForColumns = (value: boolean) => {
+  useCurrentViewStore.setState(
+    { useSolutionsForColumns: value },
+    false,
+    "setUseSolutionsForColumns",
+  );
 };
 
 // misc


### PR DESCRIPTION
Closes #503

This PR addresses the issue of the transpose state (`useSolutionsForColumns`) in the CriteriaTable not persisting across page refreshes. The following changes have been made:

**Added `useSolutionsForColumns` to `ViewState`**

- Updated the `ViewState` interface to include`useSolutionsForColumns`
- Set the default value for useSolutionsForColumns in `initialViewState`.

**Created a Hook and Setter:**

- Added `useUseSolutionsForColumns` to retrieve the current state of `useSolutionsForColumns`.
- Added `setUseSolutionsForColumns` to update the state.

**Integrated with CriteriaTable:**

- Updated the CriteriaTable component to use the `useUseSolutionsForColumns` hook and `setUseSolutionsForColumns` setter.
- Ensured the transpose state persists across page refreshes and integrates with Quick Views.
