### PR TITLE
touchup: use ellipses for quick view titles

### DIFF
--- a/src/web/topic/components/TopicPane/QuickViewSection.tsx
+++ b/src/web/topic/components/TopicPane/QuickViewSection.tsx
@@ -90,7 +90,7 @@ const QuickViewRow = ({ view, selected, editable, onEdit }: RowProps) => {
           )}
         </ListItemIcon>
 
-        <ListItemText primary={view.title} />
+        <ListItemText primary={view.title} className="[&>span]:truncate" />
 
         {editable && (
           <>


### PR DESCRIPTION
Closes #723

### Description of changes

- Long quick view titles now use ellipses instead of overflowing behind the buttons

    Before:
![before](https://github.com/user-attachments/assets/fc7114a3-da7a-40a4-9204-53b8a0f8b2a7)

    After:
![after](https://github.com/user-attachments/assets/d3ab1cc6-d732-4b17-bae0-470edf9c9218)

- This change was implemented by adding `className="[&>span]:truncate"` to the `<ListItemText>` displaying the quick view title in the `QuickViewSection.tsx` file

### Additional context

- See the issue comments for a discussion of the change.
