### PR TITLE
chore: unpin netlify version

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
     "@commitlint/cli": "17.6.6",
     "@commitlint/config-conventional": "17.6.6",
     "@emotion/babel-plugin": "11.10.5",
-    "@netlify/plugin-nextjs": "5.1.2",
     "@playwright/test": "1.49.1",
     "@sindresorhus/slugify": "2.2.1",
     "@types/dagre": "0.7.48",


### PR DESCRIPTION
originally pinned this for local deploy reasons, but that's not worth losing out on newer netlify nextjs deployment improvements

(motivated by warning about not using the latest netlify nextjs runtime in the deploy's build section log)

### Description of changes

-

### Additional context

-
