### PR TITLE
chore: upgrade next to address vuln

### DIFF
--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "dompurify": "^3.2.1",
-        "next": "^15.5.7",
+        "next": "^15.5.10",
         "next-plausible": "^3.12.4",
         "next-sitemap": "^4.2.3",
         "nextra": "^4.2.16",
@@ -931,9 +931,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.9",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.9.tgz",
-      "integrity": "sha512-4GlTZ+EJM7WaW2HEZcyU317tIQDjkQIyENDLxYJfSWlfqguN+dHkZgyQTV/7ykvobU7yEH5gKvreNrH4B6QgIg==",
+      "version": "15.5.11",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.11.tgz",
+      "integrity": "sha512-g9s5SS9gC7GJCEOR3OV3zqs7C5VddqxP9X+/6BpMbdXRkqsWfFf2CJPBZNvNEtAkKTNuRgRXAgNxSAXzfLdaTg==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
@@ -5313,13 +5313,13 @@
       }
     },
     "node_modules/next": {
-      "version": "15.5.9",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.9.tgz",
-      "integrity": "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==",
+      "version": "15.5.11",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.11.tgz",
+      "integrity": "sha512-L2KPiKmqTDpRdeVDdPjhf43g2/VPe0NCNndq7OKDCgOLWtxe1kbr/zXGIZtYY7kZEAjRf7Bj/mwUFSr+tYC2Yg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@next/env": "15.5.9",
+        "@next/env": "15.5.11",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -19,7 +19,7 @@
   "/": "dompurify should not be needed here, it's only used indirectly via nextra's mermaid rendering, but there is a dependency issue they need to fix, see https://github.com/mermaid-js/mermaid/issues/6078",
   "dependencies": {
     "dompurify": "^3.2.1",
-    "next": "^15.5.7",
+    "next": "^15.5.10",
     "next-plausible": "^3.12.4",
     "next-sitemap": "^4.2.3",
     "nextra": "^4.2.16",


### PR DESCRIPTION
`npm audit` still seems to think this version is vulnerable, I believe because Next.js has listed "<15.6.0-canary.61" as affected, but their security summary lists "15.5.10" as a fix version
https://vercel.com/changelog/summaries-of-cve-2025-59471-and-cve-2025-59472

Should resolve https://github.com/amelioro/ameliorate/security/dependabot/156 and https://github.com/amelioro/ameliorate/security/dependabot/157

### Description of changes

-

### Additional context

-
