### PR TITLE
refactor: more-align node+edge schemas in store+db

### DIFF
--- a/examples/visible_act.json
+++ b/examples/visible_act.json
@@ -21,8 +21,8 @@
           "id": "42c7137b-fa72-4f8f-b9a6-5d73c1c1752d",
           "data": {
             "customType": null,
-            "label": "duties of Office for Civil Rights and Civil Liberties",
-            "notes": ""
+            "notes": "",
+            "text": "duties of Office for Civil Rights and Civil Liberties"
           },
           "type": "solutionComponent"
         },
@@ -30,8 +30,8 @@
           "id": "23f77b69-bbe5-42f2-8c9e-83750ae14c79",
           "data": {
             "customType": null,
-            "label": "receive and investigate public complaints re: Act's violations",
-            "notes": ""
+            "notes": "",
+            "text": "receive and investigate public complaints re: Act's violations"
           },
           "type": "solutionComponent"
         },
@@ -39,8 +39,8 @@
           "id": "0e6b7924-0baf-4e51-b112-088a1cb4c4e1",
           "data": {
             "customType": null,
-            "label": "advise compliance and corrective actions to relevant DHS* groups",
-            "notes": "*DHS: Department of Homeland Security"
+            "notes": "*DHS: Department of Homeland Security",
+            "text": "advise compliance and corrective actions to relevant DHS* groups"
           },
           "type": "solutionComponent"
         },
@@ -48,22 +48,26 @@
           "id": "5a9d03d4-4471-4bef-ac4a-2e7f71068222",
           "data": {
             "customType": null,
-            "label": "include its findings and actions re: this Act it its annual report",
-            "notes": ""
+            "notes": "",
+            "text": "include its findings and actions re: this Act it its annual report"
           },
           "type": "solutionComponent"
         },
         {
           "id": "943d8d9f-d2be-41ba-b204-68f9f75fa5d8",
-          "data": { "customType": null, "label": "encourages proper officer conduct", "notes": "" },
+          "data": {
+            "customType": null,
+            "notes": "",
+            "text": "encourages proper officer conduct"
+          },
           "type": "benefit"
         },
         {
           "id": "764e60a2-55d8-41b6-90fe-30bf0139873a",
           "data": {
             "customType": null,
-            "label": "could interfere with covert operations",
-            "notes": ""
+            "notes": "",
+            "text": "could interfere with covert operations"
           },
           "type": "detriment"
         },
@@ -71,9 +75,9 @@
           "id": "9fd0c1cf-22b7-4b79-bba0-6726e86f72ae",
           "data": {
             "customType": null,
-            "label": "\"could interfere with covert operations\" is an important Detriment in this topic",
             "notes": "",
-            "arguedDiagramPartId": "764e60a2-55d8-41b6-90fe-30bf0139873a"
+            "arguedDiagramPartId": "764e60a2-55d8-41b6-90fe-30bf0139873a",
+            "text": "\"could interfere with covert operations\" is an important Detriment in this topic"
           },
           "type": "rootClaim"
         },
@@ -81,9 +85,9 @@
           "id": "7463f6ed-ab02-4cfc-9320-67fe97a476a0",
           "data": {
             "customType": null,
-            "label": "this Act does not apply to covert operations",
             "notes": "",
-            "arguedDiagramPartId": "764e60a2-55d8-41b6-90fe-30bf0139873a"
+            "arguedDiagramPartId": "764e60a2-55d8-41b6-90fe-30bf0139873a",
+            "text": "this Act does not apply to covert operations"
           },
           "type": "critique"
         },
@@ -91,36 +95,44 @@
           "id": "6e86019f-2806-4c58-9d18-336e7b243b2b",
           "data": {
             "customType": null,
-            "label": "procedural burdens on officers during urgent enforcement actions",
-            "notes": ""
+            "notes": "",
+            "text": "procedural burdens on officers during urgent enforcement actions"
           },
           "type": "detriment"
         },
         {
           "id": "8ac1f9f2-c82b-47d3-9360-81d14115e43d",
-          "data": { "customType": null, "label": "increased response times", "notes": "" },
+          "data": {
+            "customType": null,
+            "notes": "",
+            "text": "increased response times"
+          },
           "type": "detriment"
         },
         {
           "id": "032f8fd2-a37c-4ba1-b0cf-b0c1a8831e18",
           "data": {
             "customType": null,
-            "label": "could endanger officers if identified in hostile environments",
-            "notes": ""
+            "notes": "",
+            "text": "could endanger officers if identified in hostile environments"
           },
           "type": "detriment"
         },
         {
           "id": "f80226b1-2aaa-4908-b1e8-0b18db700afb",
-          "data": { "customType": null, "label": "HR 4667: The VISIBLE Act of 2025", "notes": "" },
+          "data": {
+            "customType": null,
+            "notes": "",
+            "text": "HR 4667: The VISIBLE Act of 2025"
+          },
           "type": "solution"
         },
         {
           "id": "0d3301a2-777d-4796-baac-a47bb2bb6c3f",
           "data": {
             "customType": null,
-            "label": "transparency in public immigration enforcement",
-            "notes": ""
+            "notes": "",
+            "text": "transparency in public immigration enforcement"
           },
           "type": "benefit"
         },
@@ -128,27 +140,35 @@
           "id": "387ec5bd-7d9f-4458-9201-781d45a7b5c9",
           "data": {
             "customType": null,
-            "label": "accountability in public immigration enforcement",
-            "notes": ""
+            "notes": "",
+            "text": "accountability in public immigration enforcement"
           },
           "type": "benefit"
         },
         {
           "id": "a4047d3d-4c13-4fd6-8274-5aacd0e327b1",
-          "data": { "customType": null, "label": "public trust in government", "notes": "" },
+          "data": {
+            "customType": null,
+            "notes": "",
+            "text": "public trust in government"
+          },
           "type": "benefit"
         },
         {
           "id": "eebab2f4-3266-4df0-a16c-2b6dc4992860",
-          "data": { "customType": null, "label": "crumbling trust in government", "notes": "" },
+          "data": {
+            "customType": null,
+            "notes": "",
+            "text": "crumbling trust in government"
+          },
           "type": "problem"
         },
         {
           "id": "51ea45f5-0873-4bcd-b7b1-90072da0f1fc",
           "data": {
             "customType": null,
-            "label": "immigration officers can take extreme action but aren't held accountable",
-            "notes": ""
+            "notes": "",
+            "text": "immigration officers can take extreme action but aren't held accountable"
           },
           "type": "cause"
         },
@@ -156,8 +176,8 @@
           "id": "e8a84156-8da0-48d7-99e8-3d959691f616",
           "data": {
             "customType": null,
-            "label": "immigration officers wear masks to hide face",
-            "notes": ""
+            "notes": "",
+            "text": "immigration officers wear masks to hide face"
           },
           "type": "cause"
         },
@@ -165,8 +185,8 @@
           "id": "17e1022d-023f-4ea2-baa6-495af3cc7116",
           "data": {
             "customType": null,
-            "label": "immigration officers don't have clear identification visible",
-            "notes": ""
+            "notes": "",
+            "text": "immigration officers don't have clear identification visible"
           },
           "type": "cause"
         },
@@ -174,8 +194,8 @@
           "id": "4c6041b1-7099-46c7-ab6d-0687bdfd16cd",
           "data": {
             "customType": null,
-            "label": "officers may not wear non-medical face coverings",
-            "notes": ""
+            "notes": "",
+            "text": "officers may not wear non-medical face coverings"
           },
           "type": "solutionComponent"
         },
@@ -183,8 +203,8 @@
           "id": "b7abedfa-babb-4518-8705-efabdecb16b4",
           "data": {
             "customType": null,
-            "label": "exception: during covert, non-public operation",
-            "notes": ""
+            "notes": "",
+            "text": "exception: during covert, non-public operation"
           },
           "type": "solutionComponent"
         },
@@ -192,8 +212,8 @@
           "id": "862013f0-8a96-495e-8028-0cf076791741",
           "data": {
             "customType": null,
-            "label": "officers are visibly identifiable during public enforcement",
-            "notes": ""
+            "notes": "",
+            "text": "officers are visibly identifiable during public enforcement"
           },
           "type": "benefit"
         },
@@ -201,22 +221,26 @@
           "id": "32cff0ae-f4ac-45ce-90ab-fba154b948ea",
           "data": {
             "customType": null,
-            "label": "exception: to guard from hazardous environment conditions",
-            "notes": ""
+            "notes": "",
+            "text": "exception: to guard from hazardous environment conditions"
           },
           "type": "solutionComponent"
         },
         {
           "id": "82c3c52b-e290-4821-88df-d22e5d784431",
-          "data": { "customType": null, "label": "definitions", "notes": "" },
+          "data": {
+            "customType": null,
+            "notes": "",
+            "text": "definitions"
+          },
           "type": "solutionComponent"
         },
         {
           "id": "1178c091-69fc-4b6d-ab97-d35bdbe46ae8",
           "data": {
             "customType": null,
-            "label": "immigration officer",
-            "notes": "any individual authorized to perform immigration enforcement functions, and is 1. an employee of US Customs and Border Protection, 2. an employee of US Immigration and Customs Enforcement, or 3. an individual authorized under Federal law or agreement to perform immigration enforcement functions"
+            "notes": "any individual authorized to perform immigration enforcement functions, and is 1. an employee of US Customs and Border Protection, 2. an employee of US Immigration and Customs Enforcement, or 3. an individual authorized under Federal law or agreement to perform immigration enforcement functions",
+            "text": "immigration officer"
           },
           "type": "solutionComponent"
         },
@@ -224,8 +248,8 @@
           "id": "7b591e64-263c-43fb-93a9-58f223fce9d1",
           "data": {
             "customType": null,
-            "label": "public immigration enforcement function",
-            "notes": "any activity directly exercising Federal immigration authority through public-facing actions, include a patrol, stop, arrest, search, interview to determine immigrations tatus, raid, check-point inspection, or the service of a judicial or administrative warrant; and does not include covert, non-public operations or non-enforcement activities"
+            "notes": "any activity directly exercising Federal immigration authority through public-facing actions, include a patrol, stop, arrest, search, interview to determine immigrations tatus, raid, check-point inspection, or the service of a judicial or administrative warrant; and does not include covert, non-public operations or non-enforcement activities",
+            "text": "public immigration enforcement function"
           },
           "type": "solutionComponent"
         },
@@ -233,8 +257,8 @@
           "id": "19d8a422-949e-4b30-bf26-1e5bd0a8b9e9",
           "data": {
             "customType": null,
-            "label": "visible identification",
-            "notes": "a display of an immigration officer’s agency and name or badge number"
+            "notes": "a display of an immigration officer’s agency and name or badge number",
+            "text": "visible identification"
           },
           "type": "solutionComponent"
         },
@@ -242,8 +266,8 @@
           "id": "efad8213-8311-4546-a391-1d96e671423c",
           "data": {
             "customType": null,
-            "label": "accountability for compliance of this Act",
-            "notes": ""
+            "notes": "",
+            "text": "accountability for compliance of this Act"
           },
           "type": "solutionComponent"
         },
@@ -251,8 +275,8 @@
           "id": "f66cc82e-101f-4b39-9fec-2337073bcdb8",
           "data": {
             "customType": null,
-            "label": "officers must wear visible ID during public enforcement",
-            "notes": ""
+            "notes": "",
+            "text": "officers must wear visible ID during public enforcement"
           },
           "type": "solutionComponent"
         },
@@ -260,8 +284,8 @@
           "id": "902c1ddd-6ec5-4897-aac8-aafa6d291bb6",
           "data": {
             "customType": null,
-            "label": "full name or widely recognized initials of officer's agency",
-            "notes": ""
+            "notes": "",
+            "text": "full name or widely recognized initials of officer's agency"
           },
           "type": "solutionComponent"
         },
