### PR TITLE
touchup: only render one Dialog for topics list

### DIFF
--- a/src/pages/[username].page.tsx
+++ b/src/pages/[username].page.tsx
@@ -103,6 +103,7 @@ const User: NextPage = () => {
   const rowData: RowData[] = foundUser.topics;
 
   const hasEditAccess = foundUser.id === sessionUser?.id;
+  const editingTopic = rowData.find((topic) => topic.id === editingTopicId) ?? null;
 
   return (
     <>
@@ -125,17 +126,6 @@ const User: NextPage = () => {
             >
               <Settings fontSize="inherit" />
             </IconButton>
-            <Dialog
-              open={editingTopicId === row.original.id}
-              onClose={() => setEditingTopicId(null)}
-              aria-label="Topic Settings"
-            >
-              <EditTopicForm
-                topic={row.original}
-                creatorName={foundUser.username}
-                afterSave={() => setEditingTopicId(null)}
-              />
-            </Dialog>
           </>
         )}
         positionActionsColumn="last"
@@ -150,13 +140,6 @@ const User: NextPage = () => {
                   <Button variant="contained" onClick={() => setCreatingTopic(true)}>
                     New Topic
                   </Button>
-                  <Dialog
-                    open={creatingTopic}
-                    onClose={() => setCreatingTopic(false)}
-                    aria-label="New Topic"
-                  >
-                    <CreateTopicForm creatorName={foundUser.username} />
-                  </Dialog>
                 </>
               )}
             </>
@@ -167,6 +150,24 @@ const User: NextPage = () => {
           sorting: [{ id: "updatedAt", desc: true }],
         }}
       />
+
+      <Dialog
+        open={editingTopic !== null}
+        onClose={() => setEditingTopicId(null)}
+        aria-label="Topic Settings"
+      >
+        {editingTopic && (
+          <EditTopicForm
+            topic={editingTopic}
+            creatorName={foundUser.username}
+            afterSave={() => setEditingTopicId(null)}
+          />
+        )}
+      </Dialog>
+
+      <Dialog open={creatingTopic} onClose={() => setCreatingTopic(false)} aria-label="New Topic">
+        <CreateTopicForm creatorName={foundUser.username} />
+      </Dialog>
     </>
   );
 };

--- a/src/web/topic/components/TopicForm/TopicForm.tsx
+++ b/src/web/topic/components/TopicForm/TopicForm.tsx
@@ -76,6 +76,9 @@ export const CreateTopicForm = ({ creatorName }: { creatorName: string }) => {
 interface EditTopicFormProps {
   topic: Topic;
   creatorName: string;
+  /**
+   * allow the calling component to react, e.g. to close a dialog that this form is within
+   */
   afterSave?: () => void;
 }
 
@@ -85,9 +88,9 @@ export const EditTopicForm = ({ topic, creatorName, afterSave }: EditTopicFormPr
 
   const updateTopic = trpc.topic.update.useMutation({
     onSuccess: (updatedTopic) => {
-      // need to update the URL if we're changing from the topic's page in the workspace
-
       if (afterSave) afterSave();
+
+      // need to update the URL if we're changing from the topic's page in the workspace
       const url = new URL(window.location.href);
       const oldPath = `/${creatorName}/${topic.title}`;
       const newPath = `/${creatorName}/${updatedTopic.title}`;

--- a/src/web/topic/components/TopicPane/TopicDetails.tsx
+++ b/src/web/topic/components/TopicPane/TopicDetails.tsx
@@ -115,6 +115,7 @@ export const TopicDetails = ({ selectedTab, setSelectedTab }: Props) => {
   const expandDetailsTabs = useExpandDetailsTabs();
 
   const [topicFormOpen, setTopicFormOpen] = useState(false);
+
   // Ideally we could exactly reuse the indicator logic here, rather than duplicating, but not sure
   // a good way to do that, so we're just duplicating the logic for now.
   // Don't want to use the exact indicators, because pane indication seems to look better with Icon


### PR DESCRIPTION
well, one for editing and one for creating, rather than one per topic to edit.

also touchup spacing and document reasoning for Topic Form's afterSave.

### Description of changes

-

### Additional context

-
