### PR TITLE
fix: nodes missing in summary view

### DIFF
--- a/src/web/summary/components/Summary.tsx
+++ b/src/web/summary/components/Summary.tsx
@@ -144,7 +144,15 @@ export const Summary = () => {
             <TabPanel
               key={category}
               value={category}
-              keepMounted
+              /**
+               * TODO?: `keepMounted` could be nice to avoid re-rendering across tab switching, but
+               * it gives a greater chance of rendering two of the same node at the same time, which
+               * breaks our `layoutId` usage in `EditableNode` for `framer-motion` animations.
+               * When two nodes with the same `layoutId` are rendered at the same time, one of them
+               * one will be given `opacity: 0` which is awful UX for our columns here.
+               * (if we fix #855 we may be able to enable this again)
+               */
+              // keepMounted
               classes={{
                 root:
                   "p-0 grow flex *:grow *:basis-0 divide-x overflow-y-auto *:min-w-0 [&>div>*]:p-1" +

--- a/src/web/topic/components/Node/EditableNode.tsx
+++ b/src/web/topic/components/Node/EditableNode.tsx
@@ -143,6 +143,7 @@ const EditableNodeBase = ({ node, className = "", onClick }: Props) => {
         key={node.id}
         ref={setNodeRef}
         // TODO?: not sure why summary nodes sometimes animate from height that's slightly off
+        // TODO(bug): #855 duplicate `layoutId`s can happen in the Summary view, causing one of the nodes to be invisible
         // don't animate in diagram because FlowNode already animates for diagram (with Handles)
         // don't animate in table because animation doesn't go over rows/cols - probably need to change overflows/positions/z-indexes in table, something like this https://github.com/amelioro/ameliorate/pull/771/files#diff-41880963d81eba31b5d0de56b7d1c84335078e0472037158b6a18b970da4d102
         // don't animate between contexts because if the node shows up in two spots at once, animation will remove it from one of the spots


### PR DESCRIPTION
### Description of changes

- Unfortunately this isn't really a fix, it's a revert that makes the bug rare again. Created #855 to track the rare bug which is hopefully fixable

### Additional context

-
