### PR TITLE
feat: allow multiple edges between 2 nodes

### DIFF
--- a/docs-site/app/diagramming-choices/page.mdx
+++ b/docs-site/app/diagramming-choices/page.mdx
@@ -27,16 +27,3 @@ If there are only a couple variations you care to consider, you could treat each
   considered: add an Option node type; allow any node type to be an option for another related node;
   add variables with discrete possible values as a new kind of information that any node can have.
 </Callout>
-
-### Cycles / Circular dependencies
-
-Sometimes two nodes cause each other, e.g. A causes B and B also causes A. This is a bit awkward to model in Ameliorate, because of the following limitations that currently exist:
-
-1. nodes are laid out such that relations always flow in the same direction (i.e. bottom-to-top) (to keep flow consistent and easy-to-see)
-2. nodes cannot have multiple edges between each other (this was an assumption originally for saving coding effort)
-
-The [diagram-choices-cycles](https://ameliorate.app/keyserj/diagram-choices-cycles) topic shows some ways to model this situation:
-
-1. [Indirect cycle](https://ameliorate.app/keyserj/diagram-choices-cycles?view=Indirect+cycle): create an intermediate node X such that A causes B, B causes X, then X can cause A. This is probably the most intuitive, but only works if the cycle is indirect, and one of the edges will look a bit awkward as it rotates around.
-2. [Opposite edge label](https://ameliorate.app/keyserj/diagram-choices-cycles?view=Opposite+edge+label): use an opposite edge label, e.g. A causes B, and A is caused by B. This is a bit awkward because the edges both point the same directions but they mean opposite things.
-3. [Duplicate one node](https://ameliorate.app/keyserj/diagram-choices-cycles?view=Duplicate+one+node): create a second node A2 with the same text as A, such that such that A causes B, and B causes A2. This creates an awkward duplication, and A2 doesn't automatically have all the details that A has (even though it should), but it allows both relations to be considered.

--- a/src/web/topic/components/Diagram/Diagram.tsx
+++ b/src/web/topic/components/Diagram/Diagram.tsx
@@ -9,6 +9,7 @@ import {
 import { ComponentType, useEffect, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 
+import { throwError } from "@/common/errorHandling";
 import { Loading } from "@/web/common/components/Loading/Loading";
 import { emitter } from "@/web/common/event";
 import { useSessionUser } from "@/web/common/hooks";
@@ -58,10 +59,54 @@ const convertToReactFlowNodes = (
   }));
 };
 
+/**
+ * Build a map from edge id to its parallel offset index, so that multiple edges between the same
+ * two nodes can be visually spread apart.
+ *
+ * Indexes are symmetric around 0: e.g. 2 edges: [-1, 1]; 3 edges: [-1, 0, 1]; 4 edges: [-2, -1, 1, 2].
+ * Index is undefined when there's only 1 edge between the two nodes.
+ */
+const getParallelOffsetsByEdgeId = (layoutedEdges: LayoutedEdge[]) => {
+  const edgesByNodePair: Record<string, LayoutedEdge[]> = {};
+  layoutedEdges.forEach((edge) => {
+    const nodeA = parsePortId(edge.sourcePortId).nodeId;
+    const nodeB = parsePortId(edge.targetPortId).nodeId;
+    // use sorted IDs so A→B and B→A share a group
+    const pairKey = nodeA < nodeB ? `${nodeA}..${nodeB}` : `${nodeB}..${nodeA}`;
+    // eslint-disable-next-line functional/immutable-data
+    (edgesByNodePair[pairKey] ??= []).push(edge);
+  });
+
+  const offsetsByEdgeId: Record<string, number | undefined> = {};
+  Object.values(edgesByNodePair).forEach((group) => {
+    if (group.length === 1) {
+      const edgeId = group[0]?.id ?? throwError("expected edge in group", group);
+      // eslint-disable-next-line functional/immutable-data
+      offsetsByEdgeId[edgeId] = undefined;
+      return;
+    }
+
+    const count = group.length;
+    const isEven = count % 2 === 0;
+    group.forEach((edge, i) => {
+      // For odd count: -floor(count/2) ... 0 ... +floor(count/2)
+      // For even count: skip 0, e.g. -2, -1, 1, 2
+      const rawIndex = i - Math.floor(count / 2);
+      const offsetIndex = isEven && rawIndex >= 0 ? rawIndex + 1 : rawIndex;
+      // eslint-disable-next-line functional/immutable-data
+      offsetsByEdgeId[edge.id] = offsetIndex;
+    });
+  });
+
+  return offsetsByEdgeId;
+};
+
 const convertToReactFlowEdges = (
   layoutedEdges: LayoutedEdge[],
   selectedGraphPartId: string | undefined,
 ): ReactFlowEdge[] => {
+  const parallelOffsetByEdgeId = getParallelOffsetsByEdgeId(layoutedEdges);
+
   return layoutedEdges.map((edge) => ({
     id: edge.id,
     // layouted edges don't have source/target nodes because they use ports directly... could add them but it seems not worth
@@ -82,6 +127,7 @@ const convertToReactFlowEdges = (
       targetPoint: edge.targetPoint,
       bendPoints: edge.bendPoints,
       labelPosition: edge.labelPosition,
+      parallelOffsetIndex: parallelOffsetByEdgeId[edge.id],
     },
     selected: edge.id === selectedGraphPartId,
   }));

--- a/src/web/topic/components/Edge/svgPathDrawer.ts
+++ b/src/web/topic/components/Edge/svgPathDrawer.ts
@@ -1,5 +1,3 @@
-import { Position, getBezierPath } from "@xyflow/react";
-
 import { throwError } from "@/common/errorHandling";
 import { scalePxViaDefaultFontSize } from "@/pages/_document.page";
 import { EdgeLayoutData } from "@/web/topic/utils/diagram";
@@ -11,19 +9,124 @@ interface Point {
 }
 
 /**
- * For the calculation, uses proper handle `Position` values based on which of start/end is above the other.
+ * Roughly scales the offset spacing between each parallel edge.
+ *
+ * E.g. two parallel edges with indices -1 and 1 will be offset by a bit less this value in px to
+ * the left and right.
+ *
+ * This value is the amount in px to shift one control point of the bezier curve, creating the
+ * offset. Technically the curve will only be pulled _towards_ the control point, so the curve will
+ * be offset by a bit less than this value in px.
  */
-const getSimpleBezierPath = (start: Point, end: Point) => {
-  const [pathDefinition, labelX, labelY] = getBezierPath({
-    sourceX: start.x,
-    sourceY: start.y,
-    sourcePosition: start.y > end.y ? Position.Top : Position.Bottom,
-    targetX: end.x,
-    targetY: end.y,
-    targetPosition: start.y > end.y ? Position.Bottom : Position.Top,
-  });
+const parallelOffsetSpacing = 80;
 
-  return { pathDefinition, labelX, labelY };
+/**
+ * Sorry this is LLM magic. It seems to work. The comments seem legit.
+ *
+ * Converts a degree-4 (quartic) Bézier defined by 5 control points into an SVG path string
+ * composed of two cubic Bézier segments joined at the quartic's midpoint (t=0.5).
+ *
+ * The two cubics are computed to match the quartic's position and tangent at t=0, t=0.5, and t=1,
+ * giving C1 continuity at the junction. This is a very close approximation — visually
+ * indistinguishable from a true quartic.
+ *
+ * Math: given quartic control points P0..P4, the midpoint is:
+ *   M = (P0 + 4*P1 + 6*P2 + 4*P3 + P4) / 16
+ *
+ * First cubic:  Q0=P0, Q1=(P0+2*P1)/3, Q2=M+(P0+2*P1-2*P3-P4)/12, Q3=M
+ * Second cubic: R0=M,  R1=M-(P0+2*P1-2*P3-P4)/12, R2=(2*P3+P4)/3, R3=P4
+ */
+const quarticToSvgPath = (p0: Point, p1: Point, p2: Point, p3: Point, p4: Point) => {
+  // Quartic Bézier evaluated at t=0.5
+  const m = {
+    x: (p0.x + 4 * p1.x + 6 * p2.x + 4 * p3.x + p4.x) / 16,
+    y: (p0.y + 4 * p1.y + 6 * p2.y + 4 * p3.y + p4.y) / 16,
+  };
+
+  // Reused term: (P0 + 2*P1 - 2*P3 - P4) / 12
+  const tangentAdj = {
+    x: (p0.x + 2 * p1.x - 2 * p3.x - p4.x) / 12,
+    y: (p0.y + 2 * p1.y - 2 * p3.y - p4.y) / 12,
+  };
+
+  // First cubic: P0 → M
+  const q1 = { x: (p0.x + 2 * p1.x) / 3, y: (p0.y + 2 * p1.y) / 3 };
+  const q2 = { x: m.x + tangentAdj.x, y: m.y + tangentAdj.y };
+
+  // Second cubic: M → P4  (R1 = 2*M - Q2, giving C1 continuity)
+  const r1 = { x: m.x - tangentAdj.x, y: m.y - tangentAdj.y };
+  const r2 = { x: (2 * p3.x + p4.x) / 3, y: (2 * p3.y + p4.y) / 3 };
+
+  const pathDefinition = [
+    `M ${p0.x} ${p0.y}`,
+    `C ${q1.x} ${q1.y}, ${q2.x} ${q2.y}, ${m.x} ${m.y}`,
+    `C ${r1.x} ${r1.y}, ${r2.x} ${r2.y}, ${p4.x} ${p4.y}`,
+  ].join(" ");
+
+  return { pathDefinition, labelX: m.x, labelY: m.y };
+};
+
+/**
+ * Draws a bezier path between start and end, optionally offset for parallel edges.
+ *
+ * See this image for a visualization: https://github.com/user-attachments/assets/1c40ff8f-2e7f-46f1-a0e8-4a525e678510
+ * See this topic for what the rendering currently looks like with a few different offsets: https://ameliorate.app/keyserj/test-some-nodes
+ *
+ * The curve is defined as a degree-4 Bézier with 5 control points:
+ *   P0 = start
+ *   P1 = (start.x, midY)  - ensures the curve exits the source handle vertically
+ *   P2 = offset point     - pulled perpendicularly to the side to offset the curve and prevent overlap
+ *   P3 = (end.x, midY)    - ensures the curve enters the target handle vertically
+ *   P4 = end
+ *
+ * For offset=0, P2 sits at the geometric center (midX, midY), reproducing React Flow's default
+ * bezier. For non-zero offsets, P2 is shifted perpendicular to the edge direction.
+ *
+ * Since SVG doesn't support quartic Béziers, this is converted to two cubic segments via
+ * `quarticToSvgPath`. I still think it's worth to use a quartic logically because moving one
+ * control point to create offset is easier for me to think about. Would be great if we could avoid
+ * this logic by using ELK to layout the edges, but I couldn't figure that out (see comment on
+ * `EdgeLayoutData`).
+ */
+const generateBezierPath = (start: Point, end: Point, parallelOffsetIndex: number) => {
+  const offset = parallelOffsetIndex * parallelOffsetSpacing;
+  const midX = (start.x + end.x) / 2;
+  const midY = (start.y + end.y) / 2;
+
+  // P1 and P3 are pinned to ensure vertical tangents at the handles.
+  const p1 = { x: start.x, y: midY };
+  const p3 = { x: end.x, y: midY };
+
+  if (offset === 0) {
+    // P2 at geometric center — reproduces React Flow's default bezier curve.
+    return quarticToSvgPath(start, p1, { x: midX, y: midY }, p3, end);
+  }
+
+  // Make edges point in the same direction so that two opposite-direction edges with opposite
+  // offset indexes (e.g. -1 and 1) don't have identically-offset paths.
+  const [canonicalStart, canonicalEnd] =
+    start.y < end.y || (start.y === end.y && start.x <= end.x) ? [start, end] : [end, start];
+
+  // dx and dy represent the vector from `start` to `end`
+  const dx = canonicalEnd.x - canonicalStart.x;
+  const dy = canonicalEnd.y - canonicalStart.y;
+  const len = Math.sqrt(dx * dx + dy * dy);
+  if (len === 0) return throwError("Start and end points shouldn't be the same", start, end);
+
+  // unit vector because we only care about the direction for offsetting, not the magnitude
+  // (-dy, dx) gives a 90 degree rotation to the right
+  const perpendicularUnitVector = {
+    x: -dy / len,
+    y: dx / len,
+  };
+
+  // P2 is the single offset control point, shifted perpendicularly to the (start, end) edge.
+  const p2 = {
+    x: midX + perpendicularUnitVector.x * offset,
+    y: midY + perpendicularUnitVector.y * offset,
+  };
+
+  return quarticToSvgPath(start, p1, p2, p3, end);
 };
 
 /**
@@ -38,10 +141,12 @@ export const getPathDefinitionForEdge = (
   edgeLayoutData: EdgeLayoutData,
   avoidEdgeLabelOverlap: boolean,
 ) => {
-  const { sourcePoint, targetPoint, bendPoints, labelPosition } = edgeLayoutData;
+  const { sourcePoint, targetPoint, bendPoints, labelPosition, parallelOffsetIndex } =
+    edgeLayoutData;
+
   if (!avoidEdgeLabelOverlap || bendPoints.length === 0) {
-    // TODO: probably ideally would draw this path through the ELK label position if that's provided
-    return getSimpleBezierPath(edgeLayoutData.sourcePoint, edgeLayoutData.targetPoint);
+    // TODO?: probably ideally would draw this path through the ELK label position if that's provided
+    return generateBezierPath(sourcePoint, targetPoint, parallelOffsetIndex ?? 0);
   }
 
   /**

--- a/src/web/topic/diagramStore/createDeleteActions.ts
+++ b/src/web/topic/diagramStore/createDeleteActions.ts
@@ -170,7 +170,7 @@ const createEdge = (
   // It's not clear at this time whether completely adding or removing support for edges to edges is better,
   // so here's a hack assuming we won't use it for now.,
   if (!isNode(source) || !isNode(target)) throw new Error("source or target is not a node");
-  if (!canCreateEdge(topicGraph, source, target)) return null;
+  if (!canCreateEdge(topicGraph, source, relationName, target)) return null;
 
   const newEdge = buildEdge({
     sourceId: source.id,
@@ -198,11 +198,9 @@ const createConnection = (
     throw errorWithData("source or target not found", sourceId, targetId, topicGraph);
   }
 
-  if (!canCreateEdge(topicGraph, source, target)) return null;
-
   const relation = getRelation(source.type, relationName, target.type);
 
-  // modifies topicGraph.edges through `state`
+  // if edge is valid, topicGraph.edges is modified via `state`
   return createEdge(topicGraph, source, relation.name, target);
 };
 

--- a/src/web/topic/utils/diagram.ts
+++ b/src/web/topic/utils/diagram.ts
@@ -8,9 +8,29 @@ export interface Diagram {
 
 /**
  * Used for rendering paths and labels. If we have ELK layout data, we should use that. Otherwise,
- * e.g. for StandaloneEdge outside of the diagram, we can set `handlePositions`.
+ * e.g. for StandaloneEdge outside of the diagram, we can set this ourselves.
  */
 export type EdgeLayoutData = Pick<
   LayoutedEdge,
   "sourcePoint" | "targetPoint" | "bendPoints" | "labelPosition"
->;
+> & {
+  /**
+   * Determines how to adjust the edge centerpoint for each edge between the same two nodes such
+   * that the edges don't follow identical paths.
+   *
+   * Ranges from -(numEdges/2) to +(numEdges/2), skipping 0 when numEdges is even. When 0 or
+   * undefined, no offset is applied.
+   *
+   * E.g. 2 edges: [-1, 1]; 3 edges: [-1, 0, 1]; 4 edges: [-2, -1, 1, 2].
+   *
+   * TODO?: ideally we wouldn't need to do this edge offsetting ourselves and could just rely on ELK
+   * to do it, but 1. we don't currently draw ELK beziers nicely (i.e. starting and ending going
+   * vertically into the handles) and 2. I don't know how to get ELK to have paths avoid identically
+   * overlapping each other without using positioned labels, which we also don't want to use because
+   * they're treated as nodes and therefore create a bunch of extra layers in the layout.
+   * Potentially we could allow ELK to choose ports for us, then each edge would have its own port
+   * and that'd result in no identical paths, but using many ports makes edges look a bit more
+   * chaotic, which seems like a tradeoff maybe not worth making.
+   */
+  parallelOffsetIndex?: number;
+};

--- a/src/web/topic/utils/edge.ts
+++ b/src/web/topic/utils/edge.ts
@@ -416,22 +416,23 @@ export const addableRelationsFrom = (
 export const canCreateEdge = (
   topicGraph: MinimalGraph,
   source: MinimalNode,
+  edgeType: RelationName,
   target: MinimalNode,
 ) => {
-  const existingEdge = topicGraph.edges.find((edge) => {
-    return (
-      (edge.sourceId === target.id && edge.targetId === source.id) ||
-      (edge.sourceId === source.id && edge.targetId === target.id)
-    );
-  });
-
   if (source.id === target.id) {
     console.log("cannot connect nodes: tried dragging node onto itself");
     return false;
   }
 
-  if (existingEdge) {
-    console.log("cannot connect nodes: tried dragging between already-connected nodes");
+  // Multiple edges between the same nodes are allowed as long as the type or direction is different.
+  const duplicateEdge = topicGraph.edges.find(
+    (edge) => edge.sourceId === source.id && edge.targetId === target.id && edge.type === edgeType,
+  );
+
+  if (duplicateEdge) {
+    console.log(
+      "cannot connect nodes: an edge with the same source, type, and target already exists",
+    );
     return false;
   }
 


### PR DESCRIPTION
unless the edge direction and label are the same.

motivation: with this, we can display multiple indirect edges between the same two nodes, so we don't need extra logic to avoid displaying an indirect edge if there's already a visible path or another hidden path with a different label.

the big effort here was making sure multiple edges between the same two nodes are layouted such that they don't overlay each other. see comments for more details.

Closes #851 

### Description of changes

-

### Additional context

-
