### PR TITLE
fix: can send empty comment

### DIFF
--- a/src/web/comment/components/Draft.tsx
+++ b/src/web/comment/components/Draft.tsx
@@ -40,6 +40,7 @@ export const Draft = ({
     deleteDraft(parentId, parentType, commentId);
     // eslint-disable-next-line functional/immutable-data
     if (inputRef.current) inputRef.current.value = "";
+    setDraftHasText(false);
     setShowActionButtons(false);
     if (onDone) onDone();
   };


### PR DESCRIPTION
to reproduce:
1. type text into a new comment draft and press cancel or send
2. focus on the new draft input again
3. observe that the send button is not disabled

### Description of changes

-

### Additional context

-
