### PR TITLE
feat(quick-views): replace individual row buttons with three-dot menu

### DIFF
--- a/src/web/topic/components/TopicPane/QuickViewSection.tsx
+++ b/src/web/topic/components/TopicPane/QuickViewSection.tsx
@@ -1,4 +1,4 @@
-import { Add, Delete, Edit, Redo, Save, SwapVert, Undo, Visibility } from "@mui/icons-material";
+import { Add, Delete, Edit, Redo, Save, SwapVert, Undo, MoreVert, Visibility } from "@mui/icons-material";
 import {
   Divider,
   IconButton,
@@ -37,57 +37,17 @@ interface RowProps {
 }
 
 const QuickViewRow = ({ view, selected, editable, onEdit }: RowProps) => {
-  const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLElement | null>(null);
+  const [actionsMenuAnchorEl, setActionsMenuAnchorEl] = useState<HTMLElement | null>(null);
 
   return (
     <ListItem key={view.id}>
       <ListItemButton
         selected={selected}
         onClick={() => selectView(view.id)}
-        sx={{ paddingY: 0, height: "40px" }} // icon buttons have padding, so this extra padding isn't necessary, and use a consistent height whether or not icon buttons are showing
+        sx={{ paddingY: 0, height: "40px" }}
       >
         <ListItemIcon>
-          {editable ? (
-            <>
-              <IconButton
-                color="inherit"
-                title="Reorder View"
-                aria-label="Reorder View"
-                onClick={(e) => {
-                  setMenuAnchorEl(e.currentTarget);
-                  e.stopPropagation(); // don't also trigger row select
-                }}
-              >
-                <SwapVert />
-              </IconButton>
-              <Menu
-                anchorEl={menuAnchorEl}
-                open={Boolean(menuAnchorEl)}
-                onClose={() => setMenuAnchorEl(null)}
-              >
-                <CloseOnClickMenuItem
-                  onClick={(e) => {
-                    moveView(view.id, "up");
-                    e.stopPropagation(); // don't also trigger row select
-                  }}
-                  closeMenu={() => setMenuAnchorEl(null)}
-                >
-                  Move up
-                </CloseOnClickMenuItem>
-                <CloseOnClickMenuItem
-                  onClick={(e) => {
-                    moveView(view.id, "down");
-                    e.stopPropagation(); // don't also trigger row select
-                  }}
-                  closeMenu={() => setMenuAnchorEl(null)}
-                >
-                  Move down
-                </CloseOnClickMenuItem>
-              </Menu>
-            </>
-          ) : (
-            <Visibility />
-          )}
+          <Visibility />
         </ListItemIcon>
 
         <ListItemText primary={view.title} className="[&>span]:truncate" />
@@ -96,40 +56,72 @@ const QuickViewRow = ({ view, selected, editable, onEdit }: RowProps) => {
           <>
             <IconButton
               color="inherit"
-              title="Edit View"
-              aria-label="Edit View"
+              title="More Actions"
+              aria-label="More Actions"
               onClick={(e) => {
-                onEdit();
-                e.stopPropagation(); // don't also trigger row select
+                setActionsMenuAnchorEl(e.currentTarget);
+                e.stopPropagation();
               }}
             >
-              <Edit />
+              <MoreVert />
             </IconButton>
-            <IconButton
-              color="inherit"
-              title="Overwrite View"
-              aria-label="Overwrite View"
-              // Assumes that the selected view is being displayed, so saving wouldn't do anything.
-              // Could be more accurate by checking if this index's view state deep equals the current view state... but that seems overkill performance-wise.
-              disabled={selected}
-              onClick={(e) => {
-                saveView(view.id);
-                e.stopPropagation(); // don't also trigger row select
-              }}
+            <Menu
+              anchorEl={actionsMenuAnchorEl}
+              open={Boolean(actionsMenuAnchorEl)}
+              onClose={() => setActionsMenuAnchorEl(null)}
             >
-              <Save />
-            </IconButton>
-            <IconButton
-              color="inherit"
-              title="Delete View"
-              aria-label="Delete View"
-              onClick={(e) => {
-                deleteView(view.id);
-                e.stopPropagation(); // don't also trigger row select
-              }}
-            >
-              <Delete />
-            </IconButton>
+              <CloseOnClickMenuItem
+                onClick={(e) => {
+                  moveView(view.id, "up");
+                  e.stopPropagation();
+                }}
+                closeMenu={() => setActionsMenuAnchorEl(null)}
+              >
+                <ListItemIcon><SwapVert fontSize="small" /></ListItemIcon>
+                <ListItemText>Move up</ListItemText>
+              </CloseOnClickMenuItem>
+              <CloseOnClickMenuItem
+                onClick={(e) => {
+                  moveView(view.id, "down");
+                  e.stopPropagation();
+                }}
+                closeMenu={() => setActionsMenuAnchorEl(null)}
+              >
+                <ListItemIcon><SwapVert fontSize="small" /></ListItemIcon>
+                <ListItemText>Move down</ListItemText>
+              </CloseOnClickMenuItem>
+              <CloseOnClickMenuItem
+                onClick={(e) => {
+                  onEdit();
+                  e.stopPropagation();
+                }}
+                closeMenu={() => setActionsMenuAnchorEl(null)}
+              >
+                <ListItemIcon><Edit fontSize="small" /></ListItemIcon>
+                <ListItemText>Edit</ListItemText>
+              </CloseOnClickMenuItem>
+              <CloseOnClickMenuItem
+                disabled={selected}
+                onClick={(e) => {
+                  saveView(view.id);
+                  e.stopPropagation();
+                }}
+                closeMenu={() => setActionsMenuAnchorEl(null)}
+              >
+                <ListItemIcon><Save fontSize="small" /></ListItemIcon>
+                <ListItemText>Overwrite</ListItemText>
+              </CloseOnClickMenuItem>
+              <CloseOnClickMenuItem
+                onClick={(e) => {
+                  deleteView(view.id);
+                  e.stopPropagation();
+                }}
+                closeMenu={() => setActionsMenuAnchorEl(null)}
+              >
+                <ListItemIcon><Delete fontSize="small" /></ListItemIcon>
+                <ListItemText>Delete</ListItemText>
+              </CloseOnClickMenuItem>
+            </Menu>
           </>
         )}
       </ListItemButton>
@@ -149,13 +141,15 @@ export const QuickViewSection = () => {
 
   return (
     <>
-      {/* slightly jank to have this section assume there's a parent MUI list, but I think it's worth extracting to this component anyway */}
       <ListItem
         key="QuickViewSection"
         disablePadding={false}
-        sx={{ paddingY: 0, height: "40px" }} // icon buttons have padding, so this extra padding isn't necessary, and use a consistent height whether or not icon buttons are showing
+        sx={{ paddingY: 0, height: "40px" }}
       >
-        <ListItemText primary="Quick Views" />
+        <ListItemText
+          primary="Quick Views"
+          primaryTypographyProps={{ fontWeight: 'bold' }}
+        />
 
         {userCanEditTopicData && (
           <>

--- a/src/web/topic/components/TopicPane/TopicViews.tsx
+++ b/src/web/topic/components/TopicPane/TopicViews.tsx
@@ -33,7 +33,8 @@ export const TopicViews = () => {
 
         <ListItem key="1">
           <ListItemButton onClick={() => setIsFormatSectionOpen(!isFormatSectionOpen)}>
-            <ListItemText primary="Format" />
+            <ListItemText primary="Format" primaryTypographyProps={{ fontWeight: 'bold' }}
+            />
             {isFormatSectionOpen ? <ExpandLess /> : <ExpandMore />}
           </ListItemButton>
         </ListItem>
@@ -72,7 +73,8 @@ export const TopicViews = () => {
               <ListItemButton
                 onClick={() => setIsInformationFiltersSectionOpen(!isInformationFiltersSectionOpen)}
               >
-                <ListItemText primary="Information Filters" />
+                <ListItemText primary="Information Filters" primaryTypographyProps={{ fontWeight: 'bold' }}
+                />
                 {isInformationFiltersSectionOpen ? <ExpandLess /> : <ExpandMore />}
               </ListItemButton>
             </ListItem>
@@ -90,7 +92,8 @@ export const TopicViews = () => {
               <ListItemButton
                 onClick={() => setIsTableFiltersSectionOpen(!isTableFiltersSectionOpen)}
               >
-                <ListItemText primary="Table Filters" />
+                <ListItemText primary="Table Filters" primaryTypographyProps={{ fontWeight: 'bold' }}
+                />
                 {isTableFiltersSectionOpen ? <ExpandLess /> : <ExpandMore />}
               </ListItemButton>
             </ListItem>
@@ -106,7 +109,8 @@ export const TopicViews = () => {
           <ListItemButton
             onClick={() => setIsGeneralFiltersSectionOpen(!isGeneralFiltersSectionOpen)}
           >
-            <ListItemText primary="General Filters" />
+            <ListItemText primary="General Filters" primaryTypographyProps={{ fontWeight: 'bold' }}
+            />
             {isGeneralFiltersSectionOpen ? <ExpandLess /> : <ExpandMore />}
           </ListItemButton>
         </ListItem>


### PR DESCRIPTION
Closes #725

### Description of changes
- Replaced individual Edit/Save/Delete buttons with single MoreVert (three-dot) menu
- Consolidated reorder (move up/down) functionality into the same menu
- Added eye icons to Quick View rows for visual consistency with other sections
- Made all section headers bold for better distinction between sections
- Maintained all existing functionality and accessibility labels

<img width="1526" height="884" alt="Screenshot 2025-09-24 212333" src="https://github.com/user-attachments/assets/24795a6e-6bed-47d0-b4fb-4e5416eb7a50" />
