### PR TITLE
feat: add disagreement scores

### DIFF
--- a/src/web/common/components/ContextMenu/AddNodeMenuItem.tsx
+++ b/src/web/common/components/ContextMenu/AddNodeMenuItem.tsx
@@ -1,8 +1,8 @@
 import { useTheme } from "@mui/material/styles";
-import { NestedMenuItem } from "mui-nested-menu";
 
 import { breakdownNodeTypes, researchNodeTypes } from "@/common/node";
 import { ContextMenuItem } from "@/web/common/components/ContextMenu/CloseOnClickMenuItem";
+import { NestedMenuItem } from "@/web/common/components/Menu/NestedMenuItem";
 import { useSessionUser } from "@/web/common/hooks";
 import { addNodeWithoutParent } from "@/web/topic/diagramStore/createDeleteActions";
 import { useUserCanEditTopicData } from "@/web/topic/topicStore/store";
@@ -30,12 +30,7 @@ export const AddNodeMenuItem = ({ parentMenuOpen }: Props) => {
 
   return (
     <>
-      <NestedMenuItem
-        label="Add node"
-        parentMenuOpen={parentMenuOpen}
-        // match default mui menu padding and size
-        className="px-[16px] [&_p]:px-0 [&_p]:text-sm"
-      >
+      <NestedMenuItem label="Add node" parentMenuOpen={parentMenuOpen}>
         {shownNodeTypes.map((type) => {
           const { NodeIcon, title } = nodeDecorations[type];
           return (

--- a/src/web/common/components/Menu/NestedMenuItem.tsx
+++ b/src/web/common/components/Menu/NestedMenuItem.tsx
@@ -1,0 +1,15 @@
+import { NestedMenuItem as MuiNestedMenuItem, NestedMenuItemProps } from "mui-nested-menu";
+
+export const NestedMenuItem = ({ className, children, ...restProps }: NestedMenuItemProps) => {
+  return (
+    <MuiNestedMenuItem
+      {...restProps}
+      className={
+        // match default mui menu padding and size
+        "px-[16px] [&_p]:px-0 [&_p]:text-sm" + (className ? ` ${className}` : "")
+      }
+    >
+      {children}
+    </MuiNestedMenuItem>
+  );
+};

--- a/src/web/topic/components/CriteriaTable/CriteriaTable.tsx
+++ b/src/web/topic/components/CriteriaTable/CriteriaTable.tsx
@@ -196,7 +196,7 @@ export const CriteriaTable = () => {
   const problemNode = useDefaultNode("problem", tableFilter.centralProblemId);
   const nodeChildren = useNodeChildren(problemNode?.id);
   const edges = useCriterionSolutionEdges(problemNode?.id);
-  const scores = useDisplayScores(nodeChildren.map((node) => node.id));
+  const { scoresByGraphPartId: scores } = useDisplayScores(nodeChildren.map((node) => node.id));
 
   if (!problemNode)
     return (

--- a/src/web/topic/components/Indicator/FoundResearchIndicator.tsx
+++ b/src/web/topic/components/Indicator/FoundResearchIndicator.tsx
@@ -6,8 +6,7 @@ import { emitter } from "@/web/common/event";
 import { ContentIndicator } from "@/web/topic/components/Indicator/Base/ContentIndicator";
 import { useResearchNodes } from "@/web/topic/diagramStore/graphPartHooks";
 import { useDisplayScores } from "@/web/topic/diagramStore/scoreHooks";
-import { Score } from "@/web/topic/utils/graph";
-import { getNumericScore, scoreColors } from "@/web/topic/utils/score";
+import { getHighestScore, getScoreColor } from "@/web/topic/utils/score";
 import { setSelected } from "@/web/view/selectedPartStore";
 
 interface Props {
@@ -18,7 +17,9 @@ interface Props {
 export const FoundResearchIndicator = ({ graphPartId, partColor }: Props) => {
   const { facts, sources } = useResearchNodes(graphPartId);
   const foundResearchNodes = facts.concat(sources);
-  const scoresByGraphPart = useDisplayScores(foundResearchNodes.map((node) => node.id));
+  const { scoresByGraphPartId, scoreMeaning } = useDisplayScores(
+    foundResearchNodes.map((node) => node.id),
+  );
 
   const onClick = useCallback(() => {
     setSelected(graphPartId);
@@ -27,11 +28,9 @@ export const FoundResearchIndicator = ({ graphPartId, partColor }: Props) => {
 
   if (foundResearchNodes.length === 0) return <></>;
 
-  const nodeScores = Object.values(scoresByGraphPart).map((score) => getNumericScore(score));
-  const highestScore = Math.max(...nodeScores);
-
+  const highestScore = getHighestScore(Object.values(scoresByGraphPartId));
   // could just color if score is > 5, to avoid bringing attention to unimportant things, but it seems nice to have the visual indication of a low score too
-  const scoreColor = scoreColors[highestScore.toString() as Score] as ButtonProps["color"];
+  const scoreColor = getScoreColor(highestScore, scoreMeaning) as ButtonProps["color"];
   const color = scoreColor ?? partColor;
 
   if (facts.length > 0 && sources.length > 0)

--- a/src/web/topic/components/Indicator/JustificationIndicator.tsx
+++ b/src/web/topic/components/Indicator/JustificationIndicator.tsx
@@ -6,8 +6,7 @@ import { emitter } from "@/web/common/event";
 import { ContentIndicator } from "@/web/topic/components/Indicator/Base/ContentIndicator";
 import { useTopLevelJustification } from "@/web/topic/diagramStore/graphPartHooks";
 import { useDisplayScores } from "@/web/topic/diagramStore/scoreHooks";
-import { Score } from "@/web/topic/utils/graph";
-import { getNumericScore, scoreColors } from "@/web/topic/utils/score";
+import { getHighestScore, getScoreColor } from "@/web/topic/utils/score";
 import { setSelected } from "@/web/view/selectedPartStore";
 
 interface Props {
@@ -18,7 +17,9 @@ interface Props {
 export const JustificationIndicator = ({ graphPartId, partColor }: Props) => {
   const { supports, critiques } = useTopLevelJustification(graphPartId);
   const justificationNodes = supports.concat(critiques);
-  const scoresByGraphPart = useDisplayScores(justificationNodes.map((node) => node.id));
+  const { scoresByGraphPartId, scoreMeaning } = useDisplayScores(
+    justificationNodes.map((node) => node.id),
+  );
 
   const onClick = useCallback(() => {
     setSelected(graphPartId);
@@ -27,11 +28,9 @@ export const JustificationIndicator = ({ graphPartId, partColor }: Props) => {
 
   if (justificationNodes.length === 0) return <></>;
 
-  const nodeScores = Object.values(scoresByGraphPart).map((score) => getNumericScore(score));
-  const highestScore = Math.max(...nodeScores);
-
+  const highestScore = getHighestScore(Object.values(scoresByGraphPartId));
   // could just color if score is > 5, to avoid bringing attention to unimportant things, but it seems nice to have the visual indication of a low score too
-  const scoreColor = scoreColors[highestScore.toString() as Score] as ButtonProps["color"];
+  const scoreColor = getScoreColor(highestScore, scoreMeaning) as ButtonProps["color"];
 
   if (supports.length > 0 && critiques.length > 0)
     return (

--- a/src/web/topic/components/Indicator/QuestionIndicator.tsx
+++ b/src/web/topic/components/Indicator/QuestionIndicator.tsx
@@ -6,8 +6,7 @@ import { emitter } from "@/web/common/event";
 import { ContentIndicator } from "@/web/topic/components/Indicator/Base/ContentIndicator";
 import { useResearchNodes } from "@/web/topic/diagramStore/graphPartHooks";
 import { useDisplayScores } from "@/web/topic/diagramStore/scoreHooks";
-import { Score } from "@/web/topic/utils/graph";
-import { getNumericScore, scoreColors } from "@/web/topic/utils/score";
+import { getHighestScore, getScoreColor } from "@/web/topic/utils/score";
 import { setSelected } from "@/web/view/selectedPartStore";
 
 interface Props {
@@ -17,7 +16,9 @@ interface Props {
 
 export const QuestionIndicator = ({ graphPartId, partColor }: Props) => {
   const { questions } = useResearchNodes(graphPartId);
-  const scoresByGraphPart = useDisplayScores(questions.map((question) => question.id));
+  const { scoresByGraphPartId, scoreMeaning } = useDisplayScores(
+    questions.map((question) => question.id),
+  );
 
   const onClick = useCallback(() => {
     setSelected(graphPartId);
@@ -26,11 +27,9 @@ export const QuestionIndicator = ({ graphPartId, partColor }: Props) => {
 
   if (questions.length === 0) return <></>;
 
-  const questionScores = Object.values(scoresByGraphPart).map((score) => getNumericScore(score));
-  const highestScore = Math.max(...questionScores);
-
+  const highestScore = getHighestScore(Object.values(scoresByGraphPartId));
   // could just color if score is > 5, to avoid bringing attention to unimportant things, but it seems nice to have the visual indication of a low score too
-  const scoreColor = scoreColors[highestScore.toString() as Score] as ButtonProps["color"];
+  const scoreColor = getScoreColor(highestScore, scoreMeaning) as ButtonProps["color"];
 
   const Icon = QuestionMark;
 

--- a/src/web/topic/components/Score/Score.tsx
+++ b/src/web/topic/components/Score/Score.tsx
@@ -14,7 +14,7 @@ import { useFlowZoom } from "@/web/topic/hooks/flowHooks";
 import { useOnPlayground } from "@/web/topic/topicStore/store";
 import { userCanEditScores } from "@/web/topic/utils/score";
 import { useReadonlyMode } from "@/web/view/actionConfigStore";
-import { usePerspectives } from "@/web/view/perspectiveStore";
+import { useAggregationMode, usePerspectives } from "@/web/view/perspectiveStore";
 import { useShowScores } from "@/web/view/userConfigStore";
 
 const circleDiameter = 6 * buttonDiameterRem; // no collisions for fitting 10 elements
@@ -36,6 +36,7 @@ export const Score = ({ graphPartId }: ScoreProps) => {
 
   const myUsername = onPlayground ? playgroundUsername : sessionUser?.username;
   const perspectives = usePerspectives();
+  const aggregationMode = useAggregationMode();
   const canEdit = userCanEditScores(myUsername, perspectives, readonlyMode);
 
   const [selected, setSelected] = useState(false);
@@ -75,7 +76,13 @@ export const Score = ({ graphPartId }: ScoreProps) => {
   const showScoreClasses = showScore ? "" : " hidden";
 
   if (!isInteractive) {
-    return <ScoreButton userScores={userScores} className={showScoreClasses} />;
+    return (
+      <ScoreButton
+        userScores={userScores}
+        aggregationMode={aggregationMode}
+        className={showScoreClasses}
+      />
+    );
   }
 
   return (
@@ -88,6 +95,7 @@ export const Score = ({ graphPartId }: ScoreProps) => {
         onMouseEnter={() => setHoverDelayHandler(setTimeout(() => setHovering(true), 100))}
         onMouseLeave={() => clearTimeout(hoverDelayHandler)}
         userScores={userScores}
+        aggregationMode={aggregationMode}
         className={showScoreClasses}
       />
 
@@ -141,6 +149,7 @@ export const Score = ({ graphPartId }: ScoreProps) => {
         <ScoreButton
           onClick={() => setSelected(!selected)}
           userScores={userScores}
+          aggregationMode={aggregationMode}
           zoomRatio={zoomRatio}
         />
       </ScorePopper>

--- a/src/web/topic/components/Score/ScoreButton.tsx
+++ b/src/web/topic/components/Score/ScoreButton.tsx
@@ -5,7 +5,12 @@ import { StyledButton } from "@/web/topic/components/Score/ScoreButton.styles";
 import { ScoreCompare } from "@/web/topic/components/Score/ScoreCompare";
 import { type Score as ScoreData } from "@/web/topic/utils/graph";
 import { indicatorLengthRem } from "@/web/topic/utils/node";
-import { getAverageScore, scoreColors } from "@/web/topic/utils/score";
+import {
+  AggregationMode,
+  getDisplayScore,
+  getScoreColor,
+  getScoreMeaning,
+} from "@/web/topic/utils/score";
 
 export const buttonDiameterRem = indicatorLengthRem; //rem
 
@@ -16,6 +21,7 @@ interface ScoreButtonProps {
   onMouseLeave?: () => void;
   zoomRatio?: number;
   userScores: Record<string, ScoreData>;
+  aggregationMode: AggregationMode;
   className?: string;
 }
 
@@ -26,12 +32,18 @@ export const ScoreButton = ({
   onMouseLeave,
   zoomRatio = 1,
   userScores,
+  aggregationMode,
   className = "",
 }: ScoreButtonProps) => {
-  const isComparing = Object.keys(userScores).length > 1;
+  const numPerspectives = Object.keys(userScores).length;
+  const aggregating = numPerspectives > 1;
+  // when showing the average, seeing a small score distribution via pie seems like nice context.
+  // when showing disagreement, the color relevant to the disagreement score seems more useful.
+  const showComparisonPie = aggregating && aggregationMode === "average";
+  const scoreMeaning = getScoreMeaning(numPerspectives, aggregationMode);
 
-  const buttonScore = getAverageScore(Object.values(userScores));
-  const scoreColor = scoreColors[buttonScore] as ButtonProps["color"]; // not sure how to type this without type assertion, while still being able to access palette with it
+  const buttonScore = getDisplayScore(Object.values(userScores), aggregationMode);
+  const scoreColor = getScoreColor(buttonScore, scoreMeaning) as ButtonProps["color"]; // not sure how to type this without type assertion, while still being able to access palette with it
 
   return (
     <>
@@ -46,12 +58,12 @@ export const ScoreButton = ({
         zoomRatio={zoomRatio}
         className={
           "shadow-none border border-solid border-neutral-main" +
-          ` ${isComparing ? "pointer-events-none z-0 bg-transparent" : ""}` +
+          ` ${showComparisonPie ? "pointer-events-none z-0 bg-transparent" : ""}` +
           ` ${onClick ? "" : "pointer-events-none"}` +
           ` ${className}`
         }
       >
-        {isComparing && (
+        {showComparisonPie && (
           <div
             // behind the button so the score shows in front of the pie
             className="absolute z-[-1] size-full"

--- a/src/web/topic/components/Score/ScoreCompare.tsx
+++ b/src/web/topic/components/Score/ScoreCompare.tsx
@@ -7,7 +7,7 @@ import { Data } from "react-minimal-pie-chart/types/commonTypes";
 
 import { CustomDataEntry, PieChart } from "@/web/topic/components/Score/PieChart";
 import { Score } from "@/web/topic/utils/graph";
-import { scoreColors } from "@/web/topic/utils/score";
+import { getScoreColor } from "@/web/topic/utils/score";
 
 interface Props {
   userScores: Record<string, Score>;
@@ -27,7 +27,7 @@ export const ScoreCompare = ({ userScores, type = "regular" }: Props) => {
   );
 
   const data: Data<CustomDataEntry> = Object.entries(scoreUsers).map(([score, usernames]) => {
-    const scoreColor = scoreColors[score as Score]; // not sure how to ensure Object.entries remembers score type
+    const scoreColor = getScoreColor(score as Score, "importance"); // not sure how to ensure Object.entries remembers score type
     const paletteColor = theme.palette[scoreColor] as PaletteColor; // not sure how to guarantee this type, since palette has non-PaletteColor keys
 
     return {

--- a/src/web/topic/components/Score/ScoreSelect.tsx
+++ b/src/web/topic/components/Score/ScoreSelect.tsx
@@ -5,7 +5,7 @@ import { Data } from "react-minimal-pie-chart/types/commonTypes";
 import { CustomDataEntry, PieChart } from "@/web/topic/components/Score/PieChart";
 import { setScore } from "@/web/topic/diagramStore/actions";
 import { Score, possibleScores } from "@/web/topic/utils/graph";
-import { scoreColors } from "@/web/topic/utils/score";
+import { getScoreColor } from "@/web/topic/utils/score";
 
 interface Props {
   username: string;
@@ -17,7 +17,7 @@ export const ScoreSelect = ({ username, graphPartId, onSelect }: Props) => {
   const theme = useTheme();
 
   const data: Data<CustomDataEntry> = possibleScores.map((score) => {
-    const scoreColor = scoreColors[score];
+    const scoreColor = getScoreColor(score, "importance");
     const paletteColor = theme.palette[scoreColor] as PaletteColor; // not sure how to guarantee this type, since palette has non-PaletteColor keys
 
     return {

--- a/src/web/topic/components/TopicWorkspace/ContentFooter.tsx
+++ b/src/web/topic/components/TopicWorkspace/ContentFooter.tsx
@@ -1,9 +1,11 @@
 import {
+  AlignVerticalCenter,
   ArrowDropDown,
   Build,
   Delete,
   EditOff,
   FiberManualRecord,
+  FormatLineSpacing,
   Group,
   Highlight,
   Looks6,
@@ -20,12 +22,16 @@ import {
   ListItemIcon,
   ListItemText,
   MenuItem,
+  Radio,
+  RadioGroup,
   Switch,
   ToggleButton,
 } from "@mui/material";
-import { Dispatch, SetStateAction, useState } from "react";
+import { startCase } from "lodash";
+import { Dispatch, ReactNode, SetStateAction, useState } from "react";
 
 import { Menu } from "@/web/common/components/Menu/Menu";
+import { NestedMenuItem } from "@/web/common/components/Menu/NestedMenuItem";
 import { useSessionUser } from "@/web/common/hooks";
 import { HelpMenu } from "@/web/topic/components/TopicWorkspace/HelpMenu";
 import { MoreActionsDrawer } from "@/web/topic/components/TopicWorkspace/MoreActionsDrawer";
@@ -34,6 +40,7 @@ import { deleteGraphPart } from "@/web/topic/diagramStore/createDeleteActions";
 import { useIsTableEdge } from "@/web/topic/diagramStore/edgeHooks";
 import { useTopic, useUserCanEditTopicData } from "@/web/topic/topicStore/store";
 import { hotkeys } from "@/web/topic/utils/hotkeys";
+import { AggregationMode, aggregationModes } from "@/web/topic/utils/score";
 import {
   toggleFlashlightMode,
   toggleReadonlyMode,
@@ -44,6 +51,8 @@ import { Perspectives } from "@/web/view/components/Perspectives/Perspectives";
 import {
   comparePerspectives,
   resetPerspectives,
+  setAggregationMode,
+  useAggregationMode,
   useIsComparingPerspectives,
 } from "@/web/view/perspectiveStore";
 import { useSelectedGraphPart } from "@/web/view/selectedPartStore";
@@ -61,12 +70,19 @@ import {
   useShowViewIndicators,
 } from "@/web/view/userConfigStore";
 
+const aggregationModeIcons: Record<AggregationMode, ReactNode> = {
+  average: <AlignVerticalCenter />,
+  disagreement: <FormatLineSpacing />,
+};
+
 interface PerspectivesMenuProps {
   anchorEl: HTMLElement | null;
   setAnchorEl: Dispatch<SetStateAction<HTMLElement | null>>;
 }
 
 const PerspectivesMenu = ({ anchorEl, setAnchorEl }: PerspectivesMenuProps) => {
+  const aggregationMode = useAggregationMode();
+
   const menuOpen = Boolean(anchorEl);
   if (!menuOpen) return;
 
@@ -79,6 +95,20 @@ const PerspectivesMenu = ({ anchorEl, setAnchorEl }: PerspectivesMenuProps) => {
       // match the ~300px width of drawer
       className="w-[18.75rem] px-2"
     >
+      <NestedMenuItem label="Aggregation mode" parentMenuOpen={menuOpen} className="mb-2">
+        <RadioGroup name="aggregation mode">
+          {aggregationModes.map((mode) => {
+            return (
+              <MenuItem key={mode} onClick={() => setAggregationMode(mode)}>
+                <ListItemIcon>{aggregationModeIcons[mode]}</ListItemIcon>
+                <ListItemText primary={startCase(mode)} />
+                <Radio checked={aggregationMode === mode} value={mode} name="aggregation mode" />
+              </MenuItem>
+            );
+          })}
+        </RadioGroup>
+      </NestedMenuItem>
+
       <Perspectives />
     </Menu>
   );

--- a/src/web/topic/diagramStore/scoreGetters.ts
+++ b/src/web/topic/diagramStore/scoreGetters.ts
@@ -2,12 +2,13 @@ import get from "lodash/get";
 
 import { UserScores } from "@/web/topic/diagramStore/store";
 import { Score } from "@/web/topic/utils/graph";
-import { getAverageScore } from "@/web/topic/utils/score";
+import { AggregationMode, getDisplayScore } from "@/web/topic/utils/score";
 
 export const getDisplayScoresByGraphPartId = (
   graphPartIds: string[],
   perspectives: string[],
   userScores: UserScores,
+  aggregationMode: AggregationMode,
 ): Record<string, Score> => {
   const perspectiveScoresByGraphPart = getPerspectiveScoresByGraphPart(
     graphPartIds,
@@ -15,10 +16,11 @@ export const getDisplayScoresByGraphPartId = (
     userScores,
   );
 
-  const averagedScoreWithGraphPart = Object.entries(perspectiveScoresByGraphPart).map(
-    ([graphPartId, scores]) => [graphPartId, getAverageScore(scores)] as [string, Score],
+  const displayScoresWithGraphParts = Object.entries(perspectiveScoresByGraphPart).map(
+    ([graphPartId, scores]) =>
+      [graphPartId, getDisplayScore(scores, aggregationMode)] as [string, Score],
   );
-  return Object.fromEntries(averagedScoreWithGraphPart);
+  return Object.fromEntries(displayScoresWithGraphParts);
 };
 
 const getPerspectiveScoresByGraphPart = (

--- a/src/web/topic/diagramStore/scoreHooks.ts
+++ b/src/web/topic/diagramStore/scoreHooks.ts
@@ -8,14 +8,26 @@ import { getDisplayScoresByGraphPartId } from "@/web/topic/diagramStore/scoreGet
 import { useDiagramStore } from "@/web/topic/diagramStore/store";
 import { Node, Score } from "@/web/topic/utils/graph";
 import { children, edges } from "@/web/topic/utils/node";
-import { getNumericScore } from "@/web/topic/utils/score";
-import { usePerspectives } from "@/web/view/perspectiveStore";
+import { ScoreMeaning, getNumericScore, getScoreMeaning } from "@/web/topic/utils/score";
+import { useAggregationMode, usePerspectives } from "@/web/view/perspectiveStore";
 
-export const useDisplayScores = (graphPartIds: string[]): Record<string, Score> => {
+export const useDisplayScores = (
+  graphPartIds: string[],
+): { scoresByGraphPartId: Record<string, Score>; scoreMeaning: ScoreMeaning } => {
   const perspectives = usePerspectives();
+  const aggregationMode = useAggregationMode();
+  const scoreMeaning = getScoreMeaning(perspectives.length, aggregationMode);
 
   return useDiagramStore(
-    (state) => getDisplayScoresByGraphPartId(graphPartIds, perspectives, state.userScores),
+    (state) => ({
+      scoresByGraphPartId: getDisplayScoresByGraphPartId(
+        graphPartIds,
+        perspectives,
+        state.userScores,
+        aggregationMode,
+      ),
+      scoreMeaning,
+    }),
     shallow,
   );
 };
@@ -53,7 +65,7 @@ export const useSolutionTotal = (solution: Node, problem: Node) => {
   });
 
   const graphPartIds = criteriaSolutionEdges.flatMap((edge) => [edge.id, edge.source]);
-  const scores = useDisplayScores(graphPartIds);
+  const { scoresByGraphPartId: scores } = useDisplayScores(graphPartIds);
 
   return sum(
     criteriaSolutionEdges.map((edge) => {

--- a/src/web/topic/diagramStore/store.ts
+++ b/src/web/topic/diagramStore/store.ts
@@ -22,7 +22,7 @@ import {
   useShowImpliedEdges,
   useShowProblemCriterionSolutionEdges,
 } from "@/web/view/currentViewStore/filter";
-import { usePerspectives } from "@/web/view/perspectiveStore";
+import { useAggregationMode, usePerspectives } from "@/web/view/perspectiveStore";
 import { applyNodeTypeFilter, applyScoreFilter } from "@/web/view/utils/generalFilter";
 import { applyInfoFilter } from "@/web/view/utils/infoFilter";
 import {
@@ -79,6 +79,7 @@ export const useDiagram = (): Diagram => {
   const showImpliedEdges = useShowImpliedEdges();
   const showProblemCriterionSolutionEdges = useShowProblemCriterionSolutionEdges();
   const perspectives = usePerspectives();
+  const aggregationMode = useAggregationMode();
 
   return useDiagramStore((state) => {
     const topicGraph = { nodes: state.nodes, edges: state.edges };
@@ -92,7 +93,12 @@ export const useDiagram = (): Diagram => {
 
     // don't filter edges because hard to prevent awkwardness when edge doesn't pass filter and suddenly nodes are scattered
     const partIdsForScores = state.nodes.map((part) => part.id);
-    const scores = getDisplayScoresByGraphPartId(partIdsForScores, perspectives, state.userScores);
+    const scores = getDisplayScoresByGraphPartId(
+      partIdsForScores,
+      perspectives,
+      state.userScores,
+      aggregationMode,
+    );
     const nodesAfterScoreFilter = applyScoreFilter(nodesAfterTypeFilter, generalFilter, scores);
 
     const nodesToShow = state.nodes.filter((node) => generalFilter.nodesToShow.includes(node.id));

--- a/src/web/view/perspectiveStore.ts
+++ b/src/web/view/perspectiveStore.ts
@@ -1,15 +1,20 @@
 import { create } from "zustand";
 
 import { getScoringUsernames } from "@/web/topic/diagramStore/utilActions";
+import { AggregationMode } from "@/web/topic/utils/score";
 
 interface PerspectiveStoreState {
   myPerspective: string;
   perspectives: string[];
+
+  aggregationMode: AggregationMode;
 }
 
 const initialState: PerspectiveStoreState = {
   myPerspective: "",
   perspectives: [],
+
+  aggregationMode: "average",
 };
 
 const usePerspectiveStore = create<PerspectiveStoreState>()(() => initialState);
@@ -27,6 +32,10 @@ export const useIsComparingPerspectives = () => {
   });
 };
 
+export const useAggregationMode = () => {
+  return usePerspectiveStore((state) => state.aggregationMode);
+};
+
 // actions
 export const setInitialPerspective = (perspective: string) => {
   usePerspectiveStore.setState({ myPerspective: perspective, perspectives: [perspective] });
@@ -34,6 +43,10 @@ export const setInitialPerspective = (perspective: string) => {
 
 export const setPerspectives = (perspectives: string[]) => {
   usePerspectiveStore.setState({ perspectives });
+};
+
+export const setAggregationMode = (aggregationMode: AggregationMode) => {
+  usePerspectiveStore.setState({ aggregationMode });
 };
 
 export const resetPerspectives = () => {


### PR DESCRIPTION
includes:
- add aggregation modes
- choose score colors by score meaning
- extract custom NestedMenuItem for consistent styling

considered using H/M/L instead of numbers for disagreement, so that they stand out clearly from regular scores, but those can't be trivially used with solution totals, so it seemed better to be consistent with using the same score numbers. potentially the score shape can distinguish disagreement in the future.

Closes #64

### Description of changes

- see commit message

### Additional context

-
