### PR TITLE
touchup: allow claims to have two parents

### DIFF
--- a/src/web/topic/utils/edge.ts
+++ b/src/web/topic/utils/edge.ts
@@ -1,5 +1,5 @@
 import { RelationName, justificationRelationNames } from "@/common/edge";
-import { NodeType, justificationNodeTypes, nodeTypes, researchNodeTypes } from "@/common/node";
+import { NodeType, nodeTypes, researchNodeTypes } from "@/common/node";
 import { Edge, Graph, Node, RelationDirection, findNodeOrThrow } from "@/web/topic/utils/graph";
 import { hasJustification } from "@/web/topic/utils/justification";
 import { children, components, parents } from "@/web/topic/utils/node";
@@ -255,16 +255,6 @@ export const canCreateEdge = (topicGraph: Graph, parent: Node, child: Node) => {
 
   if (existingEdge) {
     console.log("cannot connect nodes: tried dragging between already-connected nodes");
-    return false;
-  }
-
-  const secondParentForJustification =
-    justificationNodeTypes.includes(child.type) &&
-    topicGraph.edges.find((edge) => edge.target === child.id);
-  if (secondParentForJustification) {
-    console.log(
-      "cannot connect nodes: justifications are in a tree so can't have multiple parents",
-    );
     return false;
   }
 


### PR DESCRIPTION
it seems like claims are better _not_ as standalone, and written in the context of their parents, but it seems ok to allow claims to have multiple parents, mainly for experimentation.

see context in discord thread https://discord.com/channels/1057707973482401892/1366783664771305492/1367138329547771905

### Description of changes

-

### Additional context

-