@@ -269,8 +293,8 @@
           "id": "e516d9c0-8500-45ee-a0cc-e61836396849",
           "data": {
             "customType": null,
-            "label": "officer's last name or unique badge/ID number",
-            "notes": ""
+            "notes": "",
+            "text": "officer's last name or unique badge/ID number"
           },
           "type": "solutionComponent"
         },
@@ -278,8 +302,8 @@
           "id": "9b242d65-d735-4def-9482-60210c0e9baf",
           "data": {
             "customType": null,
-            "label": "visibility requirements for worn identification",
-            "notes": ""
+            "notes": "",
+            "text": "visibility requirements for worn identification"
           },
           "type": "solutionComponent"
         },
@@ -287,8 +311,8 @@
           "id": "5dc7c0cc-d9b7-4a64-987e-1c4a99ce6c18",
           "data": {
             "customType": null,
-            "label": "agency: clearly legible from 25 feet in low-light conditions",
-            "notes": ""
+            "notes": "",
+            "text": "agency: clearly legible from 25 feet in low-light conditions"
           },
           "type": "solutionComponent"
         },
@@ -296,8 +320,8 @@
           "id": "ed00db2d-c6ea-43f1-9cd2-dcb12686f3a7",
           "data": {
             "customType": null,
-            "label": "Secretary of HS* ensures discipline for noncompliant officers",
-            "notes": "*HS: Homeland Security"
+            "notes": "*HS: Homeland Security",
+            "text": "Secretary of HS* ensures discipline for noncompliant officers"
           },
           "type": "solutionComponent"
         },
@@ -305,8 +329,8 @@
           "id": "9d4c3b1b-c500-491b-b34b-570f0be992cb",
           "data": {
             "customType": null,
-            "label": "officer info: clearly readable during direct engagement w/public",
-            "notes": ""
+            "notes": "",
+            "text": "officer info: clearly readable during direct engagement w/public"
           },
           "type": "solutionComponent"
         },
@@ -314,8 +338,8 @@
           "id": "fe82fb32-dafd-49b8-abcb-c92b0b695ce0",
           "data": {
             "customType": null,
-            "label": "displayed on outermost gear and not obscured by gear",
-            "notes": ""
+            "notes": "",
+            "text": "displayed on outermost gear and not obscured by gear"
           },
           "type": "solutionComponent"
         },
@@ -323,8 +347,8 @@
           "id": "59c4859b-e925-4a43-a00b-d1f2804823f3",
           "data": {
             "customType": null,
-            "label": "Secretary of Homeland Security submits annual report",
-            "notes": ""
+            "notes": "",
+            "text": "Secretary of Homeland Security submits annual report"
           },
           "type": "solutionComponent"
         },
@@ -332,8 +356,8 @@
           "id": "9381d6af-0a99-4c56-b20a-324fc6100d12",
           "data": {
             "customType": null,
-            "label": "number of public enforcement functions",
-            "notes": ""
+            "notes": "",
+            "text": "number of public enforcement functions"
           },
           "type": "solutionComponent"
         },
@@ -341,8 +365,8 @@
           "id": "bd75021c-edb2-4c73-a13d-94acaddc0272",
           "data": {
             "customType": null,
-            "label": "number of instances of noncompliance with this Act",
-            "notes": ""
+            "notes": "",
+            "text": "number of instances of noncompliance with this Act"
           },
           "type": "solutionComponent"
         },
@@ -350,8 +374,8 @@
           "id": "a19dec8f-930e-4499-9e4c-8820d31bcb79",
           "data": {
             "customType": null,
-            "label": "summary of disciplinary actions for noncompliance",
-            "notes": ""
+            "notes": "",
+            "text": "summary of disciplinary actions for noncompliance"
           },
           "type": "solutionComponent"
         }
