### PR TITLE
fix: details opens every time node is selected

### DIFF
--- a/src/web/topic/components/TopicPane/TopicPane.tsx
+++ b/src/web/topic/components/TopicPane/TopicPane.tsx
@@ -127,7 +127,7 @@ const TopicPaneBase = ({ anchor, tabs }: Props) => {
     });
 
     const unbindSelectedPart = emitter.on("partSelected", (partId) => {
-      if (partId) setTabs("Details"); // convenient to show details when clicking a node, but don't open the pane if it's not open, because that can be jarring
+      if (partId) setSelectedTab("Details"); // convenient to show details when clicking a node, but don't open the pane if it's not open, because that can be jarring
     });
 
     return () => {


### PR DESCRIPTION
### Description of changes

- woops, this was an unintentional result of https://github.com/amelioro/ameliorate/commit/950fbc688a44c42aeda4ddfeae08a17bdc9bd184

### Additional context

-
