### PR TITLE
fix: keep topic upload input mounted while reading

### DIFF
--- a/src/web/common/components/Menu/FlyoutSubMenu.tsx
+++ b/src/web/common/components/Menu/FlyoutSubMenu.tsx
@@ -146,6 +146,7 @@ export const FlyoutSubMenu = forwardRef<HTMLLIElement | null, Props>(
         </MenuItem>
         <Popper
           open={open}
+          keepMounted
           anchorEl={menuItemRef.current}
           placement="right-start"
           style={{ zIndex: 1300 }}

--- a/src/web/topic/components/TopicWorkspace/MoreActionsMenu.tsx
+++ b/src/web/topic/components/TopicWorkspace/MoreActionsMenu.tsx
@@ -49,7 +49,14 @@ import {
   useMediaQuery,
   useTheme,
 } from "@mui/material";
-import { type Dispatch, type SetStateAction, useState } from "react";
+import {
+  type Dispatch,
+  Fragment,
+  type RefObject,
+  type SetStateAction,
+  useRef,
+  useState,
+} from "react";
 
 import { hasComments, resetComments } from "@/web/comment/store/commentStore";
 import { HelpIcon } from "@/web/common/components/HelpIcon";
@@ -132,6 +139,7 @@ export const MoreActionsMenu = ({
 
   const menuOpen = Boolean(anchorEl);
   const handleClose = () => setAnchorEl(null);
+  const uploadInputRef = useRef<HTMLInputElement>(null);
 
   const format = useFormat();
   const isTableActive = format === "table";
@@ -142,9 +150,9 @@ export const MoreActionsMenu = ({
       key="topic"
       menuOpen={menuOpen}
       handleClose={handleClose}
-      sessionUser={sessionUser}
       userCanEditTopicData={userCanEditTopicData}
       isTableActive={isTableActive}
+      onUploadClick={() => uploadInputRef.current?.click()}
     />,
 
     !isTableActive && (
@@ -160,46 +168,77 @@ export const MoreActionsMenu = ({
     !isTableActive && <FilterSubmenu key="filter" menuOpen={menuOpen} />,
   ];
 
-  if (isMobile) {
-    return (
-      <MobileMenuDrawer
-        open={menuOpen}
-        onClose={handleClose}
-        slotProps={{ list: { dense: false } }} // give our More MenuItems a bit more breathing space because many of them have sizable icons like switches/radios
-      >
-        {menuContent}
-      </MobileMenuDrawer>
-    );
-  }
-
   return (
-    <Menu
-      anchorEl={anchorEl}
-      open={menuOpen}
-      onClose={handleClose}
-      closeOnClick={false}
-      openDirection={openDirection}
-      slotProps={{ list: { dense: false } }} // give our More MenuItems a bit more breathing space because many of them have sizable icons like switches/radios
-    >
-      {menuContent}
-    </Menu>
+    <Fragment>
+      <TopicUploadInput
+        inputRef={uploadInputRef}
+        sessionUsername={sessionUser?.username}
+        userCanEditTopicData={userCanEditTopicData}
+        onUpload={handleClose}
+      />
+      {isMobile ? (
+        <MobileMenuDrawer
+          open={menuOpen}
+          onClose={handleClose}
+          slotProps={{ list: { dense: false } }} // give our More MenuItems a bit more breathing space because many of them have sizable icons like switches/radios
+        >
+          {menuContent}
+        </MobileMenuDrawer>
+      ) : (
+        <Menu
+          anchorEl={anchorEl}
+          open={menuOpen}
+          onClose={handleClose}
+          closeOnClick={false}
+          openDirection={openDirection}
+          slotProps={{ list: { dense: false } }} // give our More MenuItems a bit more breathing space because many of them have sizable icons like switches/radios
+        >
+          {menuContent}
+        </Menu>
+      )}
+    </Fragment>
   );
 };
+
+interface TopicUploadInputProps {
+  inputRef: RefObject<HTMLInputElement>;
+  sessionUsername?: string;
+  userCanEditTopicData: boolean;
+  onUpload: () => void;
+}
+
+const TopicUploadInput = ({
+  inputRef,
+  sessionUsername,
+  userCanEditTopicData,
+  onUpload,
+}: TopicUploadInputProps) => (
+  <input
+    ref={inputRef}
+    hidden
+    accept=".json"
+    type="file"
+    disabled={!userCanEditTopicData}
+    onChange={(event) => {
+      void uploadTopic(event, sessionUsername).then(onUpload);
+    }}
+  />
+);
 
 interface TopicSubmenuProps {
   menuOpen: boolean;
   handleClose: () => void;
-  sessionUser?: { username: string } | null;
   userCanEditTopicData: boolean;
   isTableActive: boolean;
+  onUploadClick: () => void;
 }
 
 const TopicSubmenu = ({
   menuOpen,
   handleClose,
-  sessionUser,
   userCanEditTopicData,
   isTableActive,
+  onUploadClick,
 }: TopicSubmenuProps) => {
   const [screenshotDialogOpen, setScreenshotDialogOpen] = useState(false);
   const [resetDialogOpen, setResetDialogOpen] = useState(false);
@@ -224,20 +263,11 @@ const TopicSubmenu = ({
           <ListItemText primary="Download" />
         </MenuItem>
 
-        <MenuItem component="label" disabled={!userCanEditTopicData}>
+        <MenuItem onClick={onUploadClick} disabled={!userCanEditTopicData}>
           <ListItemIcon>
             <Upload />
           </ListItemIcon>
           <ListItemText primary="Upload" />
-          <input
-            hidden
-            accept=".json"
-            type="file"
-            disabled={!userCanEditTopicData}
-            onChange={(event) => {
-              void uploadTopic(event, sessionUser?.username).then(handleClose);
-            }}
-          />
         </MenuItem>
 
         {!isTableActive && (

--- a/src/web/topic/components/TopicWorkspace/MoreActionsMenu.tsx
+++ b/src/web/topic/components/TopicWorkspace/MoreActionsMenu.tsx
@@ -235,8 +235,7 @@ const TopicSubmenu = ({
             type="file"
             disabled={!userCanEditTopicData}
             onChange={(event) => {
-              void uploadTopic(event, sessionUser?.username);
-              handleClose();
+              void uploadTopic(event, sessionUser?.username).then(handleClose);
             }}
           />
         </MenuItem>

--- a/src/web/topic/components/TopicWorkspace/MoreActionsMenu.tsx
+++ b/src/web/topic/components/TopicWorkspace/MoreActionsMenu.tsx
@@ -49,14 +49,7 @@ import {
   useMediaQuery,
   useTheme,
 } from "@mui/material";
-import {
-  type Dispatch,
-  Fragment,
-  type RefObject,
-  type SetStateAction,
-  useRef,
-  useState,
-} from "react";
+import { type Dispatch, type SetStateAction, useState } from "react";
 
 import { hasComments, resetComments } from "@/web/comment/store/commentStore";
 import { HelpIcon } from "@/web/common/components/HelpIcon";
@@ -139,7 +132,6 @@ export const MoreActionsMenu = ({
 
   const menuOpen = Boolean(anchorEl);
   const handleClose = () => setAnchorEl(null);
-  const uploadInputRef = useRef<HTMLInputElement>(null);
 
   const format = useFormat();
   const isTableActive = format === "table";
@@ -150,9 +142,9 @@ export const MoreActionsMenu = ({
       key="topic"
       menuOpen={menuOpen}
       handleClose={handleClose}
+      sessionUser={sessionUser}
       userCanEditTopicData={userCanEditTopicData}
       isTableActive={isTableActive}
-      onUploadClick={() => uploadInputRef.current?.click()}
     />,
 
     !isTableActive && (
@@ -168,77 +160,46 @@ export const MoreActionsMenu = ({
     !isTableActive && <FilterSubmenu key="filter" menuOpen={menuOpen} />,
   ];
 
+  if (isMobile) {
+    return (
+      <MobileMenuDrawer
+        open={menuOpen}
+        onClose={handleClose}
+        slotProps={{ list: { dense: false } }} // give our More MenuItems a bit more breathing space because many of them have sizable icons like switches/radios
+      >
+        {menuContent}
+      </MobileMenuDrawer>
+    );
+  }
+
   return (
-    <Fragment>
-      <TopicUploadInput
-        inputRef={uploadInputRef}
-        sessionUsername={sessionUser?.username}
-        userCanEditTopicData={userCanEditTopicData}
-        onUpload={handleClose}
-      />
-      {isMobile ? (
-        <MobileMenuDrawer
-          open={menuOpen}
-          onClose={handleClose}
-          slotProps={{ list: { dense: false } }} // give our More MenuItems a bit more breathing space because many of them have sizable icons like switches/radios
-        >
-          {menuContent}
-        </MobileMenuDrawer>
-      ) : (
-        <Menu
-          anchorEl={anchorEl}
-          open={menuOpen}
-          onClose={handleClose}
-          closeOnClick={false}
-          openDirection={openDirection}
-          slotProps={{ list: { dense: false } }} // give our More MenuItems a bit more breathing space because many of them have sizable icons like switches/radios
-        >
-          {menuContent}
-        </Menu>
-      )}
-    </Fragment>
+    <Menu
+      anchorEl={anchorEl}
+      open={menuOpen}
+      onClose={handleClose}
+      closeOnClick={false}
+      openDirection={openDirection}
+      slotProps={{ list: { dense: false } }} // give our More MenuItems a bit more breathing space because many of them have sizable icons like switches/radios
+    >
+      {menuContent}
+    </Menu>
   );
 };
-
-interface TopicUploadInputProps {
-  inputRef: RefObject<HTMLInputElement>;
-  sessionUsername?: string;
-  userCanEditTopicData: boolean;
-  onUpload: () => void;
-}
-
-const TopicUploadInput = ({
-  inputRef,
-  sessionUsername,
-  userCanEditTopicData,
-  onUpload,
-}: TopicUploadInputProps) => (
-  <input
-    ref={inputRef}
-    hidden
-    accept=".json"
-    type="file"
-    disabled={!userCanEditTopicData}
-    onChange={(event) => {
-      void uploadTopic(event, sessionUsername).then(onUpload);
-    }}
-  />
-);
 
 interface TopicSubmenuProps {
   menuOpen: boolean;
   handleClose: () => void;
+  sessionUser?: { username: string } | null;
   userCanEditTopicData: boolean;
   isTableActive: boolean;
-  onUploadClick: () => void;
 }
 
 const TopicSubmenu = ({
   menuOpen,
   handleClose,
+  sessionUser,
   userCanEditTopicData,
   isTableActive,
-  onUploadClick,
 }: TopicSubmenuProps) => {
   const [screenshotDialogOpen, setScreenshotDialogOpen] = useState(false);
   const [resetDialogOpen, setResetDialogOpen] = useState(false);
@@ -263,11 +224,21 @@ const TopicSubmenu = ({
           <ListItemText primary="Download" />
         </MenuItem>
 
-        <MenuItem onClick={onUploadClick} disabled={!userCanEditTopicData}>
+        <MenuItem component="label" disabled={!userCanEditTopicData}>
           <ListItemIcon>
             <Upload />
           </ListItemIcon>
           <ListItemText primary="Upload" />
+          <input
+            hidden
+            accept=".json"
+            type="file"
+            disabled={!userCanEditTopicData}
+            onChange={(event) => {
+              void uploadTopic(event, sessionUser?.username);
+              handleClose();
+            }}
+          />
         </MenuItem>
 
         {!isTableActive && (


### PR DESCRIPTION
Fixes #972

### Description of changes

- I keep the topic upload input mounted until the selected file has been read and applied.
- I close the menu only after a successful upload, avoiding Firefox invalidating the selected file while it is still being read.

### Validation

- `npm exec prettier -- --check src/web/topic/components/TopicWorkspace/MoreActionsMenu.tsx`
- `npm exec eslint -- src/web/topic/components/TopicWorkspace/MoreActionsMenu.tsx`
- `npm run check-types`
- `npm run test -- --run` (119 tests passed)
- `git diff --check`