@@ -359,275 +383,343 @@
       "edges": [
         {
           "id": "787cf32a-a69b-4692-bb88-323905d8382e",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "causes",
-          "source": "0d3301a2-777d-4796-baac-a47bb2bb6c3f",
-          "target": "a4047d3d-4c13-4fd6-8274-5aacd0e327b1",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "causes",
+          "sourceId": "0d3301a2-777d-4796-baac-a47bb2bb6c3f",
+          "targetId": "a4047d3d-4c13-4fd6-8274-5aacd0e327b1"
         },
         {
           "id": "a04c1d03-6d6a-4402-82ed-112c7dd83f33",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "causes",
-          "source": "51ea45f5-0873-4bcd-b7b1-90072da0f1fc",
-          "target": "eebab2f4-3266-4df0-a16c-2b6dc4992860",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "causes",
+          "sourceId": "51ea45f5-0873-4bcd-b7b1-90072da0f1fc",
+          "targetId": "eebab2f4-3266-4df0-a16c-2b6dc4992860"
         },
         {
           "id": "743dde95-3dcf-4ccd-b270-87f9d1f0997e",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "causes",
-          "source": "e8a84156-8da0-48d7-99e8-3d959691f616",
-          "target": "51ea45f5-0873-4bcd-b7b1-90072da0f1fc",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "causes",
+          "sourceId": "e8a84156-8da0-48d7-99e8-3d959691f616",
+          "targetId": "51ea45f5-0873-4bcd-b7b1-90072da0f1fc"
         },
         {
           "id": "14b3abd9-e212-459d-8fab-8d7c34e66dbb",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "causes",
-          "source": "17e1022d-023f-4ea2-baa6-495af3cc7116",
-          "target": "51ea45f5-0873-4bcd-b7b1-90072da0f1fc",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "causes",
+          "sourceId": "17e1022d-023f-4ea2-baa6-495af3cc7116",
+          "targetId": "51ea45f5-0873-4bcd-b7b1-90072da0f1fc"
         },
         {
           "id": "b0310cd3-f283-486c-955f-221a8802493b",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "addresses",
-          "source": "a4047d3d-4c13-4fd6-8274-5aacd0e327b1",
-          "target": "eebab2f4-3266-4df0-a16c-2b6dc4992860",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "addresses",
+          "sourceId": "a4047d3d-4c13-4fd6-8274-5aacd0e327b1",
+          "targetId": "eebab2f4-3266-4df0-a16c-2b6dc4992860"
         },
         {
           "id": "650c3681-8915-4b61-9e7d-474ecd3bbc5c",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "causes",
-          "source": "387ec5bd-7d9f-4458-9201-781d45a7b5c9",
-          "target": "a4047d3d-4c13-4fd6-8274-5aacd0e327b1",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "causes",
+          "sourceId": "387ec5bd-7d9f-4458-9201-781d45a7b5c9",
+          "targetId": "a4047d3d-4c13-4fd6-8274-5aacd0e327b1"
         },
         {
           "id": "84c98dc0-bfa5-4af4-a993-e92cd84b7ecb",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "causes",
-          "source": "862013f0-8a96-495e-8028-0cf076791741",
-          "target": "387ec5bd-7d9f-4458-9201-781d45a7b5c9",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "causes",
+          "sourceId": "862013f0-8a96-495e-8028-0cf076791741",
+          "targetId": "387ec5bd-7d9f-4458-9201-781d45a7b5c9"
         },
         {
           "id": "4baa1341-7ee5-4409-90e2-50ea8b0f00c0",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "causes",
-          "source": "862013f0-8a96-495e-8028-0cf076791741",
-          "target": "0d3301a2-777d-4796-baac-a47bb2bb6c3f",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "causes",
+          "sourceId": "862013f0-8a96-495e-8028-0cf076791741",
+          "targetId": "0d3301a2-777d-4796-baac-a47bb2bb6c3f"
         },
         {
           "id": "922d7824-9750-4b3d-847b-6243f66ed7e9",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "has",
-          "source": "f80226b1-2aaa-4908-b1e8-0b18db700afb",
-          "target": "82c3c52b-e290-4821-88df-d22e5d784431",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "has",
+          "sourceId": "f80226b1-2aaa-4908-b1e8-0b18db700afb",
+          "targetId": "82c3c52b-e290-4821-88df-d22e5d784431"
         },
         {
           "id": "3e3ada52-f94b-44c1-94a5-2b2d35dd47f7",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "has",
-          "source": "82c3c52b-e290-4821-88df-d22e5d784431",
-          "target": "1178c091-69fc-4b6d-ab97-d35bdbe46ae8",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "has",
+          "sourceId": "82c3c52b-e290-4821-88df-d22e5d784431",
+          "targetId": "1178c091-69fc-4b6d-ab97-d35bdbe46ae8"
         },
         {
           "id": "6908cf71-18f9-4875-9720-051377be9049",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "has",
-          "source": "82c3c52b-e290-4821-88df-d22e5d784431",
-          "target": "7b591e64-263c-43fb-93a9-58f223fce9d1",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "has",
+          "sourceId": "82c3c52b-e290-4821-88df-d22e5d784431",
+          "targetId": "7b591e64-263c-43fb-93a9-58f223fce9d1"
         },
         {
           "id": "3d8ca18b-879a-401f-9950-feedf05e107d",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "has",
-          "source": "82c3c52b-e290-4821-88df-d22e5d784431",
-          "target": "19d8a422-949e-4b30-bf26-1e5bd0a8b9e9",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "has",
+          "sourceId": "82c3c52b-e290-4821-88df-d22e5d784431",
+          "targetId": "19d8a422-949e-4b30-bf26-1e5bd0a8b9e9"
         },
         {
           "id": "a8ca4bcb-fcfb-4123-988c-66c0700abec3",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "has",
-          "source": "f80226b1-2aaa-4908-b1e8-0b18db700afb",
-          "target": "f66cc82e-101f-4b39-9fec-2337073bcdb8",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "has",
+          "sourceId": "f80226b1-2aaa-4908-b1e8-0b18db700afb",
+          "targetId": "f66cc82e-101f-4b39-9fec-2337073bcdb8"
         },
         {
           "id": "fb56612d-f895-4489-b25e-bed5ec602e04",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "has",
-          "source": "f66cc82e-101f-4b39-9fec-2337073bcdb8",
-          "target": "902c1ddd-6ec5-4897-aac8-aafa6d291bb6",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "has",
+          "sourceId": "f66cc82e-101f-4b39-9fec-2337073bcdb8",
+          "targetId": "902c1ddd-6ec5-4897-aac8-aafa6d291bb6"
         },
         {
           "id": "1e0f65d4-21b3-41ec-a1f9-077d43eea7c9",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "has",
-          "source": "f66cc82e-101f-4b39-9fec-2337073bcdb8",
-          "target": "e516d9c0-8500-45ee-a0cc-e61836396849",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "has",
+          "sourceId": "f66cc82e-101f-4b39-9fec-2337073bcdb8",
+          "targetId": "e516d9c0-8500-45ee-a0cc-e61836396849"
         },
         {
           "id": "199eb475-537a-4bc7-b6a7-20d5a871a05d",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "has",
-          "source": "f80226b1-2aaa-4908-b1e8-0b18db700afb",
-          "target": "9b242d65-d735-4def-9482-60210c0e9baf",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "has",
+          "sourceId": "f80226b1-2aaa-4908-b1e8-0b18db700afb",
+          "targetId": "9b242d65-d735-4def-9482-60210c0e9baf"
         },
         {
           "id": "07b35b19-8733-44dc-a61d-75fe77de830b",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "has",
-          "source": "9b242d65-d735-4def-9482-60210c0e9baf",
-          "target": "5dc7c0cc-d9b7-4a64-987e-1c4a99ce6c18",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "has",
+          "sourceId": "9b242d65-d735-4def-9482-60210c0e9baf",
+          "targetId": "5dc7c0cc-d9b7-4a64-987e-1c4a99ce6c18"
         },
         {
           "id": "fd4aac56-11d0-4391-b27e-7ef90948e7c4",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "has",
-          "source": "9b242d65-d735-4def-9482-60210c0e9baf",
-          "target": "9d4c3b1b-c500-491b-b34b-570f0be992cb",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "has",
+          "sourceId": "9b242d65-d735-4def-9482-60210c0e9baf",
+          "targetId": "9d4c3b1b-c500-491b-b34b-570f0be992cb"
         },
         {
           "id": "a076555f-4486-40f3-9dd0-d802cc461d24",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "has",
-          "source": "9b242d65-d735-4def-9482-60210c0e9baf",
-          "target": "fe82fb32-dafd-49b8-abcb-c92b0b695ce0",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "has",
+          "sourceId": "9b242d65-d735-4def-9482-60210c0e9baf",
+          "targetId": "fe82fb32-dafd-49b8-abcb-c92b0b695ce0"
         },
         {
           "id": "7c65086e-c678-4858-9ae1-0d92e5a18f54",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "has",
-          "source": "f80226b1-2aaa-4908-b1e8-0b18db700afb",
-          "target": "4c6041b1-7099-46c7-ab6d-0687bdfd16cd",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "has",
+          "sourceId": "f80226b1-2aaa-4908-b1e8-0b18db700afb",
+          "targetId": "4c6041b1-7099-46c7-ab6d-0687bdfd16cd"
         },
         {
           "id": "e1ab55d5-05a9-4d26-8a25-857b5cf7e816",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "has",
-          "source": "4c6041b1-7099-46c7-ab6d-0687bdfd16cd",
-          "target": "b7abedfa-babb-4518-8705-efabdecb16b4",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "has",
+          "sourceId": "4c6041b1-7099-46c7-ab6d-0687bdfd16cd",
+          "targetId": "b7abedfa-babb-4518-8705-efabdecb16b4"
         },
         {
           "id": "3c8547d9-398e-43b2-9af9-c2cead0d7fe3",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "has",
-          "source": "4c6041b1-7099-46c7-ab6d-0687bdfd16cd",
-          "target": "32cff0ae-f4ac-45ce-90ab-fba154b948ea",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "has",
+          "sourceId": "4c6041b1-7099-46c7-ab6d-0687bdfd16cd",
+          "targetId": "32cff0ae-f4ac-45ce-90ab-fba154b948ea"
         },
         {
           "id": "fe6565e7-a568-4397-93ec-449cdf03eee2",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "has",
-          "source": "f80226b1-2aaa-4908-b1e8-0b18db700afb",
-          "target": "efad8213-8311-4546-a391-1d96e671423c",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "has",
+          "sourceId": "f80226b1-2aaa-4908-b1e8-0b18db700afb",
+          "targetId": "efad8213-8311-4546-a391-1d96e671423c"
         },
         {
           "id": "26852f39-3450-4777-b4a1-35dc03d53202",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "has",
-          "source": "efad8213-8311-4546-a391-1d96e671423c",
-          "target": "ed00db2d-c6ea-43f1-9cd2-dcb12686f3a7",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "has",
+          "sourceId": "efad8213-8311-4546-a391-1d96e671423c",
+          "targetId": "ed00db2d-c6ea-43f1-9cd2-dcb12686f3a7"
         },
         {
           "id": "bc567e2f-e859-45d7-aea7-bd37fc0892e2",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "has",
-          "source": "efad8213-8311-4546-a391-1d96e671423c",
-          "target": "59c4859b-e925-4a43-a00b-d1f2804823f3",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "has",
+          "sourceId": "efad8213-8311-4546-a391-1d96e671423c",
+          "targetId": "59c4859b-e925-4a43-a00b-d1f2804823f3"
         },
         {
           "id": "bda35dab-aad8-432e-bb64-b955118f5133",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "has",
-          "source": "59c4859b-e925-4a43-a00b-d1f2804823f3",
-          "target": "9381d6af-0a99-4c56-b20a-324fc6100d12",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "has",
+          "sourceId": "59c4859b-e925-4a43-a00b-d1f2804823f3",
+          "targetId": "9381d6af-0a99-4c56-b20a-324fc6100d12"
         },
         {
           "id": "1e1d8bbd-09c3-45a8-985f-f86f9f3b5015",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "has",
-          "source": "59c4859b-e925-4a43-a00b-d1f2804823f3",
-          "target": "bd75021c-edb2-4c73-a13d-94acaddc0272",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "has",
+          "sourceId": "59c4859b-e925-4a43-a00b-d1f2804823f3",
+          "targetId": "bd75021c-edb2-4c73-a13d-94acaddc0272"
         },
         {
           "id": "f8da1301-f8d9-4556-85e1-857c83eff0ba",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "has",
-          "source": "59c4859b-e925-4a43-a00b-d1f2804823f3",
-          "target": "a19dec8f-930e-4499-9e4c-8820d31bcb79",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "has",
+          "sourceId": "59c4859b-e925-4a43-a00b-d1f2804823f3",
+          "targetId": "a19dec8f-930e-4499-9e4c-8820d31bcb79"
         },
         {
           "id": "5336eda0-90e9-4bbe-9962-e1e4db2ecb8b",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "has",
-          "source": "f80226b1-2aaa-4908-b1e8-0b18db700afb",
-          "target": "42c7137b-fa72-4f8f-b9a6-5d73c1c1752d",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "has",
+          "sourceId": "f80226b1-2aaa-4908-b1e8-0b18db700afb",
+          "targetId": "42c7137b-fa72-4f8f-b9a6-5d73c1c1752d"
         },
         {
           "id": "2a1849f0-019e-49fe-b91d-20f2f6aa0e5a",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "has",
-          "source": "42c7137b-fa72-4f8f-b9a6-5d73c1c1752d",
-          "target": "23f77b69-bbe5-42f2-8c9e-83750ae14c79",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "has",
+          "sourceId": "42c7137b-fa72-4f8f-b9a6-5d73c1c1752d",
+          "targetId": "23f77b69-bbe5-42f2-8c9e-83750ae14c79"
         },
         {
           "id": "206c37a2-a137-482c-893b-9594a3b81ea2",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "has",
-          "source": "42c7137b-fa72-4f8f-b9a6-5d73c1c1752d",
-          "target": "0e6b7924-0baf-4e51-b112-088a1cb4c4e1",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "has",
+          "sourceId": "42c7137b-fa72-4f8f-b9a6-5d73c1c1752d",
+          "targetId": "0e6b7924-0baf-4e51-b112-088a1cb4c4e1"
         },
         {
           "id": "bb721ab0-bb06-4b51-9ae9-2996a585121a",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "has",
-          "source": "42c7137b-fa72-4f8f-b9a6-5d73c1c1752d",
-          "target": "5a9d03d4-4471-4bef-ac4a-2e7f71068222",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "has",
+          "sourceId": "42c7137b-fa72-4f8f-b9a6-5d73c1c1752d",
+          "targetId": "5a9d03d4-4471-4bef-ac4a-2e7f71068222"
         },
         {
           "id": "8ae33359-1102-43b6-ab8b-4004a3e29338",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "causes",
-          "source": "387ec5bd-7d9f-4458-9201-781d45a7b5c9",
-          "target": "943d8d9f-d2be-41ba-b204-68f9f75fa5d8",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "causes",
+          "sourceId": "387ec5bd-7d9f-4458-9201-781d45a7b5c9",
+          "targetId": "943d8d9f-d2be-41ba-b204-68f9f75fa5d8"
         },
         {
           "id": "295778f9-be57-4c18-8f3a-60786c186c49",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "causes",
-          "source": "862013f0-8a96-495e-8028-0cf076791741",
-          "target": "764e60a2-55d8-41b6-90fe-30bf0139873a",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "causes",
+          "sourceId": "862013f0-8a96-495e-8028-0cf076791741",
+          "targetId": "764e60a2-55d8-41b6-90fe-30bf0139873a"
         },
         {
           "id": "17f584e8-4935-4644-b2f5-5eb2b37d4810",
@@ -636,74 +728,89 @@
             "notes": "",
             "arguedDiagramPartId": "764e60a2-55d8-41b6-90fe-30bf0139873a"
           },
-          "label": "critiques",
-          "source": "7463f6ed-ab02-4cfc-9320-67fe97a476a0",
-          "target": "9fd0c1cf-22b7-4b79-bba0-6726e86f72ae",
-          "type": "FlowEdge"
+          "type": "critiques",
+          "sourceId": "7463f6ed-ab02-4cfc-9320-67fe97a476a0",
+          "targetId": "9fd0c1cf-22b7-4b79-bba0-6726e86f72ae"
         },
         {
           "id": "9118aac4-4797-4de0-8d53-47ec9bd5927f",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "causes",
-          "source": "4c6041b1-7099-46c7-ab6d-0687bdfd16cd",
-          "target": "862013f0-8a96-495e-8028-0cf076791741",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "causes",
+          "sourceId": "4c6041b1-7099-46c7-ab6d-0687bdfd16cd",
+          "targetId": "862013f0-8a96-495e-8028-0cf076791741"
         },
         {
           "id": "dcbc7b69-4f15-4954-8979-d1d080525c1b",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "causes",
-          "source": "f66cc82e-101f-4b39-9fec-2337073bcdb8",
-          "target": "862013f0-8a96-495e-8028-0cf076791741",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "causes",
+          "sourceId": "f66cc82e-101f-4b39-9fec-2337073bcdb8",
+          "targetId": "862013f0-8a96-495e-8028-0cf076791741"
         },
         {
           "id": "aa73cb53-9acb-4217-86e1-45d633e9de72",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "causes",
-          "source": "9b242d65-d735-4def-9482-60210c0e9baf",
-          "target": "862013f0-8a96-495e-8028-0cf076791741",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "causes",
+          "sourceId": "9b242d65-d735-4def-9482-60210c0e9baf",
+          "targetId": "862013f0-8a96-495e-8028-0cf076791741"
         },
         {
           "id": "4438cf8b-f0c3-4015-bb1f-5bb36b2ba9be",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "causes",
-          "source": "f66cc82e-101f-4b39-9fec-2337073bcdb8",
-          "target": "6e86019f-2806-4c58-9d18-336e7b243b2b",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "causes",
+          "sourceId": "f66cc82e-101f-4b39-9fec-2337073bcdb8",
+          "targetId": "6e86019f-2806-4c58-9d18-336e7b243b2b"
         },
         {
           "id": "afd4fb92-0e1a-427c-83a2-ddaa82d09232",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "causes",
-          "source": "6e86019f-2806-4c58-9d18-336e7b243b2b",
-          "target": "8ac1f9f2-c82b-47d3-9360-81d14115e43d",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "causes",
+          "sourceId": "6e86019f-2806-4c58-9d18-336e7b243b2b",
+          "targetId": "8ac1f9f2-c82b-47d3-9360-81d14115e43d"
         },
         {
           "id": "a007342b-8bc7-46ff-b3a0-343730501bde",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "causes",
-          "source": "9b242d65-d735-4def-9482-60210c0e9baf",
-          "target": "6e86019f-2806-4c58-9d18-336e7b243b2b",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "causes",
+          "sourceId": "9b242d65-d735-4def-9482-60210c0e9baf",
+          "targetId": "6e86019f-2806-4c58-9d18-336e7b243b2b"
         },
         {
           "id": "9b03cae6-9e4e-4c81-94da-479a34ff22ae",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "causes",
-          "source": "862013f0-8a96-495e-8028-0cf076791741",
-          "target": "032f8fd2-a37c-4ba1-b0cf-b0c1a8831e18",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "causes",
+          "sourceId": "862013f0-8a96-495e-8028-0cf076791741",
+          "targetId": "032f8fd2-a37c-4ba1-b0cf-b0c1a8831e18"
         },
         {
           "id": "fc1c10cd-c41a-458b-a6b8-4e6e845a2075",
-          "data": { "customLabel": null, "notes": "" },
-          "label": "addresses",
-          "source": "943d8d9f-d2be-41ba-b204-68f9f75fa5d8",
-          "target": "51ea45f5-0873-4bcd-b7b1-90072da0f1fc",
-          "type": "FlowEdge"
+          "data": {
+            "customLabel": null,
+            "notes": ""
+          },
+          "type": "addresses",
+          "sourceId": "943d8d9f-d2be-41ba-b204-68f9f75fa5d8",
+          "targetId": "51ea45f5-0873-4bcd-b7b1-90072da0f1fc"
         }
       ],
       "userScores": {}
