### PR TITLE
Add automated cleanup for orphaned UserScores

### DIFF
--- a/.github/workflows/cleanup-orphans.yml
+++ b/.github/workflows/cleanup-orphans.yml
@@ -1,0 +1,32 @@
+name: Cleanup Orphaned Scores
+
+on:
+  schedule:
+    # Runs at 00:00 every Sunday
+    #- cron: '0 0 * * 0'
+    # Runs at 18:45 (6:45 PM) every Monday
+    - cron: "15 13 * * 1"
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24.11.1"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Generate Prisma Client
+        run: npx prisma generate
+
+      - name: Run Cleanup Script
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: npm run db:cleanup

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -8,6 +8,7 @@ const buildEslintCommand = (filenames) =>
     .join(" --file ")}`;
 
 const config = {
-  "*": ["prettier --ignore-unknown --write", buildEslintCommand],
+  "*": "prettier --ignore-unknown --write",
+  "**/*.{js,jsx,ts,tsx}": buildEslintCommand,
 };
 export default config;

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "migration:rollback": "tsx scripts/rollbackMigration.ts",
     "migration:run": "prisma migrate dev",
     "migration:deploy": "prisma migrate deploy",
+    "db:cleanup": "tsx scripts/cleanupOrphanedScores.ts",
     "postinstall": "prisma generate"
   },
   "dependencies": {

--- a/scripts/cleanupOrphanedScores.ts
+++ b/scripts/cleanupOrphanedScores.ts
@@ -1,0 +1,50 @@
+import { prisma } from "@/db/basePrisma";
+
+async function main() {
+  console.log("Starting cleanup of orphaned UserScores.");
+
+  // Find all score IDs that don't match any Node or Edge
+  // because the graphPartId can point to a Node or an Edge we need to check both
+  const orphanedScores = await prisma.$queryRaw<{ username: string; graphPartId: string }[]>`
+    SELECT us.username, us."graphPartId"
+    FROM "userScores" us
+    LEFT JOIN nodes n ON us."graphPartId" = n.id
+    LEFT JOIN edges e ON us."graphPartId" = e.id
+    WHERE n.id IS NULL AND e.id IS NULL
+  `;
+
+  if (orphanedScores.length === 0) {
+    console.log("No orphaned scores found. Database is clean!");
+    return;
+  }
+
+  console.log(`Found ${orphanedScores.length} orphaned scores. Cleaning up...`);
+
+  console.log(`Found ${orphanedScores.length} orphaned scores. Cleaning up...`);
+
+  // Delete orphaned scores in parallel
+  //Use map to delete each score in parallel
+  await Promise.all(
+    orphanedScores.map((score) =>
+      prisma.userScore.delete({
+        where: {
+          username_graphPartId: {
+            username: score.username,
+            graphPartId: score.graphPartId,
+          },
+        },
+      }),
+    ),
+  );
+
+  console.log(`Successfully deleted ${orphanedScores.length} orphaned scores!`);
+}
+
+main()
+  .catch((e: unknown) => {
+    console.error("Cleanup failed:", e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Overview

This PR introduces an automated cleanup (scavenger) service to identify and remove orphaned `UserScore` records.

These "ghost" records are created when a Node or Edge is deleted but the associated scoring data remains in the database.

---

## Key Changes

### 🆕 New Script
Added `scripts/cleanupOrphanedScores.ts`, which uses Prisma to safely identify and delete scores that do not have matching parent records.

### ⚙️ Automation
Created a GitHub Action (`.github/workflows/cleanup-orphans.yml`) to run the cleanup automatically on a weekly schedule.

### 🚀 Efficiency
The script uses parallel processing (`Promise.all`) to handle deletions efficiently and complies with the project's functional programming lint rules.

### 📦 NPM Integration
Added:

```bash
npm run db:cleanup