### PR TITLE
fix: modifying notes doesn't render NoteIndicator

### DIFF
--- a/src/web/common/theme.ts
+++ b/src/web/common/theme.ts
@@ -48,15 +48,15 @@ import {
 import { createEmotionCache } from "@mui/material-nextjs/v14-pagesRouter";
 import Color from "colorjs.io";
 
-import { type FlowNodeType } from "@/web/topic/utils/node";
+import { type NodeType } from "@/common/node";
 
 // adding colors to theme documented at https://mui.com/material-ui/customization/palette/#adding-new-colors
 
 declare module "@mui/material/styles" {
   // bit awkward but don't think it's possible to create keys for each NodeType in an interface without creating this intermediate type
   // thanks https://stackoverflow.com/a/60378992
-  type NodeTypePalettes = Record<FlowNodeType, PaletteColor>;
-  type NodeTypePaletteOptions = Record<FlowNodeType, PaletteColorOptions>;
+  type NodeTypePalettes = Record<NodeType, PaletteColor>;
+  type NodeTypePaletteOptions = Record<NodeType, PaletteColorOptions>;
 
   interface Palette extends NodeTypePalettes {
     neutral: PaletteColor;
@@ -95,7 +95,7 @@ declare module "@mui/material/styles" {
 }
 
 declare module "@mui/material" {
-  type NodeTypeColors = Record<FlowNodeType, true>;
+  type NodeTypeColors = Record<NodeType, true>;
 
   interface ButtonPropsColorOverrides extends NodeTypeColors {
     neutral: true;

--- a/src/web/topic/components/Edge/FlowEdge.tsx
+++ b/src/web/topic/components/Edge/FlowEdge.tsx
@@ -1,6 +1,11 @@
-import { EdgeProps } from "@/web/topic/components/Diagram/Diagram";
 import { ScoreEdge } from "@/web/topic/components/Edge/ScoreEdge";
+import { useEdge } from "@/web/topic/diagramStore/edgeHooks";
+import { FlowEdgeProps } from "@/web/topic/utils/flowUtils";
 
-export const FlowEdge = (flowEdge: EdgeProps) => {
-  return <ScoreEdge inReactFlow={true} {...flowEdge} />;
+export const FlowEdge = (flowEdge: FlowEdgeProps) => {
+  const edge = useEdge(flowEdge.id);
+
+  if (!edge) return null;
+
+  return <ScoreEdge edge={edge} edgeLayoutData={flowEdge.data} inReactFlow={true} />;
 };

--- a/src/web/topic/components/Edge/StandaloneEdge.tsx
+++ b/src/web/topic/components/Edge/StandaloneEdge.tsx
@@ -1,34 +1,11 @@
 import { Stack } from "@mui/material";
-import { Position } from "@xyflow/react";
 
-import { EdgeProps } from "@/web/topic/components/Diagram/Diagram";
 import { ScoreEdge } from "@/web/topic/components/Edge/ScoreEdge";
 import { EditableNode } from "@/web/topic/components/Node/EditableNode";
 import { nodeWidthPx } from "@/web/topic/components/Node/EditableNode.styles";
 import { useNode } from "@/web/topic/diagramStore/nodeHooks";
+import { EdgeLayoutData } from "@/web/topic/utils/diagram";
 import { Edge } from "@/web/topic/utils/graph";
-import { useIsGraphPartSelected } from "@/web/view/selectedPartStore";
-
-const convertToStandaloneFlowEdge = (edge: Edge, selected: boolean): EdgeProps => {
-  return {
-    id: edge.id,
-    // don't provide a position for the label, so it defaults to being placed between the two nodes
-    // also we don't need source/target port ids because these are only used within react flow
-    data: { ...edge.data, elkSections: [] },
-    label: edge.label,
-    selected: selected,
-    type: "FlowEdge",
-    source: edge.source,
-    target: edge.target,
-
-    sourceX: nodeWidthPx / 2, // center of node
-    sourceY: 100,
-    sourcePosition: Position.Top, // match layout's upward orientation, so source handles will be on top of nodes
-    targetX: nodeWidthPx / 2,
-    targetY: 0,
-    targetPosition: Position.Bottom,
-  };
-};
 
 interface Props {
   edge: Edge;
@@ -37,20 +14,24 @@ interface Props {
 export const StandaloneEdge = ({ edge }: Props) => {
   const sourceNode = useNode(edge.source);
   const targetNode = useNode(edge.target);
-  const isEdgeSelected = useIsGraphPartSelected(edge.id);
 
   if (!sourceNode || !targetNode) {
     return <p>Could not find edge data!</p>;
   }
 
-  const flowEdge = convertToStandaloneFlowEdge(edge, isEdgeSelected);
+  const edgeLayoutData: EdgeLayoutData = {
+    sourcePoint: { x: nodeWidthPx / 2, y: 100 }, // center of node
+    targetPoint: { x: nodeWidthPx / 2, y: 0 },
+    bendPoints: [],
+    labelPosition: undefined,
+  };
 
   // TODO?: could consider flipping the edge if layout will flip it, but doesn't seem totally necessary
   return (
     <Stack>
       {/* z-index to ensure hanging node indicators don't fall behind the edge svg empty background */}
       <EditableNode node={targetNode} className="z-10" />
-      <ScoreEdge inReactFlow={false} {...flowEdge} />
+      <ScoreEdge edge={edge} edgeLayoutData={edgeLayoutData} inReactFlow={false} />
       <EditableNode node={sourceNode} className="z-10" />
     </Stack>
   );

--- a/src/web/topic/diagramStore/createDeleteActions.ts
+++ b/src/web/topic/diagramStore/createDeleteActions.ts
@@ -2,7 +2,7 @@ import { createDraft, finishDraft } from "immer";
 
 import { RelationName } from "@/common/edge";
 import { errorWithData } from "@/common/errorHandling";
-import { justificationNodeTypes } from "@/common/node";
+import { NodeType, justificationNodeTypes } from "@/common/node";
 import { emitter } from "@/web/common/event";
 import { setNewlyAddedNode } from "@/web/common/store/ephemeralStore";
 import { WorkspaceContextType } from "@/web/topic/components/TopicWorkspace/WorkspaceContext";
@@ -20,12 +20,12 @@ import {
   isNode,
 } from "@/web/topic/utils/graph";
 import { getImplicitLabel } from "@/web/topic/utils/justification";
-import { FlowNodeType, edges } from "@/web/topic/utils/node";
+import { edges } from "@/web/topic/utils/node";
 import { setSelected } from "@/web/view/selectedPartStore";
 
 const createNode = (
   state: DiagramStoreState,
-  toNodeType: FlowNodeType,
+  toNodeType: NodeType,
   arguedDiagramPartId?: string,
   selectNewNode = true,
 ) => {
@@ -142,7 +142,7 @@ export const addNode = ({ fromPartId, directedRelation, context, selectNewNode }
 };
 
 export const addNodeWithoutEdge = (
-  nodeType: FlowNodeType,
+  nodeType: NodeType,
   context: WorkspaceContextType,
   selectNewNode = true,
 ) => {

--- a/src/web/topic/diagramStore/edgeHooks.ts
+++ b/src/web/topic/diagramStore/edgeHooks.ts
@@ -5,6 +5,18 @@ import { nodes } from "@/web/topic/utils/edge";
 import { Node, findEdgeOrThrow } from "@/web/topic/utils/graph";
 import { useIsAnyGraphPartSelected } from "@/web/view/selectedPartStore";
 
+export const useEdge = (edgeId: string | null) => {
+  return useDiagramStore((state) => {
+    if (!edgeId) return null;
+
+    try {
+      return findEdgeOrThrow(edgeId, state.edges);
+    } catch {
+      return null;
+    }
+  });
+};
+
 export const useEdgeNodes = (edgeId: string): [Node, Node] | [] => {
   return useDiagramStore((state) => {
     try {

--- a/src/web/topic/hooks/diagramHooks.ts
+++ b/src/web/topic/hooks/diagramHooks.ts
@@ -1,8 +1,8 @@
 import { useState } from "react";
 
-import { Diagram, PositionedDiagram } from "@/web/topic/utils/diagram";
+import { Diagram } from "@/web/topic/utils/diagram";
 import { isNode } from "@/web/topic/utils/graph";
-import { layout } from "@/web/topic/utils/layout";
+import { LayoutedGraph, layout } from "@/web/topic/utils/layout";
 import {
   useAvoidEdgeLabelOverlap,
   useForceNodesIntoLayers,
@@ -12,7 +12,7 @@ import {
 } from "@/web/view/currentViewStore/layout";
 
 // re-renders when diagram changes, but only re-layouts if graph parts are added or removed
-export const usePositionedDiagram = (diagram: Diagram) => {
+export const useLayoutedDiagram = (diagram: Diagram) => {
   const forceNodesIntoLayers = useForceNodesIntoLayers();
   const layerNodeIslandsTogether = useLayerNodeIslandsTogether();
   const minimizeEdgeCrossings = useMinimizeEdgeCrossings();
@@ -37,7 +37,7 @@ export const usePositionedDiagram = (diagram: Diagram) => {
     .join();
   const [prevDiagramHash, setPrevDiagramHash] = useState<string | null>(null);
 
-  const [positionedDiagram, setPositionedDiagram] = useState<PositionedDiagram | null>(null);
+  const [layoutedDiagram, setLayoutedDiagram] = useState<LayoutedGraph | null>(null);
   const [hasNewLayout, setHasNewLayout] = useState<boolean>(false);
 
   if (diagramHash !== prevDiagramHash) {
@@ -55,51 +55,14 @@ export const usePositionedDiagram = (diagram: Diagram) => {
         thoroughness,
       );
 
-      const positionedDiagram: PositionedDiagram = {
-        ...diagram,
-        nodes: diagram.nodes
-          .map((node) => {
-            const layoutedNode = newLayoutedDiagram.layoutedNodes.find(
-              (layoutedNode) => layoutedNode.id === node.id,
-            );
-            if (!layoutedNode) return null;
-
-            return {
-              ...node,
-              data: { ...node.data, ports: layoutedNode.ports },
-              position: {
-                x: layoutedNode.x,
-                y: layoutedNode.y,
-              },
-            };
-          })
-          .filter((node) => node !== null),
-        edges: diagram.edges
-          .map((edge) => {
-            const layoutedEdge = newLayoutedDiagram.layoutedEdges.find(
-              (layoutedEdge) => layoutedEdge.id === edge.id,
-            );
-            if (!layoutedEdge) return null;
-            const { sourcePortId, targetPortId, elkLabel, elkSections } = layoutedEdge;
-
-            return {
-              ...edge,
-              sourceHandle: sourcePortId,
-              targetHandle: targetPortId,
-              data: { ...edge.data, elkLabel, elkSections },
-            };
-          })
-          .filter((edge) => edge !== null),
-      };
-
-      setPositionedDiagram(positionedDiagram);
+      setLayoutedDiagram(newLayoutedDiagram);
       setHasNewLayout(true);
     };
     void layoutDiagram();
   }
 
   // if we're waiting for the first layout to complete
-  if (!positionedDiagram) return { positionedDiagram: null, hasNewLayout, setHasNewLayout };
+  if (!layoutedDiagram) return { layoutedDiagram: null, hasNewLayout, setHasNewLayout };
 
-  return { positionedDiagram, hasNewLayout, setHasNewLayout };
+  return { layoutedDiagram, hasNewLayout, setHasNewLayout };
 };

--- a/src/web/topic/hooks/flowHooks.ts
+++ b/src/web/topic/hooks/flowHooks.ts
@@ -2,11 +2,11 @@ import { type Viewport, useReactFlow, useStore, useStoreApi } from "@xyflow/reac
 import { shallow } from "zustand/shallow";
 
 import { nodeHeightPx, nodeWidthPx } from "@/web/topic/components/Node/EditableNode.styles";
-import { PositionedNode } from "@/web/topic/utils/diagram";
+import { ReactFlowNode } from "@/web/topic/utils/flowUtils";
 import { Node } from "@/web/topic/utils/graph";
 
 const getViewportToIncludeNode = (
-  node: PositionedNode,
+  node: ReactFlowNode,
   viewport: Viewport,
   viewportHeight: number,
   viewportWidth: number,
@@ -69,7 +69,7 @@ export const useViewportUpdater = () => {
    * but it still throws a "cannot update a component while rendering a different component" error,
    * so we're still wrapping it in a convenient method.
    */
-  const fitViewForNodes = (nodes: PositionedNode[], smoothTransition = false) => {
+  const fitViewForNodes = (nodes: ReactFlowNode[], smoothTransition = false) => {
     // defer to avoid "Cannot update a component while rendering a different component" error e.g. when called during Diagram render, so that react flow's Background component doesn't try to re-render during that Diagram render
     setTimeout(
       () => void fitView({ nodes, minZoom, maxZoom: 1, duration: smoothTransition ? 1300 : 0 }),
@@ -77,7 +77,7 @@ export const useViewportUpdater = () => {
     );
   };
 
-  const moveViewportToIncludeNode = (node: PositionedNode) => {
+  const moveViewportToIncludeNode = (node: ReactFlowNode) => {
     // This is intentionally not-reactive. Using a hook that fires whenever the viewport changes is very slow.
     const viewport = getViewport();
     const newViewport = getViewportToIncludeNode(node, viewport, viewportHeight, viewportWidth);

--- a/src/web/topic/utils/diagram.ts
+++ b/src/web/topic/utils/diagram.ts
@@ -1,28 +1,16 @@
-import { type Edge as ReactFlowEdge } from "@xyflow/react";
-
 import { type Edge, type Node } from "@/web/topic/utils/graph";
-import { type LayoutedEdge, type LayoutedNode } from "@/web/topic/utils/layout";
+import { LayoutedEdge } from "@/web/topic/utils/layout";
 
 export interface Diagram {
   nodes: Node[];
   edges: Edge[];
 }
 
-export interface PositionedNode extends Node {
-  data: Node["data"] & { ports: LayoutedNode["ports"] };
-  position: {
-    x: number;
-    y: number;
-  };
-}
-
-export interface PositionedEdge
-  extends Edge,
-    Required<Pick<ReactFlowEdge, "sourceHandle" | "targetHandle">> {
-  data: Edge["data"] & Omit<LayoutedEdge, "id" | "sourcePortId" | "targetPortId">; // edge already has id directly on it
-}
-
-export interface PositionedDiagram extends Diagram {
-  nodes: PositionedNode[];
-  edges: PositionedEdge[];
-}
+/**
+ * Used for rendering paths and labels. If we have ELK layout data, we should use that. Otherwise,
+ * e.g. for StandaloneEdge outside of the diagram, we can set `handlePositions`.
+ */
+export type EdgeLayoutData = Pick<
+  LayoutedEdge,
+  "sourcePoint" | "targetPoint" | "bendPoints" | "labelPosition"
+>;

--- a/src/web/topic/utils/flowUtils.ts
+++ b/src/web/topic/utils/flowUtils.ts
@@ -1,4 +1,46 @@
+import {
+  type EdgeProps as DefaultEdgeProps,
+  type NodeProps as DefaultNodeProps,
+  type Edge,
+  type Node,
+} from "@xyflow/react";
+
+import { EdgeLayoutData } from "@/web/topic/utils/diagram";
+import { LayoutedNode } from "@/web/topic/utils/layout";
+
 /**
  * Match padding used by React Flow's fitView https://github.com/xyflow/xyflow/blob/ede221a7ad9555763edc2321033d3c3e61261da2/packages/system/src/utils/graph.ts#L375
  */
 export const defaultFitViewPadding = 0.1;
+
+/**
+ * React Flow passes this type into custom Node components (e.g. EditableNode).
+ *
+ * It differs from `ReactFlowNode` because this has some data calculated during rendering like
+ * handle positions. `ReactFlowNode` also has some DOM/CSS-specific props on it.
+ */
+export interface FlowNodeProps extends DefaultNodeProps {
+  data: Pick<LayoutedNode, "ports">;
+  type: "FlowNode"; // may as well be explicit so from the FlowNode component we know we're not getting e.g. `problem`/`benefit`/...
+}
+
+/**
+ * React Flow passes this type into custom Edge components (e.g. ScoreEdge).
+ *
+ * This doesn't look very different from `ReactFlowEdge` but since the node version is different,
+ * let's just make this one different too.
+ */
+export interface FlowEdgeProps extends DefaultEdgeProps {
+  data: EdgeLayoutData;
+  type: "FlowEdge"; // for some reason after reactflow 11->12, DefaultEdgeProps has optional type, but ReactFlow component expects it to be defined
+}
+
+/**
+ * This type is passed into the ReactFlow component's `nodes` prop.
+ */
+export type ReactFlowNode = Node<FlowNodeProps["data"], "FlowNode">;
+
+/**
+ * This type is passed into the ReactFlow component's `edges` prop.
+ */
+export type ReactFlowEdge = Edge<FlowEdgeProps["data"], "FlowEdge">;

--- a/src/web/topic/utils/graph.ts
+++ b/src/web/topic/utils/graph.ts
@@ -16,7 +16,6 @@ import {
   nodeTypes,
   reactFlowNodeSchema,
 } from "@/common/node";
-import { type FlowNodeType } from "@/web/topic/utils/node";
 import { GeneralFilter } from "@/web/view/utils/generalFilter";
 
 export interface Graph {
@@ -35,7 +34,7 @@ interface BuildProps {
   customType?: string | null;
   label?: string;
   notes?: string;
-  type: FlowNodeType;
+  type: NodeType;
   arguedDiagramPartId?: string;
 }
 export const buildNode = ({

--- a/src/web/topic/utils/node.ts
+++ b/src/web/topic/utils/node.ts
@@ -3,11 +3,7 @@ import { NodeType, areSameCategoryNodes } from "@/common/node";
 import { componentTypes } from "@/web/topic/utils/edge";
 import { Edge, Graph, Node } from "@/web/topic/utils/graph";
 
-// this is expected to differ from the backend at some point, i.e. if we visualize solutionComponents as nested within solutions
-// this is somewhat premature optimization, but already spent time designing this way so it's probably worth leaving these as distinct
-export type FlowNodeType = NodeType;
-
-export const hideableNodeTypes: FlowNodeType[] = ["criterion", "effect", "solutionComponent"];
+export const hideableNodeTypes: NodeType[] = ["criterion", "effect", "solutionComponent"];
 
 // TODO: memoize? this could traverse a lot of nodes & edges, seems not performant
 export const sourceNodes = (node: Node, topicGraph: Graph, sameCategoryNodes = true) => {

--- a/src/web/topic/utils/nodeDecoration.ts
+++ b/src/web/topic/utils/nodeDecoration.ts
@@ -25,7 +25,7 @@ import {
   Widgets,
 } from "@mui/icons-material";
 
-import { FlowNodeType } from "@/web/topic/utils/node";
+import { NodeType } from "@/common/node";
 
 export const indicatorLengthRem = 1.25; // rem
 
@@ -42,7 +42,7 @@ interface NodeDecoration {
  * Could refactor this to nodeIcons, but it seems like more decoration stuff could be useful in the
  * future, so I'm leaving it as nodeDecorations for now.
  */
-export const nodeDecorations: Record<FlowNodeType, NodeDecoration> = {
+export const nodeDecorations: Record<NodeType, NodeDecoration> = {
   // topic
   problem: {
     NodeIcon: Extension,


### PR DESCRIPTION
(sorry for the massive commit, changes are pretty tightly coupled)

this was because our layout hook was only passing forward update node/edge info if there was a change affecting layout. it generally seems like our react flow component shouldn't need to rerender if non-layout node/edge data changes anyway - we should be able to watch for changes from the specific components that need updating.

so this included a sizable refactor to only pass layout data into react flow. now we'll grab non-layout data from custom node/edge components that need it.

more motivation for the refactor:
- we want to eventually move our graph logic to use a more generic data structure, that isn't shaped based on react flow's expected shape, because its shape is built for its frontend needs, and has unnecessary things (e.g. `data`). separating non-layout data from react flow is a step in this direction of using the structure we want, uninfluenced by react flow.

also includes:
- refactoring layout to return start/end/bend points instead of elk-specific types. this makes it much cleaner to handle path drawing the same way for edges that were laid by ELK vs drawn separately from the diagram ("standalone").
- overwrite `type` to `FlowNode`/`FlowEdge` when passing nodes to react flow. slightly jank, but seems best for now - see `Diagram.tsx` comments.
- remove separate `FlowNodeType`. that existed in case we make a node component per node type, but that very likely will never happen. more likely is making other custom node types like "minimized node" or "small node" or something.
- `flowEdge.style` isn't passed into the edge's path anymore, since the flowEdge isn't passed in anymore and I thiiiiink we're handling all the styles ourselves now anyway? can just re-pass that in if it there turns out to be some important style that reactflow adds

### Description of changes

-

### Additional context

-