@@ -721,7 +828,10 @@
           "viewState": {
             "format": "diagram",
             "transposed": true,
-            "tableFilter": { "criteria": [], "solutions": [] },
+            "tableFilter": {
+              "criteria": [],
+              "solutions": []
+            },
             "generalFilter": {
               "nodeTypes": [],
               "nodesToHide": [],
@@ -732,13 +842,19 @@
               "showSecondaryResearch": false,
               "showSecondaryBreakdown": true
             },
-            "researchFilter": { "type": "none" },
-            "breakdownFilter": { "type": "none" },
+            "researchFilter": {
+              "type": "none"
+            },
+            "breakdownFilter": {
+              "type": "none"
+            },
             "categoriesToShow": ["breakdown"],
             "showImpliedEdges": false,
             "layoutThoroughness": 100,
             "selectedSummaryTab": "coreNodes",
-            "justificationFilter": { "type": "none" },
+            "justificationFilter": {
+              "type": "none"
+            },
             "forceNodesIntoLayers": true,
             "avoidEdgeLabelOverlap": true,
             "minimizeEdgeCrossings": true,
@@ -755,7 +871,10 @@
           "viewState": {
             "format": "summary",
             "transposed": true,
-            "tableFilter": { "criteria": [], "solutions": [] },
+            "tableFilter": {
+              "criteria": [],
+              "solutions": []
+            },
             "generalFilter": {
               "nodeTypes": [],
               "nodesToHide": [],
@@ -766,13 +885,19 @@
               "showSecondaryResearch": false,
               "showSecondaryBreakdown": true
             },
-            "researchFilter": { "type": "none" },
-            "breakdownFilter": { "type": "none" },
+            "researchFilter": {
+              "type": "none"
+            },
+            "breakdownFilter": {
+              "type": "none"
+            },
             "categoriesToShow": ["breakdown"],
             "showImpliedEdges": false,
             "layoutThoroughness": 100,
             "selectedSummaryTab": "components",
-            "justificationFilter": { "type": "none" },
+            "justificationFilter": {
+              "type": "none"
+            },
             "forceNodesIntoLayers": true,
             "avoidEdgeLabelOverlap": true,
             "minimizeEdgeCrossings": true,

--- a/src/api/topicAI.ts
+++ b/src/api/topicAI.ts
@@ -60,21 +60,21 @@ export const getRefinedVisibleAct = () => {
         return {
           tempId,
           type: node.type,
-          text: node.data.label,
+          text: node.data.text,
           notes: node.data.notes,
         };
       }),
     edgesToCreate: parsedVisibleAct.diagram.state.edges
       // TODO: remove `rootClaim` nodes so it's easier for an AI to use justification properly
-      .filter((edge) => !justificationRelationNames.includes(edge.label))
+      .filter((edge) => !justificationRelationNames.includes(edge.type))
       .map((edge) => {
-        const tempSourceId = tempNodeIds[edge.source];
-        const tempTargetId = tempNodeIds[edge.target];
+        const tempSourceId = tempNodeIds[edge.sourceId];
+        const tempTargetId = tempNodeIds[edge.targetId];
         if (tempSourceId === undefined || tempTargetId === undefined)
           throw new Error("Failed to refine visible act: couldn't find source/target nodes");
 
         return {
-          type: edge.label,
+          type: edge.type,
           notes: edge.data.notes,
           tempSourceId,
           tempTargetId,
@@ -86,7 +86,7 @@ export const getRefinedVisibleAct = () => {
 };
 
 const formatNode = (node: WebNode) => {
-  return `${node.type}: ${node.data.label}`;
+  return `${node.type}: ${node.data.text}`;
 };
 
 const formatNodeWithRelationDescription = (node: WebNode, relationDescription: string) => {

--- a/src/common/edge.ts
+++ b/src/common/edge.ts
@@ -105,13 +105,13 @@ export const diagramStoreEdgeSchema = z.object({
   id: z.string(),
   data: z.object({
     /**
-     * Distinguished from `label` because this is explicitly open user input, and `label` can maintain stricter typing
+     * Distinguished from `type` because this is explicitly open user input, and `type` can maintain stricter typing
      */
     customLabel: z.string().nullable(),
     notes: z.string(),
     arguedDiagramPartId: z.string().optional(),
   }),
-  label: zRelationNames,
+  type: zRelationNames,
   /**
    * id of the source graph part. Can be a node or an edge, but most UI edge operations only work
    * with node sources.
@@ -120,7 +120,7 @@ export const diagramStoreEdgeSchema = z.object({
    * regular edges can be distinguished. But that sounds like a lot of work and it's hard to tell
    * that it'd be worth it.
    */
-  source: z.string(), // arrows point from source to target
+  sourceId: z.string(), // arrows point from source to target
   /**
    * id of the target graph part. Can be a node or an edge, but most UI edge operations only work
    * with node targets.
@@ -129,8 +129,7 @@ export const diagramStoreEdgeSchema = z.object({
    * regular edges can be distinguished. But that sounds like a lot of work and it's hard to tell
    * that it'd be worth it.
    */
-  target: z.string(), // arrows point from source to target
-  type: z.literal("FlowEdge"),
+  targetId: z.string(), // arrows point from source to target
 });
 
 export const infoRelationNames: Record<InfoCategory, RelationName[]> = {

--- a/src/common/node.ts
+++ b/src/common/node.ts
@@ -163,7 +163,7 @@ export const diagramStoreNodeSchema = z.object({
      * Distinguished from `type` because this is explicitly open user input, and `type` can maintain stricter typing
      */
     customType: z.string().nullable(),
-    label: z.string(),
+    text: z.string(),
     notes: z.string(),
     arguedDiagramPartId: z.string().optional(),
   }),

--- a/src/web/common/components/ContextMenu/ChangeEdgeTypeMenuItem.tsx
+++ b/src/web/common/components/ContextMenu/ChangeEdgeTypeMenuItem.tsx
@@ -27,7 +27,7 @@ export const ChangeEdgeTypeMenuItem = ({ edge, parentMenuOpen }: Props) => {
   return (
     <>
       <NestedMenuItem label="Change edge type" parentMenuOpen={parentMenuOpen}>
-        {getSameCategoryEdgeTypes(edge.label).map((type) => (
+        {getSameCategoryEdgeTypes(edge.type).map((type) => (
           <ContextMenuItem
             key={type}
             onClick={() => {

--- a/src/web/common/components/ContextMenu/ViewContextInDiagramMenuItem.tsx
+++ b/src/web/common/components/ContextMenu/ViewContextInDiagramMenuItem.tsx
@@ -1,9 +1,9 @@
 import { ContextMenuItem } from "@/web/common/components/ContextMenu/CloseOnClickMenuItem";
 import { diagramPartContextMethods } from "@/web/topic/utils/diagramPartContext";
-import { GraphPart, isNode } from "@/web/topic/utils/graph";
+import { GraphPart } from "@/web/topic/utils/graph";
 
 export const ViewContextInDiagramMenuItem = ({ graphPart }: { graphPart: GraphPart }) => {
-  const partType = isNode(graphPart) ? graphPart.type : graphPart.label;
+  const partType = graphPart.type;
   const viewContext = diagramPartContextMethods[partType]?.viewContext;
 
   if (!viewContext) return <></>;

--- a/src/web/common/components/Form/NodeSelect.tsx
+++ b/src/web/common/components/Form/NodeSelect.tsx
@@ -25,7 +25,7 @@ export const NodeSelect = ({
     return nodeOptions.map((node) => {
       return {
         id: node.id,
-        label: node.data.label,
+        label: node.data.text,
         beforeSlot: <ColoredNodeIcon type={node.type} className="mr-2 rounded-sm p-0.5" />,
       };
     });

--- a/src/web/summary/aspectFilter.ts
+++ b/src/web/summary/aspectFilter.ts
@@ -86,13 +86,13 @@ export const getIncomingNodesByRelationDescription = (summaryNode: Node, graph: 
   const sourcesByRelationDescription = graph.edges
     .filter(
       (edge) =>
-        edge.target === summaryNode.id && getEdgeInfoCategory(edge.label) === nodeInfoCategory,
+        edge.targetId === summaryNode.id && getEdgeInfoCategory(edge.type) === nodeInfoCategory,
     )
     .reduce<Record<string, Node[]>>((acc, incomingEdge) => {
-      const incomingNode = findNodeOrThrow(incomingEdge.source, graph.nodes);
+      const incomingNode = findNodeOrThrow(incomingEdge.sourceId, graph.nodes);
       const relationDescription = getDirectedRelationDescription({
         source: incomingNode.type,
-        name: incomingEdge.label,
+        name: incomingEdge.type,
         target: summaryNode.type,
         as: "source",
       });
@@ -113,13 +113,13 @@ export const getOutgoingNodesByRelationDescription = (summaryNode: Node, graph: 
   const targetsByRelationDescription = graph.edges
     .filter(
       (edge) =>
-        edge.source === summaryNode.id && getEdgeInfoCategory(edge.label) === nodeInfoCategory,
+        edge.sourceId === summaryNode.id && getEdgeInfoCategory(edge.type) === nodeInfoCategory,
     )
     .reduce<Record<string, Node[]>>((acc, sourceEdge) => {
-      const targetNode = findNodeOrThrow(sourceEdge.target, graph.nodes);
+      const targetNode = findNodeOrThrow(sourceEdge.targetId, graph.nodes);
       const relationDescription = getDirectedRelationDescription({
         source: summaryNode.type,
-        name: sourceEdge.label,
+        name: sourceEdge.type,
         target: targetNode.type,
         as: "target",
       });

--- a/src/web/topic/components/CriteriaTable/CriteriaTable.tsx
+++ b/src/web/topic/components/CriteriaTable/CriteriaTable.tsx
@@ -56,7 +56,7 @@ interface HeaderCell extends Cell {
 const buildNodeHeader = (node: Node): HeaderCell => {
   return {
     id: node.id,
-    label: node.data.label,
+    label: node.data.text,
     data: node,
     render: () => <NodeCell node={node} />,
   };

--- a/src/web/topic/components/Edge/ScoreEdge.tsx
+++ b/src/web/topic/components/Edge/ScoreEdge.tsx
@@ -78,7 +78,7 @@ export const ScoreEdge = ({ edge, edgeLayoutData, inReactFlow }: Props) => {
     />
   );
 
-  const labelText = edge.data.customLabel ?? lowerCase(edge.label);
+  const labelText = edge.data.customLabel ?? lowerCase(edge.type);
 
   const label = (
     <StyledDiv
@@ -108,7 +108,7 @@ export const ScoreEdge = ({ edge, edgeLayoutData, inReactFlow }: Props) => {
         suppressContentEditableWarning // https://stackoverflow.com/a/49639256/8409296
         onBlur={(event) => {
           const text = event.target.textContent.trim();
-          if (text && text !== lowerCase(edge.label) && text !== edge.data.customLabel)
+          if (text && text !== lowerCase(edge.type) && text !== edge.data.customLabel)
             setCustomEdgeLabel(edge, text);
         }}
         // without nopan, clicking on the span won't let you edit text

--- a/src/web/topic/components/Edge/StandaloneEdge.tsx
+++ b/src/web/topic/components/Edge/StandaloneEdge.tsx
@@ -12,8 +12,8 @@ interface Props {
 }
 
 export const StandaloneEdge = ({ edge }: Props) => {
-  const sourceNode = useNode(edge.source);
-  const targetNode = useNode(edge.target);
+  const sourceNode = useNode(edge.sourceId);
+  const targetNode = useNode(edge.targetId);
 
   if (!sourceNode || !targetNode) {
     return <p>Could not find edge data!</p>;

--- a/src/web/topic/components/ImpliedClaimText.tsx
+++ b/src/web/topic/components/ImpliedClaimText.tsx
@@ -16,7 +16,7 @@ export const ImpliedClaimText = ({ graphPart }: { graphPart: GraphPart }) => {
   if (isNode) {
     return (
       <i>
-        "{graphPart.data.label}" <b>is an important {prettyNodeTypes[graphPart.type]}</b> in this
+        "{graphPart.data.text}" <b>is an important {prettyNodeTypes[graphPart.type]}</b> in this
         topic
       </i>
     );
@@ -25,12 +25,12 @@ export const ImpliedClaimText = ({ graphPart }: { graphPart: GraphPart }) => {
 
     return (
       <i>
-        <b>{prettyNodeTypes[edgeSourceNode.type]}</b> "{edgeSourceNode.data.label}"{" "}
+        <b>{prettyNodeTypes[edgeSourceNode.type]}</b> "{edgeSourceNode.data.text}"{" "}
         <b>
-          {lowerCase(graphPart.data.customLabel ?? graphPart.label)}{" "}
+          {lowerCase(graphPart.data.customLabel ?? graphPart.type)}{" "}
           {prettyNodeTypes[edgeTargetNode.type]}
         </b>{" "}
-        "{edgeTargetNode.data.label}"
+        "{edgeTargetNode.data.text}"
       </i>
     );
   }

--- a/src/web/topic/components/Indicator/ContextIndicator.tsx
+++ b/src/web/topic/components/Indicator/ContextIndicator.tsx
@@ -4,7 +4,7 @@ import { useContext } from "react";
 import { ViewIndicator } from "@/web/topic/components/Indicator/Base/ViewIndicator";
 import { WorkspaceContext } from "@/web/topic/components/TopicWorkspace/WorkspaceContext";
 import { diagramPartContextMethods } from "@/web/topic/utils/diagramPartContext";
-import { GraphPart, isNode } from "@/web/topic/utils/graph";
+import { GraphPart } from "@/web/topic/utils/graph";
 
 interface Props {
   graphPart: GraphPart;
@@ -13,14 +13,14 @@ interface Props {
 export const ContextIndicator = ({ graphPart }: Props) => {
   const workspaceContext = useContext(WorkspaceContext);
 
-  const type = isNode(graphPart) ? graphPart.type : graphPart.label;
-
   // Fulfills edges could show between criterion and benefits, but we only care about those between criterion and solutions.
   // The simple jank-ish solution is to only show this indicator in the table view (for fulfills edges), since that'll only show criterion-solution edges.
   // We likely won't care about this indicator for fulfills edges in the diagram view anyway.
-  const fulfillsOutOfTable = type === "fulfills" && workspaceContext !== "table";
+  const fulfillsOutOfTable = graphPart.type === "fulfills" && workspaceContext !== "table";
 
-  const partContextMethods = fulfillsOutOfTable ? undefined : diagramPartContextMethods[type];
+  const partContextMethods = fulfillsOutOfTable
+    ? undefined
+    : diagramPartContextMethods[graphPart.type];
 
   const useHasContext = partContextMethods?.useHasContext ?? (() => false);
   const hasContext = useHasContext(graphPart.id);

--- a/src/web/topic/components/Node/AddNodeButtonGroup.tsx
+++ b/src/web/topic/components/Node/AddNodeButtonGroup.tsx
@@ -28,7 +28,7 @@ import { useExpandAddNodeButtons } from "@/web/view/userConfigStore/store";
 
 const getOptionText = (node: Node) => {
   const title = prettyNodeTypes[node.type];
-  return `${title}: ${node.data.label}`;
+  return `${title}: ${node.data.text}`;
 };
 
 interface AddMenuSearchProps {
@@ -135,7 +135,7 @@ const AddMenuSearch = ({ fromNodeId, addableRelations, className }: AddMenuSearc
                   : optionText}
                 <i className="text-slate-400">
                   {/* ideally the `existingEdge` would probably use the same format of relation description, but that'd require grabbing the source/target node types from the edge, which is a bit annoying to do, and showing at least the edge label seems fine enough */}
-                  {` (${option.addableRelationToNode ? getDirectedRelationDescription(option.addableRelationToNode) : option.existingEdge.label})`}
+                  {` (${option.addableRelationToNode ? getDirectedRelationDescription(option.addableRelationToNode) : option.existingEdge.type})`}
                 </i>
               </span>
             </div>

--- a/src/web/topic/components/Node/EditableNode.tsx
+++ b/src/web/topic/components/Node/EditableNode.tsx
@@ -200,7 +200,7 @@ const EditableNodeBase = ({ node, className = "", onClick }: Props) => {
         <MiddleDiv className="flex grow px-1 pt-1 pb-2">
           <NodeTextArea
             nodeId={node.id}
-            nodeText={node.data.label}
+            nodeText={node.data.text}
             context={context}
             editable={userCanEditTopicData}
           />

--- a/src/web/topic/components/Node/FocusNodeAttachment.tsx
+++ b/src/web/topic/components/Node/FocusNodeAttachment.tsx
@@ -26,7 +26,7 @@ const NodeSummary = ({ node, beforeSlot }: { node: Node; beforeSlot?: ReactNode 
   const { NodeIcon } = nodeDecorations[node.type];
   const title = prettyNodeTypes[node.type];
 
-  const summary = `${title}: ${node.data.label}`;
+  const summary = `${title}: ${node.data.text}`;
 
   return (
     <div className="flex items-center text-nowrap">

--- a/src/web/topic/components/Node/IconNode.tsx
+++ b/src/web/topic/components/Node/IconNode.tsx
@@ -28,7 +28,7 @@ export const IconNode = ({ node, className, onClick }: Props) => {
   const NodeIcon = nodeDecorations[node.type].NodeIcon;
 
   const typeText = node.data.customType ?? prettyNodeTypes[node.type];
-  const nodeDescription = `${typeText}: ${node.data.label}`;
+  const nodeDescription = `${typeText}: ${node.data.text}`;
 
   const tooltipBody = (
     // Slight hack to ensure that the tooltip node doesn't animate towards/from a currently-showing node, which would cause that node to disappear.

--- a/src/web/topic/components/Node/NodeTextArea.tsx
+++ b/src/web/topic/components/Node/NodeTextArea.tsx
@@ -7,7 +7,7 @@ import { hasSeenTrigger } from "@/web/common/components/InfoDialog/infoDialogSto
 import { showInfo } from "@/web/common/components/InfoDialog/infoEvents";
 import { clearNewlyAddedNode, isNodeNewlyAdded } from "@/web/common/store/ephemeralStore";
 import { WorkspaceContextType } from "@/web/topic/components/TopicWorkspace/WorkspaceContext";
-import { setNodeLabel } from "@/web/topic/diagramStore/actions";
+import { setNodeText } from "@/web/topic/diagramStore/actions";
 
 // If we had to resize, make sure the user knows that text should be concise.
 const onFontResize = (textAreaId: string) => {
@@ -176,7 +176,7 @@ const NodeTextAreaBase = ({ nodeId, nodeText, context, editable }: Props) => {
       }}
       onBlur={(event) => {
         if (textAreaSelected) setTextAreaSelected(false);
-        if (event.target.value !== nodeText) setNodeLabel(nodeId, event.target.value);
+        if (event.target.value !== nodeText) setNodeText(nodeId, event.target.value);
       }}
       onChange={(event) => {
         const resized = fitTextIntoElement(event.target);

--- a/src/web/topic/diagramStore/actions.ts
+++ b/src/web/topic/diagramStore/actions.ts
@@ -50,16 +50,16 @@ export const setScore = (username: string, graphPartId: string, score: Score) =>
   useDiagramStore.setState(finishDraft(state), false, "setScore");
 };
 
-export const setNodeLabel = (nodeId: string, value: string) => {
+export const setNodeText = (nodeId: string, value: string) => {
   const state = createDraft(useDiagramStore.getState());
 
   const foundNode = findNodeOrThrow(nodeId, state.nodes);
 
   /* eslint-disable functional/immutable-data */
-  foundNode.data.label = value;
+  foundNode.data.text = value;
   /* eslint-enable functional/immutable-data */
 
-  useDiagramStore.setState(finishDraft(state), false, "setNodeLabel");
+  useDiagramStore.setState(finishDraft(state), false, "setNodeText");
 };
 
 export const setCustomNodeType = (node: Node, value: string) => {
@@ -80,7 +80,7 @@ export const setCustomNodeType = (node: Node, value: string) => {
   foundNode.data.customType = value;
   /* eslint-enable functional/immutable-data */
 
-  useDiagramStore.setState(finishDraft(state), false, "setCustomEdgeLabel");
+  useDiagramStore.setState(finishDraft(state), false, "setCustomNodeType");
 };
 
 export const setCustomEdgeLabel = (edge: Edge, value: string) => {
@@ -123,7 +123,7 @@ export const changeEdgeType = (edge: Edge, newType: RelationName) => {
   const foundEdge = findEdgeOrThrow(edge.id, state.edges);
 
   /* eslint-disable functional/immutable-data */
-  foundEdge.label = newType;
+  foundEdge.type = newType;
   foundEdge.data.customLabel = null; // reset custom label so new type is used for label
   /* eslint-enable functional/immutable-data */
 

--- a/src/web/topic/diagramStore/createDeleteActions.ts
+++ b/src/web/topic/diagramStore/createDeleteActions.ts
@@ -19,7 +19,7 @@ import {
   findNodeOrThrow,
   isNode,
 } from "@/web/topic/utils/graph";
-import { getImplicitLabel } from "@/web/topic/utils/justification";
+import { getImplicitText } from "@/web/topic/utils/justification";
 import { edges } from "@/web/topic/utils/node";
 import { setSelected } from "@/web/view/selectedPartStore";
 
@@ -53,13 +53,13 @@ const connectCriteriaToSolutions = (state: DiagramStoreState, newNode: Node, pro
   const newCriterionEdges = state.edges
     .filter(
       (edge) =>
-        edge.target === problemNode.id &&
-        edge.label === targetRelation.name &&
-        findNodeOrThrow(edge.source, state.nodes).type === targetRelation.source,
+        edge.targetId === problemNode.id &&
+        edge.type === targetRelation.name &&
+        findNodeOrThrow(edge.sourceId, state.nodes).type === targetRelation.source,
     )
     .map((edge) => {
-      const sourceId = newNode.type === "criterion" ? edge.source : newNode.id; // point from other solutions to this criterion
-      const targetId = newNode.type === "criterion" ? newNode.id : edge.source; // point from this solution to other criteria
+      const sourceId = newNode.type === "criterion" ? edge.sourceId : newNode.id; // point from other solutions to this criterion
+      const targetId = newNode.type === "criterion" ? newNode.id : edge.sourceId; // point from this solution to other criteria
 
       return buildEdge({
         sourceId,
@@ -99,9 +99,9 @@ export const addNode = ({ fromPartId, directedRelation, context, selectNewNode }
         (node.data.arguedDiagramPartId === fromPartId || node.id === fromPartId),
     )
   ) {
-    const label = getImplicitLabel(fromPartId, topicGraph);
+    const text = getImplicitText(fromPartId, topicGraph);
     // eslint-disable-next-line functional/immutable-data
-    state.nodes.push(buildNode({ type: "rootClaim", arguedDiagramPartId: fromPartId, label }));
+    state.nodes.push(buildNode({ type: "rootClaim", arguedDiagramPartId: fromPartId, text }));
   }
 
   const rootClaim =

--- a/src/web/topic/diagramStore/edgeHooks.ts
+++ b/src/web/topic/diagramStore/edgeHooks.ts
@@ -37,7 +37,7 @@ export const useIsTableEdge = (edgeId: string) => {
   return useDiagramStore((state) => {
     try {
       const edge = findEdgeOrThrow(edgeId, state.edges);
-      if (edge.label !== "fulfills") return false;
+      if (edge.type !== "fulfills") return false;
 
       const [sourceNode, targetNode] = nodes(edge, state.nodes);
       return sourceNode.type === "solution" && targetNode.type === "criterion";

--- a/src/web/topic/diagramStore/graphPartHooks.ts
+++ b/src/web/topic/diagramStore/graphPartHooks.ts
@@ -43,17 +43,19 @@ export const useTopLevelJustification = (graphPartId: string) => {
 
     const topLevelJustificationEdges = state.edges.filter(
       (edge) =>
-        justificationRelationNames.includes(edge.label) &&
-        edge.target === nodeToCheckForJustification.id,
+        justificationRelationNames.includes(edge.type) &&
+        edge.targetId === nodeToCheckForJustification.id,
     );
 
     const supports = topLevelJustificationEdges
-      .map((edge) => state.nodes.find((node) => node.id === edge.source && node.type === "support"))
+      .map((edge) =>
+        state.nodes.find((node) => node.id === edge.sourceId && node.type === "support"),
+      )
       .filter((node): node is Node => !!node);
 
     const critiques = topLevelJustificationEdges
       .map((edge) =>
-        state.nodes.find((node) => node.id === edge.source && node.type === "critique"),
+        state.nodes.find((node) => node.id === edge.sourceId && node.type === "critique"),
       )
       .filter((node): node is Node => !!node);
 
@@ -69,7 +71,7 @@ export const useNonTopLevelJustificationCount = (graphPartId: string) => {
     if (!rootClaim) return 0;
 
     return state.edges.filter(
-      (edge) => edge.data.arguedDiagramPartId === graphPartId && edge.target !== rootClaim.id,
+      (edge) => edge.data.arguedDiagramPartId === graphPartId && edge.targetId !== rootClaim.id,
     ).length;
   });
 };
@@ -79,7 +81,7 @@ export const useResearchNodes = (graphPartId: string) => {
     const researchNodes = state.nodes.filter(
       (node) =>
         researchNodeTypes.includes(node.type) &&
-        state.edges.find((edge) => edge.source === node.id && edge.target === graphPartId),
+        state.edges.find((edge) => edge.sourceId === node.id && edge.targetId === graphPartId),
     );
 
     return {

--- a/src/web/topic/diagramStore/migrate.ts
+++ b/src/web/topic/diagramStore/migrate.ts
@@ -34,6 +34,7 @@ export const migrate = (persistedState: any, version: number) => {
     migrate_24_to_25,
     migrate_25_to_26,
     migrate_26_to_27,
+    migrate_27_to_28,
   ];
 
   let state = persistedState;
@@ -687,6 +688,58 @@ const migrate_26_to_27 = (state: State26) => {
     if (newLabel) {
       (edge.label as Relation27) = newLabel;
     }
+  });
+
+  return state;
+};
+
+interface Node27 {
+  data: {
+    label?: string;
+  };
+}
+
+interface Edge27 {
+  label?: string;
+  source?: string;
+  target?: string;
+  type: string;
+}
+
+interface State27 {
+  nodes: Node27[];
+  edges: Edge27[];
+}
+
+interface Node28 {
+  data: {
+    text?: string;
+  };
+}
+
+interface Edge28 {
+  sourceId?: string;
+  targetId?: string;
+  type?: string;
+}
+
+const migrate_27_to_28 = (state: State27) => {
+  // rename node data.label to data.text
+  state.nodes.forEach((node) => {
+    (node as unknown as Node28).data.text = node.data.label;
+    delete node.data.label;
+  });
+
+  // rename edge label to type, remove old type ("FlowEdge"), rename source/target to sourceId/targetId
+  state.edges.forEach((edge) => {
+    (edge as unknown as Edge28).type = edge.label;
+    delete edge.label;
+
+    (edge as unknown as Edge28).sourceId = edge.source;
+    delete edge.source;
+
+    (edge as unknown as Edge28).targetId = edge.target;
+    delete edge.target;
   });
 
   return state;

--- a/src/web/topic/diagramStore/nodeHooks.ts
+++ b/src/web/topic/diagramStore/nodeHooks.ts
@@ -65,8 +65,8 @@ export const useConnectableNodes = (fromNodeId: string, addableRelations: Direct
 
         const existingEdge = state.edges.find(
           (edge) =>
-            (edge.source === fromNodeId && edge.target === toNode.id) ||
-            (edge.target === fromNodeId && edge.source === toNode.id),
+            (edge.sourceId === fromNodeId && edge.targetId === toNode.id) ||
+            (edge.targetId === fromNodeId && edge.sourceId === toNode.id),
         );
 
         if (existingEdge) return { ...toNode, existingEdge };
@@ -151,7 +151,7 @@ export const useCriterionSolutionEdges = (problemNodeId: string | undefined) => 
       const solutionIds = solutions.map((node) => node.id);
 
       return topicGraph.edges.filter((edge) => {
-        return solutionIds.includes(edge.source) && criteriaIds.includes(edge.target);
+        return solutionIds.includes(edge.sourceId) && criteriaIds.includes(edge.targetId);
       });
     } catch {
       return [];
@@ -224,7 +224,7 @@ export const useSolutions = (problemId?: string) => {
     const problemSolutions = solutions.filter((solution) =>
       state.edges.find(
         (edge) =>
-          edge.source === solution.id && edge.label === "addresses" && edge.target === problemId,
+          edge.sourceId === solution.id && edge.type === "addresses" && edge.targetId === problemId,
       ),
     );
 
@@ -240,9 +240,9 @@ export const useCriteria = (problemId?: string) => {
     const problemCriteria = criteria.filter((criterion) =>
       state.edges.find(
         (edge) =>
-          edge.source === criterion.id &&
-          edge.label === "criterionFor" &&
-          edge.target === problemId,
+          edge.sourceId === criterion.id &&
+          edge.type === "criterionFor" &&
+          edge.targetId === problemId,
       ),
     );
 

--- a/src/web/topic/diagramStore/nodeTypeHooks.ts
+++ b/src/web/topic/diagramStore/nodeTypeHooks.ts
@@ -17,17 +17,17 @@ export const useQuestionDetails = (questionNodeId: string) => {
   return useDiagramStore((state) => {
     try {
       const asksAboutEdge = state.edges.find(
-        (edge) => edge.source === questionNodeId && edge.label === "asksAbout",
+        (edge) => edge.sourceId === questionNodeId && edge.type === "asksAbout",
       );
       const partAskingAbout = asksAboutEdge
-        ? findGraphPartOrThrow(asksAboutEdge.target, state.nodes, state.edges)
+        ? findGraphPartOrThrow(asksAboutEdge.targetId, state.nodes, state.edges)
         : null;
 
       const answerEdges = state.edges.filter(
-        (edge) => edge.target === questionNodeId && edge.label === "potentialAnswerTo",
+        (edge) => edge.targetId === questionNodeId && edge.type === "potentialAnswerTo",
       );
       const answers = state.nodes.filter((node) =>
-        answerEdges.some((edge) => edge.source === node.id),
+        answerEdges.some((edge) => edge.sourceId === node.id),
       );
 
       return { partAskingAbout, answers };
@@ -41,9 +41,9 @@ export const useAnswerDetails = (answerNodeId: string) => {
   return useDiagramStore((state) => {
     try {
       const answerToEdge = state.edges.find(
-        (edge) => edge.source === answerNodeId && edge.label === "potentialAnswerTo",
+        (edge) => edge.sourceId === answerNodeId && edge.type === "potentialAnswerTo",
       );
-      const question = answerToEdge ? findNodeOrThrow(answerToEdge.target, state.nodes) : null;
+      const question = answerToEdge ? findNodeOrThrow(answerToEdge.targetId, state.nodes) : null;
       return { question };
     } catch {
       return { question: null };
@@ -54,21 +54,21 @@ export const useAnswerDetails = (answerNodeId: string) => {
 export const useFactDetails = (factNodeId: string) => {
   return useDiagramStore((state) => {
     const relevantForEdges = state.edges.filter(
-      (edge) => edge.source === factNodeId && edge.label === "relevantFor",
+      (edge) => edge.sourceId === factNodeId && edge.type === "relevantFor",
     );
 
     const nodesRelevantFor = state.nodes.filter((node) =>
-      relevantForEdges.some((relevantForEdge) => relevantForEdge.target === node.id),
+      relevantForEdges.some((relevantForEdge) => relevantForEdge.targetId === node.id),
     );
     const edgesRelevantFor = state.edges.filter((edge) =>
-      relevantForEdges.some((relevantForEdge) => relevantForEdge.target === edge.id),
+      relevantForEdges.some((relevantForEdge) => relevantForEdge.targetId === edge.id),
     );
 
     const sourceEdges = state.edges.filter(
-      (edge) => edge.target === factNodeId && edge.label === "sourceOf",
+      (edge) => edge.targetId === factNodeId && edge.type === "sourceOf",
     );
     const sources = state.nodes.filter((node) =>
-      sourceEdges.some((sourceEdge) => node.id === sourceEdge.source),
+      sourceEdges.some((sourceEdge) => node.id === sourceEdge.sourceId),
     );
 
     return { nodesRelevantFor, edgesRelevantFor, sources };
@@ -78,28 +78,28 @@ export const useFactDetails = (factNodeId: string) => {
 export const useSourceDetails = (sourceNodeId: string) => {
   return useDiagramStore((state) => {
     const relevantForEdges = state.edges.filter(
-      (edge) => edge.source === sourceNodeId && edge.label === "relevantFor",
+      (edge) => edge.sourceId === sourceNodeId && edge.type === "relevantFor",
     );
 
     const nodesRelevantFor = state.nodes.filter((node) =>
-      relevantForEdges.some((relevantForEdge) => relevantForEdge.target === node.id),
+      relevantForEdges.some((relevantForEdge) => relevantForEdge.targetId === node.id),
     );
     const edgesRelevantFor = state.edges.filter((edge) =>
-      relevantForEdges.some((relevantForEdge) => relevantForEdge.target === edge.id),
+      relevantForEdges.some((relevantForEdge) => relevantForEdge.targetId === edge.id),
     );
 
     const factEdges = state.edges.filter(
-      (edge) => edge.source === sourceNodeId && edge.label === "sourceOf",
+      (edge) => edge.sourceId === sourceNodeId && edge.type === "sourceOf",
     );
     const facts = state.nodes.filter((node) =>
-      factEdges.some((factEdge) => node.id === factEdge.target),
+      factEdges.some((factEdge) => node.id === factEdge.targetId),
     );
 
     const mentionEdges = state.edges.filter(
-      (edge) => edge.source === sourceNodeId && edge.label === "mentions",
+      (edge) => edge.sourceId === sourceNodeId && edge.type === "mentions",
     );
     const mentionedSources = state.nodes.filter((node) =>
-      mentionEdges.some((mentionEdge) => node.id === mentionEdge.target),
+      mentionEdges.some((mentionEdge) => node.id === mentionEdge.targetId),
     );
 
     return { nodesRelevantFor, edgesRelevantFor, facts, mentionedSources };

--- a/src/web/topic/diagramStore/partContextHooks.ts
+++ b/src/web/topic/diagramStore/partContextHooks.ts
@@ -66,7 +66,7 @@ export const useFulfillsHasContext = (fulfillsEdgeId: string) => {
       // - remove reactiveness from the context indicator
       const { nodes } = applyTradeoffsFilter(topicGraph, filter);
       const contextNodes = nodes.filter(
-        (node) => node.id !== fulfillsEdge.source && node.id !== fulfillsEdge.target,
+        (node) => node.id !== fulfillsEdge.sourceId && node.id !== fulfillsEdge.targetId,
       );
 
       return contextNodes.length > 0;

--- a/src/web/topic/diagramStore/scoreHooks.ts
+++ b/src/web/topic/diagramStore/scoreHooks.ts
@@ -56,21 +56,21 @@ export const useSolutionTotal = (solution: Node, problem: Node) => {
     );
     const criteriaSolutionEdges = compact(
       criteriaForProblem.map((criterion) =>
-        edges(criterion, state.edges).find((edge) => edge.source === solution.id),
+        edges(criterion, state.edges).find((edge) => edge.sourceId === solution.id),
       ),
     );
 
     return criteriaSolutionEdges;
   });
 
-  const graphPartIds = criteriaSolutionEdges.flatMap((edge) => [edge.id, edge.target]);
+  const graphPartIds = criteriaSolutionEdges.flatMap((edge) => [edge.id, edge.targetId]);
   const { scoresByGraphPartId: scores } = useDisplayScores(graphPartIds);
 
   return sum(
     criteriaSolutionEdges.map((edge) => {
       const edgeScore = scores[edge.id] ?? throwError(`No score found for edge ${edge.id}`);
       const criterionScore =
-        scores[edge.target] ?? throwError(`No score found for criterion ${edge.target}`);
+        scores[edge.targetId] ?? throwError(`No score found for criterion ${edge.targetId}`);
 
       // use a (-4,4) range for the edge because low means doesn't embody, high means does
       // use a (0,8) range for the criterion because it's just importance, and should therefore just increase/decrease emphasis of the edge score

--- a/src/web/topic/diagramStore/store.ts
+++ b/src/web/topic/diagramStore/store.ts
@@ -33,7 +33,7 @@ export const initialState: DiagramStoreState = {
 };
 
 export const diagramStorePlaygroundName = "diagram-storage";
-export const currentDiagramVersion = 27;
+export const currentDiagramVersion = 28;
 
 // create atomic selectors for usage outside of store/ dir
 // this is only exported to allow actions to be extracted to a separate file

--- a/src/web/topic/diagramStore/utils.ts
+++ b/src/web/topic/diagramStore/utils.ts
@@ -5,5 +5,5 @@ export const getTopicTitleFromNodes = (state: DiagramStoreState) => {
   const rootNode = state.nodes[0];
   if (!rootNode) throw errorWithData("diagram has no root node", state.nodes);
 
-  return rootNode.data.label;
+  return rootNode.data.text;
 };

--- a/src/web/topic/hooks/diagramHooks.ts
+++ b/src/web/topic/hooks/diagramHooks.ts
@@ -24,8 +24,8 @@ export const useLayoutedDiagram = (diagram: Diagram) => {
     // not 100% sure that it's worth re-laying out when node text changes, but we can easily remove if it doesn't seem like it
     .map((graphPart) =>
       isNode(graphPart)
-        ? graphPart.id + graphPart.data.label + graphPart.type
-        : graphPart.id + graphPart.label,
+        ? graphPart.id + graphPart.data.text + graphPart.type
+        : graphPart.id + graphPart.type,
     )
     .concat(
       String(forceNodesIntoLayers),

--- a/src/web/topic/utils/apiConversion.ts
+++ b/src/web/topic/utils/apiConversion.ts
@@ -21,7 +21,7 @@ import {
 export const convertToStoreNode = (apiNode: ApiNode) => {
   return buildNode({
     id: apiNode.id,
-    label: apiNode.text,
+    text: apiNode.text,
     notes: apiNode.notes,
     type: apiNode.type,
     arguedDiagramPartId: apiNode.arguedDiagramPartId ?? undefined,
@@ -66,7 +66,7 @@ export const convertToApiNode = (storeNode: StoreNode, topicId: number): ApiNode
     arguedDiagramPartId: storeNode.data.arguedDiagramPartId ?? null,
     type: storeNode.type,
     customType: storeNode.data.customType,
-    text: storeNode.data.label,
+    text: storeNode.data.text,
     notes: storeNode.data.notes,
   };
 };
@@ -76,11 +76,11 @@ export const convertToApiEdge = (storeEdge: StoreEdge, topicId: number): ApiEdge
     id: storeEdge.id,
     topicId: topicId,
     arguedDiagramPartId: storeEdge.data.arguedDiagramPartId ?? null,
-    type: storeEdge.label,
+    type: storeEdge.type,
     customLabel: storeEdge.data.customLabel,
     notes: storeEdge.data.notes,
-    sourceId: storeEdge.source,
-    targetId: storeEdge.target,
+    sourceId: storeEdge.sourceId,
+    targetId: storeEdge.targetId,
   };
 };
 

--- a/src/web/topic/utils/edge.ts
+++ b/src/web/topic/utils/edge.ts
@@ -416,8 +416,8 @@ export const addableRelationsFrom = (
 export const canCreateEdge = (topicGraph: Graph, source: Node, target: Node) => {
   const existingEdge = topicGraph.edges.find((edge) => {
     return (
-      (edge.source === target.id && edge.target === source.id) ||
-      (edge.source === source.id && edge.target === target.id)
+      (edge.sourceId === target.id && edge.targetId === source.id) ||
+      (edge.sourceId === source.id && edge.targetId === target.id)
     );
   });
 
@@ -435,11 +435,11 @@ export const canCreateEdge = (topicGraph: Graph, source: Node, target: Node) => 
 };
 
 export const sourceNode = (edge: Edge, nodes: Node[]) => {
-  return findNodeOrThrow(edge.source, nodes);
+  return findNodeOrThrow(edge.sourceId, nodes);
 };
 
 export const targetNode = (edge: Edge, nodes: Node[]) => {
-  return findNodeOrThrow(edge.target, nodes);
+  return findNodeOrThrow(edge.targetId, nodes);
 };
 
 export const nodes = (edge: Edge, nodes: Node[]): [Node, Node] => {
@@ -449,8 +449,8 @@ export const nodes = (edge: Edge, nodes: Node[]): [Node, Node] => {
 export const getConnectingEdge = (graphPartId1: string, graphPartId2: string, edges: Edge[]) => {
   const edge = edges.find(
     (edge) =>
-      (edge.source === graphPartId1 && edge.target === graphPartId2) ||
-      (edge.source === graphPartId2 && edge.target === graphPartId1),
+      (edge.sourceId === graphPartId1 && edge.targetId === graphPartId2) ||
+      (edge.sourceId === graphPartId2 && edge.targetId === graphPartId1),
   );
 
   return edge;
@@ -494,7 +494,7 @@ export const isEdgeImpliedByComposition = (edge: Edge, topicGraph: Graph) => {
   // hiding nodes composed by composed nodes is really complex, let's not bother
   // TODO?: this complexity makes me think it's not worth trying to hide composed edges at all, and
   // that #434 is a better solution to the issue of showing connections when nodes are hidden
-  if (edge.label === "has") return false;
+  if (edge.type === "has") return false;
 
   const edgeSource = sourceNode(edge, topicGraph.nodes);
   const edgeTarget = targetNode(edge, topicGraph.nodes);
@@ -504,9 +504,9 @@ export const isEdgeImpliedByComposition = (edge: Edge, topicGraph: Graph) => {
   const impliedThroughTargetComponent = componentsOfTarget.some((component) => {
     return topicGraph.edges.some(
       (otherEdge) =>
-        otherEdge.target === component.id &&
-        otherEdge.label === edge.label &&
-        otherEdge.source === edgeSource.id,
+        otherEdge.targetId === component.id &&
+        otherEdge.type === edge.type &&
+        otherEdge.sourceId === edgeSource.id,
     );
   });
 
@@ -517,9 +517,9 @@ export const isEdgeImpliedByComposition = (edge: Edge, topicGraph: Graph) => {
   const impliedThroughSourceComponent = componentsOfSource.some((component) => {
     return topicGraph.edges.some(
       (otherEdge) =>
-        otherEdge.source === component.id &&
-        otherEdge.label === edge.label &&
-        otherEdge.target === edgeTarget.id,
+        otherEdge.sourceId === component.id &&
+        otherEdge.type === edge.type &&
+        otherEdge.targetId === edgeTarget.id,
     );
   });
 
@@ -535,7 +535,7 @@ export const isEdgeImpliedByComposition = (edge: Edge, topicGraph: Graph) => {
 // hidden. The button to show implied edges should reduce this pain, but maybe we need a better view
 // to reduce the need to hide implied edges?
 export const isEdgeImplied = (edge: Edge, graph: Graph, justificationEdges: Edge[]) => {
-  if (justificationRelationNames.includes(edge.label)) return false; // justifications can't be implied
+  if (justificationRelationNames.includes(edge.type)) return false; // justifications can't be implied
   if (hasJustification(edge, justificationEdges)) return false;
 
   return isEdgeAShortcut(edge, graph) || isEdgeImpliedByComposition(edge, graph);

--- a/src/web/topic/utils/graph.ts
+++ b/src/web/topic/utils/graph.ts
@@ -32,7 +32,7 @@ export interface ProblemNode extends Node {
 interface BuildProps {
   id?: string;
   customType?: string | null;
-  label?: string;
+  text?: string;
   notes?: string;
   type: NodeType;
   arguedDiagramPartId?: string;
@@ -40,7 +40,7 @@ interface BuildProps {
 export const buildNode = ({
   id,
   customType = null,
-  label,
+  text,
   notes,
   type,
   arguedDiagramPartId,
@@ -49,7 +49,7 @@ export const buildNode = ({
     id: id ?? uuid(),
     data: {
       customType: customType,
-      label: label ?? `new node`,
+      text: text ?? `new node`,
       notes: notes ?? "",
       arguedDiagramPartId: justificationNodeTypes.includes(type) ? arguedDiagramPartId : undefined, // don't set arguedDiagramPartId on non-justifications because non-justifications shouldn't be deleted when the justification tree is deleted
     },
@@ -90,10 +90,9 @@ export const buildEdge = ({
         ? arguedDiagramPartId
         : undefined, // don't set arguedDiagramPartId on non-justifications because non-justifications shouldn't be deleted when the justification tree is deleted
     },
-    label: relation,
-    source: sourceId,
-    target: targetId,
-    type: "FlowEdge" as const,
+    type: relation,
+    sourceId: sourceId,
+    targetId: targetId,
   };
 };
 
@@ -125,8 +124,8 @@ export const findGraphPartOrThrow = (graphPartId: string, nodes: Node[], edges: 
 };
 
 export const isNode = (graphPart: GraphPart): graphPart is Node => {
-  if (graphPart.type !== "FlowEdge") return true;
-  return false;
+  if ("sourceId" in graphPart) return false;
+  return true;
 };
 
 export const isNodeType = <T extends NodeType>(
@@ -159,20 +158,20 @@ const findNodesRecursivelyFrom = (
    */
   layersAway: number;
 })[] => {
-  const from = toDirection === "target" ? "source" : "target";
-  const to = toDirection;
+  const from = toDirection === "target" ? "sourceId" : "targetId";
+  const to = toDirection === "target" ? "targetId" : "sourceId";
 
   const foundEdges = {
     traverse: graph.edges.filter(
       (edge) =>
         edge[from] === fromNode.id &&
-        labelsToTraverse.includes(edge.label) &&
+        labelsToTraverse.includes(edge.type) &&
         !seenIds.includes(edge[to]),
     ),
     keep: graph.edges.filter(
       (edge) =>
         edge[from] === fromNode.id &&
-        labelsToKeep.includes(edge.label) &&
+        labelsToKeep.includes(edge.type) &&
         !seenIds.includes(edge[to]),
     ),
   };
@@ -252,7 +251,7 @@ export const getRelevantEdges = (nodes: Node[], graph: Graph) => {
   const nodeIds = nodes.map((node) => node.id);
 
   return graph.edges.filter(
-    (edge) => nodeIds.includes(edge.target) && nodeIds.includes(edge.source),
+    (edge) => nodeIds.includes(edge.targetId) && nodeIds.includes(edge.sourceId),
   );
 };
 
@@ -282,8 +281,8 @@ export const getSecondaryNeighbors = (
         infoNodeTypes.research.includes(node.type) &&
         graph.edges.some(
           (edge) =>
-            (edge.source === node.id && primaryNonResearchIds.includes(edge.target)) ||
-            (edge.target === node.id && primaryNonResearchIds.includes(edge.source)),
+            (edge.sourceId === node.id && primaryNonResearchIds.includes(edge.targetId)) ||
+            (edge.targetId === node.id && primaryNonResearchIds.includes(edge.sourceId)),
         ),
     );
 
@@ -302,8 +301,8 @@ export const getSecondaryNeighbors = (
         infoNodeTypes.breakdown.includes(node.type) &&
         graph.edges.some(
           (edge) =>
-            (edge.source === node.id && primaryNonBreakdownIds.includes(edge.target)) ||
-            (edge.target === node.id && primaryNonBreakdownIds.includes(edge.source)),
+            (edge.sourceId === node.id && primaryNonBreakdownIds.includes(edge.targetId)) ||
+            (edge.targetId === node.id && primaryNonBreakdownIds.includes(edge.sourceId)),
         ),
     );
 

--- a/src/web/topic/utils/justification.ts
+++ b/src/web/topic/utils/justification.ts
@@ -13,29 +13,29 @@ export const hasJustification = (edge: Edge, justificationEdges: Edge[]) => {
   );
 };
 
-export const getImplicitLabel = (arguedDiagramPartId: string, topicGraph: Graph): string => {
+export const getImplicitText = (arguedDiagramPartId: string, topicGraph: Graph): string => {
   const arguedDiagramPart = findGraphPartOrThrow(
     arguedDiagramPartId,
     topicGraph.nodes,
     topicGraph.edges,
   );
   if (isNode(arguedDiagramPart)) {
-    return `"${arguedDiagramPart.data.label}" is an important ${prettyNodeTypes[arguedDiagramPart.type]} in this topic`;
+    return `"${arguedDiagramPart.data.text}" is an important ${prettyNodeTypes[arguedDiagramPart.type]} in this topic`;
   } else {
-    const sourceNode = topicGraph.nodes.find((node) => node.id === arguedDiagramPart.source);
-    const targetNode = topicGraph.nodes.find((node) => node.id === arguedDiagramPart.target);
+    const sourceNode = topicGraph.nodes.find((node) => node.id === arguedDiagramPart.sourceId);
+    const targetNode = topicGraph.nodes.find((node) => node.id === arguedDiagramPart.targetId);
     if (!sourceNode || !targetNode) {
       throw errorWithData("edge nodes not found", arguedDiagramPart, topicGraph);
     }
 
     return (
-      `${prettyNodeTypes[sourceNode.type]} "${sourceNode.data.label}" ` +
-      lowerCase(arguedDiagramPart.data.customLabel ?? arguedDiagramPart.label) +
-      ` ${prettyNodeTypes[targetNode.type]} "${targetNode.data.label}"`
+      `${prettyNodeTypes[sourceNode.type]} "${sourceNode.data.text}" ` +
+      lowerCase(arguedDiagramPart.data.customLabel ?? arguedDiagramPart.type) +
+      ` ${prettyNodeTypes[targetNode.type]} "${targetNode.data.text}"`
     );
   }
 };
 
 export const isJustificationEdge = (graphPart: GraphPart) => {
-  return !isNode(graphPart) && justificationRelationNames.includes(graphPart.label);
+  return !isNode(graphPart) && justificationRelationNames.includes(graphPart.type);
 };

--- a/src/web/topic/utils/layout.ts
+++ b/src/web/topic/utils/layout.ts
@@ -352,16 +352,16 @@ const buildElkLayoutOptions = (
 };
 
 const shouldFlipEdge = (edge: Edge, nodes: Node[], edges: Edge[]) => {
-  if (edge.label !== "has" && edge.label !== "causes") return false;
+  if (edge.type !== "has" && edge.type !== "causes") return false;
 
   const sourceNode = sourceNodeOfEdge(edge, nodes);
   const targetNode = targetNodeOfEdge(edge, nodes);
 
   const sourceEffectType: EffectType = getEffectType(sourceNode, { nodes, edges });
 
-  const isSubproblemEdge = edge.label === "has" && sourceNode.type === "problem";
+  const isSubproblemEdge = edge.type === "has" && sourceNode.type === "problem";
   const isProblemCausesEdge =
-    edge.label === "causes" &&
+    edge.type === "causes" &&
     (sourceNode.type === "problem" || sourceEffectType === "problem") &&
     // if causing a problem, let problem continue in orientation direction so that its causes and effects can both be placed between it and solutions
     targetNode.type !== "problem";
@@ -389,25 +389,25 @@ const buildElkEdgesAndUsedPorts = ({ edges, nodes }: Diagram, avoidEdgeLabelOver
   const elkEdges: ElkExtendedEdge[] = edges
     .map((edge) => {
       return shouldFlipEdge(edge, nodes, edges)
-        ? { ...edge, source: edge.target, target: edge.source, flipped: true }
+        ? { ...edge, sourceId: edge.targetId, targetId: edge.sourceId, flipped: true }
         : { ...edge, flipped: false };
     })
     .map((edge) => {
       /* eslint-disable functional/immutable-data -- seems significantly easier to populate used ports via mutation */
       const sourcePort: ElkPort = {
-        id: buildPortId(edge.source, "source"),
+        id: buildPortId(edge.sourceId, "source"),
         layoutOptions: { "elk.port.side": "NORTH" },
       };
-      const usedSourcePorts = (usedPortsByNodeId[edge.source] ??= []);
+      const usedSourcePorts = (usedPortsByNodeId[edge.sourceId] ??= []);
       if (usedSourcePorts.find((port) => port.id === sourcePort.id) === undefined) {
         usedSourcePorts.push(sourcePort);
       }
 
       const targetPort: ElkPort = {
-        id: buildPortId(edge.target, "target"),
+        id: buildPortId(edge.targetId, "target"),
         layoutOptions: { "elk.port.side": "SOUTH" },
       };
-      const usedTargetPorts = (usedPortsByNodeId[edge.target] ??= []);
+      const usedTargetPorts = (usedPortsByNodeId[edge.targetId] ??= []);
       if (usedTargetPorts.find((port) => port.id === targetPort.id) === undefined) {
         usedTargetPorts.push(targetPort);
       }
@@ -425,14 +425,14 @@ const buildElkEdgesAndUsedPorts = ({ edges, nodes }: Diagram, avoidEdgeLabelOver
           // using space efficiently.
           // This isn't thoroughly tested, and might be more accurate to check source/target types?
           // But seems ok enough for now.
-          "elk.layered.priority.shortness": ["addresses", "mitigates"].includes(edge.label)
+          "elk.layered.priority.shortness": ["addresses", "mitigates"].includes(edge.type)
             ? "0"
             : "100",
         },
         labels: avoidEdgeLabelOverlap
           ? [
               {
-                text: edge.label,
+                text: edge.type,
                 layoutOptions: {
                   "edgeLabels.inline": "true",
                 },
@@ -459,7 +459,7 @@ const buildElkNodes = (
       const elkNode: ElkNode = {
         id: node.id,
         width: nodeWidthPx,
-        height: calculateNodeHeight(node.data.label),
+        height: calculateNodeHeight(node.data.text),
         ports: usedPortsByNodeId[node.id],
         layoutOptions: {
           // Some nodes can be taller than others (based on how long their text is),

--- a/src/web/topic/utils/node.ts
+++ b/src/web/topic/utils/node.ts
@@ -7,11 +7,11 @@ export const hideableNodeTypes: NodeType[] = ["criterion", "effect", "solutionCo
 
 // TODO: memoize? this could traverse a lot of nodes & edges, seems not performant
 export const sourceNodes = (node: Node, topicGraph: Graph, sameCategoryNodes = true) => {
-  const sourceEdges = topicGraph.edges.filter((edge) => edge.target === node.id);
+  const sourceEdges = topicGraph.edges.filter((edge) => edge.targetId === node.id);
 
   const sources = sourceEdges.map((edge) => {
-    const node = topicGraph.nodes.find((node) => edge.source === node.id);
-    if (!node) throw errorWithData(`node ${edge.source} not found`, topicGraph);
+    const node = topicGraph.nodes.find((node) => edge.sourceId === node.id);
+    if (!node) throw errorWithData(`node ${edge.sourceId} not found`, topicGraph);
 
     return node;
   });
@@ -23,10 +23,10 @@ export const sourceNodes = (node: Node, topicGraph: Graph, sameCategoryNodes = t
 
 // all children references prefer to look for same-category nodes
 export const targetNodes = (node: Node, topicGraph: Graph, sameCategoryNodes = true) => {
-  const targetEdges = topicGraph.edges.filter((edge) => edge.source === node.id);
+  const targetEdges = topicGraph.edges.filter((edge) => edge.sourceId === node.id);
   const targets = targetEdges.map((edge) => {
-    const node = topicGraph.nodes.find((node) => edge.target === node.id);
-    if (!node) throw errorWithData(`node ${edge.target} not found`, topicGraph);
+    const node = topicGraph.nodes.find((node) => edge.targetId === node.id);
+    if (!node) throw errorWithData(`node ${edge.targetId} not found`, topicGraph);
 
     return node;
   });
@@ -73,5 +73,5 @@ export const components = (node: Node, topicGraph: Graph) => {
 };
 
 export const edges = (node: Node, edges: Edge[]) => {
-  return edges.filter((edge) => edge.source === node.id || edge.target === node.id);
+  return edges.filter((edge) => edge.sourceId === node.id || edge.targetId === node.id);
 };

--- a/src/web/view/utils/miscDiagramFilters.ts
+++ b/src/web/view/utils/miscDiagramFilters.ts
@@ -4,7 +4,7 @@ import { Edge, Graph, Node } from "@/web/topic/utils/graph";
 
 export const hideImpliedEdges = (edges: Edge[], displayGraph: Graph, topicGraph: Graph) => {
   const justificationEdges = topicGraph.edges.filter((edge) =>
-    justificationRelationNames.includes(edge.label),
+    justificationRelationNames.includes(edge.type),
   );
 
   return edges.filter((edge) => !isEdgeImplied(edge, displayGraph, justificationEdges));
@@ -16,9 +16,9 @@ export const hideProblemCriterionSolutionEdges = (nodes: Node[], edges: Edge[]) 
   const solutionIds = nodes.filter((node) => node.type === "solution").map((node) => node.id);
 
   return edges.filter((edge) => {
-    if (criterionIds.includes(edge.source) && problemIds.includes(edge.target)) return false;
-    if (solutionIds.includes(edge.source) && criterionIds.includes(edge.target)) return false;
-    if (solutionIds.includes(edge.source) && problemIds.includes(edge.target)) return false;
+    if (criterionIds.includes(edge.sourceId) && problemIds.includes(edge.targetId)) return false;
+    if (solutionIds.includes(edge.sourceId) && criterionIds.includes(edge.targetId)) return false;
+    if (solutionIds.includes(edge.sourceId) && problemIds.includes(edge.targetId)) return false;
 
     return true;
   });


### PR DESCRIPTION
because these are unnecessarily different, historically due to following react flow's schema on the frontend but wanting to use "what's best" on the backend.

motivation: cleaning up the schemas in prep for adding indirect edges along with new edge types that make more sense with that.

schema-change summary:

Node store schema (`diagramStoreNodeSchema`):
- rename "label" to "text"

Edge store schema (`diagramStoreEdgeSchema`):
- replace the current "type" field with the current "label" field.
- rename "source" and "target" to "sourceId" and "targetId"

### Description of changes

-

### Additional context

-
